### PR TITLE
Fix PPC bootloader link: Explicitly link full path to libgcc.a

### DIFF
--- a/build/jam/BootRules
+++ b/build/jam/BootRules
@@ -138,11 +138,15 @@ rule BootLd
 	# For PPC, also try linking against the general libgcc, as it might contain
 	# ABI helpers not present in libgcc-kernel.a for the bootloader.
 	if $(TARGET_KERNEL_ARCH) = ppc {
-		# Assuming libgcc.a is found via -lgcc by the linker in the toolchain's lib path
-		libs += -lgcc ;
+		# Provide full path to libgcc.a from the toolchain
+		libs += [ FJoin $(HAIKU_GCC_LIB_DIR_$(TARGET_KERNEL_ARCH)) libgcc.a ] ;
 	}
 	LINKLIBS on $(1) = $(libs) ;
 	Depends $(1) : [ TargetBootLibgcc $(TARGET_KERNEL_ARCH) ] ;
+	# Ensure dependency on the explicitly added libgcc.a if it's PPC
+	if $(TARGET_KERNEL_ARCH) = ppc {
+		Depends $(1) : [ FJoin $(HAIKU_GCC_LIB_DIR_$(TARGET_KERNEL_ARCH)) libgcc.a ] ;
+	}
 
 	# TODO: Do we really want to invoke SetupBoot here? The objects should
 	# have been compiled with BootObjects anyway, so we're doing that twice.

--- a/src/system/libroot/posix/musl/Jamfile
+++ b/src/system/libroot/posix/musl/Jamfile
@@ -24,10 +24,6 @@ for architectureObject in [ MultiArchSubDirSetup ] {
 
 local arch ;
 for arch in $(TARGET_ARCHS) {
-	# Explicitly tell Jam not to try to build anything from complex/<arch>/* using default rules,
-	# as these directories are expected to be empty or managed by complex/Jamfile itself.
-	local complexArchDir = [ FDirName complex $(arch) ] ;
-	NoUserObject $(complexArchDir)/* ;
 	HaikuSubInclude math $(arch) ;
 }
 


### PR DESCRIPTION
Modified build/jam/BootRules to link the PPC bootloader against the full path to libgcc.a from the toolchain's GCC library directory. This is to resolve linker errors where -lgcc was not found or recognized, and aims to provide the missing _restgpr_ and _restfpr_ ABI symbols.