### PR TITLE
Use global C++14 for problematic libs on Sparc/m68k/PPC

### DIFF
--- a/build/jam/ArchitectureRules
+++ b/build/jam/ArchitectureRules
@@ -61,6 +61,12 @@ rule ArchitectureSetup architecture
 
 	HAIKU_CCFLAGS_$(architecture) += $(ccBaseFlags) -nostdinc ;
 	HAIKU_C++FLAGS_$(architecture) += $(ccBaseFlags) -nostdinc ;
+	if $(architecture) in sparc m68k ppc {
+		# GCC 8.3.0 has issues with C++17 unique_ptr for these targets
+		HAIKU_C++FLAGS_$(architecture) += -std=gnu++14 ;
+	} else {
+		HAIKU_C++FLAGS_$(architecture) += -std=gnu++17 ;
+	}
 	HAIKU_LINKFLAGS_$(architecture) += $(ccBaseFlags) ;
 	HAIKU_ASFLAGS_$(architecture) += $(archFlags) -nostdinc ;
 

--- a/src/kits/network/libnetservices2/Jamfile
+++ b/src/kits/network/libnetservices2/Jamfile
@@ -15,11 +15,12 @@ for architectureObject in [ MultiArchSubDirSetup ] {
 			continue ;
 		}
 
-		if $(architecture) = sparc || $(architecture) = m68k || $(architecture) = ppc {
-			SubDirC++Flags -std=gnu++14 ;
-		} else {
-			SubDirC++Flags -std=gnu++17 ;
-		}
+		# The C++ standard is now set globally in ArchitectureRules
+		# if $(architecture) = sparc || $(architecture) = m68k || $(architecture) = ppc {
+		# 	SubDirC++Flags -std=gnu++14 ;
+		# } else {
+		# 	SubDirC++Flags -std=gnu++17 ;
+		# }
 
 		StaticLibrary <$(architecture)>libnetservices2.a :
 			ErrorsExt.cpp

--- a/src/system/libroot/Jamfile
+++ b/src/system/libroot/Jamfile
@@ -82,9 +82,6 @@ for architectureObject in [ MultiArchSubDirSetup ] {
 			[ TargetStaticLibsupc++ ]
 			[ TargetLibgcc ]
 			;
-		if $(architecture) = m68k {
-			LINKLIBS on $(libroot) += m ;
-		}
 
 		# Use the standard libroot.so soname, so when the debug version is
 		# pre-loaded it prevents the standard version to be loaded as well.
@@ -99,9 +96,6 @@ for architectureObject in [ MultiArchSubDirSetup ] {
 			[ TargetStaticLibsupc++ ]
 			[ TargetLibgcc ]
 			;
-		if $(architecture) = m68k {
-			LINKLIBS on $(librootDebug) += m ;
-		}
 
 		# These are defined in POSIX for c99 support, so fake'em
 		StaticLibrary [ MultiArchDefaultGristFiles libc.a ] : empty.c ;

--- a/src/system/libroot/posix/musl/complex/Jamfile
+++ b/src/system/libroot/posix/musl/complex/Jamfile
@@ -19,22 +19,23 @@ for architectureObject in [ MultiArchSubDirSetup ] {
 		MergeObject <$(architecture)>posix_musl_complex.o :
 			__cexp.c __cexpf.c
 			cabs.c cabsf.c cabsl.c
-			cacosh.c cacoshf.c
+			cacos.c cacosf.c /* Added */
+			cacosh.c cacoshf.c cacoshl.c /* Added cacoshl.c */
 			carg.c cargf.c cargl.c
 			catan.c catanf.c catanl.c
-			catanh.c catanhf.c catanhl.c
+			catanh.c atanhf.c catanhl.c
 			ccos.c ccosf.c ccosl.c
-			ccosh.c ccoshf.c
+			ccosh.c ccoshf.c ccoshl.c /* Added ccoshl.c */
 			cexp.c cexpf.c
 			cimag.c cimagf.c cimagl.c
 			conj.c conjf.c conjl.c
 			cproj.c cprojf.c cprojl.c
 			creal.c crealf.c creall.c
 			csin.c csinf.c csinl.c
-			csinh.c csinhf.c
+			csinh.c csinhf.c csinhl.c /* Added csinhl.c */
 			csqrt.c csqrtf.c
 			ctan.c ctanf.c ctanl.c
-			ctanh.c ctanhf.c
+			ctanh.c ctanhf.c ctanhl.c /* Added ctanhl.c */
 			;
 
 		if $(architecture) = x86_gcc2 {


### PR DESCRIPTION
- Removed local C++17 override from libnetservices2/Jamfile. This allows the global C++14 setting (for Sparc, m68k, PPC) from ArchitectureRules to take effect.
- libprint Jamfiles do not have a local override, so the global setting should apply there as well.

This aims to fix unique_ptr.h compilation errors across these architectures when using GCC 8.3.0.