### PR TITLE
Fix Jamfile syntax error in musl/Jamfile for NoUserObject

### DIFF
--- a/src/system/libroot/posix/musl/Jamfile
+++ b/src/system/libroot/posix/musl/Jamfile
@@ -26,7 +26,8 @@ local arch ;
 for arch in $(TARGET_ARCHS) {
 	# Explicitly tell Jam not to try to build anything from complex/<arch>/* using default rules,
 	# as these directories are expected to be empty or managed by complex/Jamfile itself.
-	NoUserObject [ FDirName complex $(arch) ]/* ;
+	local complexArchDir = [ FDirName complex $(arch) ] ;
+	NoUserObject $(complexArchDir)/* ;
 	HaikuSubInclude math $(arch) ;
 }
 


### PR DESCRIPTION
Corrected the syntax for the NoUserObject directive in src/system/libroot/posix/musl/Jamfile. The path is now constructed first using FDirName and then used with the wildcard in NoUserObject. This should resolve the Jamfile parsing error that was occurring.