### PR TITLE
Fix ArchitectureRules: Replace FUnique with manual C++ flag logic

### DIFF
--- a/build/jam/ArchitectureRules
+++ b/build/jam/ArchitectureRules
@@ -61,23 +61,25 @@ rule ArchitectureSetup architecture
 
 	HAIKU_CCFLAGS_$(architecture) += $(ccBaseFlags) -nostdinc ;
 
-	# Determine the base C++ flags by taking existing HAIKU_C++FLAGS_$(architecture),
-	# adding ccBaseFlags and -nostdinc, ensuring uniqueness, and removing any existing -std= flags.
-	local baseCxxFlagsSansStd = [ FUnique $(HAIKU_C++FLAGS_$(architecture)) $(ccBaseFlags) -nostdinc ] ;
-	local finalCxxFlags ;
+	# Construct C++ flags: start with base, add existing non-std flags, then add desired std.
+	local newCxxFlags = $(ccBaseFlags) -nostdinc ;
+	local existingArchCxxFlags = $(HAIKU_C++FLAGS_$(architecture)) ;
 	local flag ;
-	for flag in $(baseCxxFlagsSansStd) {
+	for flag in $(existingArchCxxFlags) {
 		if ! [ Match "-std=*" : $(flag) ] {
-			finalCxxFlags += $(flag) ;
+			# Add flag if it's not already in newCxxFlags (basic uniqueness)
+			if ! ( $(flag) in $(newCxxFlags) ) {
+				newCxxFlags += $(flag) ;
+			}
 		}
 	}
 
 	if $(architecture) in sparc m68k ppc {
 		# GCC 8.3.0 has issues with C++17 unique_ptr for these targets
-		HAIKU_C++FLAGS_$(architecture) = $(finalCxxFlags) -std=gnu++14 ;
+		HAIKU_C++FLAGS_$(architecture) = $(newCxxFlags) -std=gnu++14 ;
 	} else {
 		# Default to C++17 for other architectures
-		HAIKU_C++FLAGS_$(architecture) = $(finalCxxFlags) -std=gnu++17 ;
+		HAIKU_C++FLAGS_$(architecture) = $(newCxxFlags) -std=gnu++17 ;
 	}
 	HAIKU_LINKFLAGS_$(architecture) += $(ccBaseFlags) ;
 	HAIKU_ASFLAGS_$(architecture) += $(archFlags) -nostdinc ;


### PR DESCRIPTION
Replaces the use of the non-existent FUnique rule with manual Jam logic to construct HAIKU_C++FLAGS_$(architecture). This logic aims to preserve existing non-std flags while ensuring the correct C++ standard (-std=gnu++14 for sparc, m68k, ppc; -std=gnu++17 for others) is applied last.

This should resolve the 'unknown rule FUnique' error and the associated C++ standard misapplication that led to unique_ptr.h compilation failures.