### PR TITLE
Fix: Address various errors in kernel cache code

### DIFF
--- a/src/system/kernel/cache/file_cache.cpp
+++ b/src/system/kernel/cache/file_cache.cpp
@@ -851,7 +851,7 @@ do_cache_io(void* _cacheRef, void* cookie, off_t offset, addr_t buffer,
 				if (doWrite) {
 					// Mark page as visited on write hit as well, as it's an access
 					// and SIEVE benefits from knowing about recent use.
-					page->sieve_visited = true; // SIEVE: Mark page as visited on write cache hit.
+					page->sieve_visited_count = 1; // SIEVE: Mark page as visited on write cache hit.
 
 					DEBUG_PAGE_ACCESS_START(page);
 
@@ -862,7 +862,7 @@ do_cache_io(void* _cacheRef, void* cookie, off_t offset, addr_t buffer,
 
 					DEBUG_PAGE_ACCESS_END(page);
 				} else { // This is a read hit
-					page->sieve_visited = true; // SIEVE: Mark page as visited on read cache hit.
+					page->sieve_visited_count = 1; // SIEVE: Mark page as visited on read cache hit.
 				}
 
 				cache->MarkPageUnbusy(page);


### PR DESCRIPTION
This commit includes several fixes:

1.  Corrected TRACE macro calls in `src/system/kernel/cache/block_cache.cpp` by wrapping multi-argument calls in double parentheses to match the single-argument macro definition when tracing is disabled.

2.  Updated `sieve_visited` to `sieve_visited_count` in `src/system/kernel/cache/file_cache.cpp` to align with the SIEVE-2 implementation in VMCache.

3.  Corrected argument counts for `object_cache_free` and `create_object_cache` calls in `src/system/kernel/cache/unified_cache.cpp` to match their definitions in `Slab.h`.

4.  Fixed the format specifier in a `panic` call in `src/system/kernel/cache/unified_cache.cpp` to correctly print a uint64 value.

5.  Addressed some undeclared identifiers in `block_cache.cpp` by reordering local type definitions for `cache_notification` and `cache_listener` and adding missing global static variable definitions.

6.  Removed the unused variable `old_ref_count` in `src/system/kernel/cache/unified_cache.cpp`.

Further refactoring of `block_cache.cpp` is expected to address remaining undeclared identifier errors related to the deprecated `block_cache` and `cached_block` types.