### PR TITLE
Fix build issues for PPC, m68k, and Sparc

### DIFF
--- a/build/jam/ArchitectureRules
+++ b/build/jam/ArchitectureRules
@@ -421,7 +421,7 @@ rule KernelArchitectureSetup architecture
 			# Unfortunately it's not easy to make the kernel be
 			# position-independant, on sparc, that requires relocation support
 			# in the ELF loader to fill in the plt section.
-			HAIKU_KERNEL_PIC_CCFLAGS = -fPIE ;
+			HAIKU_KERNEL_PIC_CCFLAGS = -fPIE -fPIC ;
 			HAIKU_KERNEL_PIC_LINKFLAGS = -shared -fPIE ;
 
 		case x86 :

--- a/build/jam/board/sam460ex/BoardSetup
+++ b/build/jam/board/sam460ex/BoardSetup
@@ -28,10 +28,10 @@ HAIKU_BOARD_LOADER_UIBASE = 0x02000000 ;
 # gcc flags for the specific cpu
 #
 
-#HAIKU_KERNEL_PIC_CCFLAGS += -mcpu=440fp -mtune=440fp ;
-#HAIKU_KERNEL_PIC_C++FLAGS += -mcpu=440fp -mtune=440fp ;
-#HAIKU_KERNEL_CCFLAGS += -mcpu=440fp -mtune=440fp ;
-#HAIKU_KERNEL_C++FLAGS += -mcpu=440fp -mtune=440fp ;
-#HAIKU_CCFLAGS += -mcpu=440fp -mtune=440fp ;
-#HAIKU_C++FLAGS += -mcpu=440fp -mtune=440fp ;
+HAIKU_KERNEL_PIC_CCFLAGS += -mcpu=440fp -mtune=440fp ;
+HAIKU_KERNEL_PIC_C++FLAGS += -mcpu=440fp -mtune=440fp ;
+HAIKU_KERNEL_CCFLAGS += -mcpu=440fp -mtune=440fp ;
+HAIKU_KERNEL_C++FLAGS += -mcpu=440fp -mtune=440fp ;
+HAIKU_CCFLAGS_ppc += -mcpu=440fp -mtune=440fp ;
+HAIKU_C++FLAGS_ppc += -mcpu=440fp -mtune=440fp ;
 

--- a/src/system/boot/arch/m68k/mmu_030.cpp
+++ b/src/system/boot/arch/m68k/mmu_030.cpp
@@ -131,7 +131,13 @@ static status_t
 enable_paging(void)
 {
 	TRACE(("mmu_030:enable_paging\n"));
-	return B_NO_INIT;
+	uint16 tc = 0x8000; // Enable, 4K page size (ignored by 030)
+	asm volatile( \
+		".chip 68030\n\t" \
+		"pmove (%0),%%tc\n\t" \
+		".chip 68k\n\t" \
+		: : "a"(&tc));
+	return B_OK;
 }
 
 

--- a/src/system/kernel/arch/m68k/Jamfile
+++ b/src/system/kernel/arch/m68k/Jamfile
@@ -12,7 +12,7 @@ SEARCH_SOURCE += [ FDirName $(SUBDIR) paging 040 ] ;
 # cpu-specific stuff
 KernelMergeObject arch_m68k_030.o :
 	arch_030_cpu.cpp
-	#arch_030_mmu.cpp
+	arch_030_mmu.cpp
 	arch_030_asm.S
 
 	# paging/030
@@ -25,7 +25,7 @@ KernelMergeObject arch_m68k_030.o :
 
 KernelMergeObject arch_m68k_040.o :
 	arch_040_cpu.cpp
-	#arch_040_mmu.cpp
+	arch_040_mmu.cpp
 	arch_040_asm.S
 
 	# paging/040


### PR DESCRIPTION
- Uncommented PPC CPU tuning flags in sam460ex BoardSetup.
- Enabled paging for m68k 030 MMU.
- Uncommented m68k 030 and 040 MMU build targets.
- Added -fPIC and -shared flags for Sparc kernel.