### PR TITLE
Fix 'Unknown suffix' error for musl/complex/<arch>/*

### DIFF
--- a/src/system/libroot/posix/musl/Jamfile
+++ b/src/system/libroot/posix/musl/Jamfile
@@ -24,6 +24,9 @@ for architectureObject in [ MultiArchSubDirSetup ] {
 
 local arch ;
 for arch in $(TARGET_ARCHS) {
+	# Explicitly tell Jam not to try to build anything from complex/<arch>/* using default rules,
+	# as these directories are expected to be empty or managed by complex/Jamfile itself.
+	NoUserObject [ FDirName complex $(arch) ]/* ;
 	HaikuSubInclude math $(arch) ;
 }
 

--- a/src/system/libroot/posix/musl/complex/Jamfile
+++ b/src/system/libroot/posix/musl/complex/Jamfile
@@ -5,6 +5,11 @@ UseHeaders [ FDirName $(SUBDIR) .. internal ] ;
 UseHeaders [ FDirName $(SUBDIR) .. arch $(TARGET_ARCH) ] ;
 UseHeaders [ FDirName $(SUBDIR) .. arch generic ] ;
 
+# If the arch-specific complex directory (e.g., complex/ppc) is empty,
+# a wildcard glob like complex/ppc/* might cause "Unknown suffix" errors.
+# Explicitly tell Jam not to try to build anything from such paths using default rules.
+NoUserObject $(SUBDIR)/$(TARGET_ARCH)/* ;
+
 local architectureObject ;
 for architectureObject in [ MultiArchSubDirSetup ] {
 	on $(architectureObject) {


### PR DESCRIPTION
Added a NoUserObject directive to src/system/libroot/posix/musl/Jamfile within the loop iterating TARGET_ARCHS. This explicitly tells Jam not to apply default build rules to files in complex/<arch>/*, which are expected to be empty or managed by complex/Jamfile itself.

This should resolve the 'Unknown suffix' errors that were blocking builds on PPC, m68k, and x86_64.