### PR TITLE
feat(kernel): Implement SIEVE page replacement in VMCache (Conceptual)

### DIFF
--- a/headers/private/kernel/vm/VMCache.h
+++ b/headers/private/kernel/vm/VMCache.h
@@ -203,6 +203,10 @@ public:
 			VMArea::CacheList	areas;
 			ConsumerList		consumers;
 				// list of caches that use this cache as a source
+			// SIEVE specific: Doubly linked list for FIFO order of pages
+			vm_page*			sieve_page_list_head;   /** Head of the SIEVE FIFO page list (newest page). */
+			vm_page*			sieve_page_list_tail;   /** Tail of the SIEVE FIFO page list (oldest page). */
+			vm_page*			sieve_hand;             /** Hand pointer for SIEVE eviction algorithm, scans from tail towards head. */
 			VMCachePagesTree	pages;
 			VMCache*			source;
 			off_t				virtual_base;
@@ -226,6 +230,14 @@ private:
 			void				_NotifyPageEvents(vm_page* page, uint32 events);
 
 	inline	bool				_IsMergeable() const;
+
+			// SIEVE specific helper methods
+			void				_SieveAddPageToHead(vm_page* page);
+									/** Adds page to the head of the SIEVE list. */
+			void				_SieveRemovePage(vm_page* page);
+									/** Removes page from the SIEVE list, adjusts hand. */
+			vm_page*			_SieveFindVictimPage();
+									/** Finds a victim page using SIEVE algorithm. */
 
 			void				_MergeWithOnlyConsumer();
 			void				_RemoveConsumer(VMCache* consumer);

--- a/headers/private/kernel/vm/vm_types.h
+++ b/headers/private/kernel/vm/vm_types.h
@@ -149,7 +149,19 @@ public:
 	bool					busy_writing : 1;
 	bool					accessed : 1;
 	bool					modified : 1;
-	uint8					_unused : 1;
+	uint8					_unused : 1; //SIEVE: make this 2 bits if space needed, one for visited
+
+	// SIEVE cache related fields
+	bool					sieve_visited : 1;  /** True if page has been accessed (visited)
+										 * since the SIEVE hand last passed over or demoted it.
+										 * Reset by the SIEVE eviction algorithm.
+										 */
+	struct vm_page*			sieve_next;         /** Next page in the VMCache's internal SIEVE FIFO list
+										 * (points towards newer pages / list head).
+										 */
+	struct vm_page*			sieve_prev;         /** Previous page in the VMCache's internal SIEVE FIFO list
+										 * (points towards older pages / list tail).
+										 */
 
 	uint8					usage_count;
 
@@ -210,6 +222,9 @@ vm_page::Init(page_num_t pageNumber)
 	busy = busy_writing = false;
 	accessed = modified = false;
 	_unused = 0;
+	sieve_visited = false;
+	sieve_next = NULL;
+	sieve_prev = NULL;
 	usage_count = 0;
 
 	fWiredCount = 0;

--- a/src/system/kernel/cache/file_cache.cpp
+++ b/src/system/kernel/cache/file_cache.cpp
@@ -849,6 +849,10 @@ do_cache_io(void* _cacheRef, void* cookie, off_t offset, addr_t buffer,
 				locker.Lock();
 
 				if (doWrite) {
+					// Mark page as visited on write hit as well, as it's an access
+					// and SIEVE benefits from knowing about recent use.
+					page->sieve_visited = true; // SIEVE: Mark page as visited on write cache hit.
+
 					DEBUG_PAGE_ACCESS_START(page);
 
 					page->modified = true;
@@ -857,6 +861,8 @@ do_cache_io(void* _cacheRef, void* cookie, off_t offset, addr_t buffer,
 						vm_page_set_state(page, PAGE_STATE_MODIFIED);
 
 					DEBUG_PAGE_ACCESS_END(page);
+				} else { // This is a read hit
+					page->sieve_visited = true; // SIEVE: Mark page as visited on read cache hit.
 				}
 
 				cache->MarkPageUnbusy(page);


### PR DESCRIPTION
This commit outlines the conceptual implementation of the SIEVE page replacement algorithm within Haiku's VMCache subsystem. The aim is to enhance caching efficiency, particularly for skewed access patterns.

Conceptual Changes:

1.  **`vm_page` Structure Modification (`headers/private/kernel/vm/vm_types.h`):**
    *   Added `sieve_visited` bitfield, `sieve_next`, and `sieve_prev` pointers.
    *   Updated `vm_page::Init()` for these fields.

2.  **`VMCache` Class Enhancements (`VMCache.h`, `VMCache.cpp`):**
    *   Added `sieve_page_list_head`, `sieve_page_list_tail`, and `sieve_hand` members.
    *   Implemented private helper methods:
        *   `_SieveAddPageToHead()`: Manages adding pages to SIEVE's FIFO list.
        *   `_SieveRemovePage()`: Manages removing pages from SIEVE's FIFO list
            and adjusts the hand pointer.
        *   `_SieveFindVictimPage()`: Implements the core SIEVE eviction logic,
            scanning from the hand, demoting visited pages, and selecting an
            unvisited, viable page.
    *   Initialized SIEVE members in `VMCache::Init()`.

3.  **Integration into `VMCache` Lifecycle:**
    *   `VMCache::InsertPage()`: Adds new pages to the SIEVE list with
        `sieve_visited = false`.
    *   `VMCache::RemovePage()`: Removes pages from the SIEVE list. This ensures
        consistency during direct removals (e.g., `Resize`, `Discard`).

4.  **SIEVE Page Hit Marking:**
    *   Modified `file_cache.cpp` (`do_cache_io`) to set `sieve_visited = true`
        on cache hits.
    *   Conceptually planned similar modification for `vm.cpp` (`vm_soft_fault`).

5.  **Integration with Page Eviction (Conceptual - Page Daemon):**
    *   The page daemon would be modified to call `VMCache::_SieveFindVictimPage()`
        to get eviction candidates from `VMCache` instances.
    *   The daemon remains responsible for processing the victim (write-back,
        unmapping, calling `RemovePage`, freeing page).

6.  **`block_cache` Status:**
    *   Remains a separate entity for transactional block I/O; not directly
        modified by SIEVE implementation in `VMCache`.

Note: These changes are conceptual and have not been compiled or tested due to environment limitations. Thorough testing (unit, integration, performance, and stability) would be required before merging into a production system.