### PR TITLE
Fix Sparc build: Use C++14 for libnetservices2

### DIFF
--- a/src/kits/network/libnetservices2/Jamfile
+++ b/src/kits/network/libnetservices2/Jamfile
@@ -15,7 +15,11 @@ for architectureObject in [ MultiArchSubDirSetup ] {
 			continue ;
 		}
 
-		SubDirC++Flags -std=gnu++17 ;
+		if $(architecture) = sparc {
+			SubDirC++Flags -std=gnu++14 ;
+		} else {
+			SubDirC++Flags -std=gnu++17 ;
+		}
 
 		StaticLibrary <$(architecture)>libnetservices2.a :
 			ErrorsExt.cpp


### PR DESCRIPTION
Attempt to fix C++ compilation errors on Sparc by downgrading the C++ standard from C++17 to C++14 for the libnetservices2 kit. This is to work around potential issues with GCC 8.3.0's C++17 support for the Sparc architecture.