### PR TITLE
Fix PPC build: Use C++14 for libnetservices2

### DIFF
--- a/src/kits/network/libnetservices2/Jamfile
+++ b/src/kits/network/libnetservices2/Jamfile
@@ -15,7 +15,7 @@ for architectureObject in [ MultiArchSubDirSetup ] {
 			continue ;
 		}
 
-		if $(architecture) = sparc || $(architecture) = m68k {
+		if $(architecture) = sparc || $(architecture) = m68k || $(architecture) = ppc {
 			SubDirC++Flags -std=gnu++14 ;
 		} else {
 			SubDirC++Flags -std=gnu++17 ;


### PR DESCRIPTION
Apply C++14 workaround for libnetservices2 to PPC to fix compilation errors similar to those on Sparc and m68k. This addresses issues with GCC 8.3.0's C++17 support for these architectures.