### PR TITLE
Fix: Address 'Unknown suffix' error for musl complex x86_64

### DIFF
--- a/src/system/libroot/posix/musl/complex/x86_64/Jamfile
+++ b/src/system/libroot/posix/musl/complex/x86_64/Jamfile
@@ -1,0 +1,8 @@
+# This Jamfile is intentionally left empty.
+# It is created to prevent the parent Jamfile's MultiArchSubDirSetup
+# from attempting to apply default rules or globs to an empty or
+# non-source-containing x86_64 specific directory for the 'complex'
+# musl component, which was causing an "Unknown suffix" error.
+# All sources for posix_musl_complex.o are common and defined in
+# src/system/libroot/posix/musl/complex/Jamfile.
+SubDir HAIKU_TOP src system libroot posix musl complex x86_64 ;


### PR DESCRIPTION
Added an empty Jamfile to src/system/libroot/posix/musl/complex/x86_64/. This is intended to prevent jam from applying default globbing rules to this directory, which was causing an 'Unknown suffix' error when the directory is empty or contains no files with recognized suffixes for the build rules active in that context.

The musl complex component sources appear to be common and are handled by the Jamfile in the parent 'complex' directory.