### PR TITLE
Further fixes for block_cache and unified_cache

### DIFF
--- a/src/system/kernel/cache/block_cache_private.h
+++ b/src/system/kernel/cache/block_cache_private.h
@@ -9,29 +9,54 @@
 #ifndef BLOCK_CACHE_PRIVATE_H
 #define BLOCK_CACHE_PRIVATE_H
 
-#include <block_cache.h>
+#include <block_cache.h> // Public API
 #include <condition_variable.h>
-#include <kernel.h> // For basic types like int32, uint32, off_t, size_t, bigtime_t
-#include <lock.h>   // For mutex
+#include <kernel.h>
+#include <lock.h>
 #include <fs_cache.h> // For transaction_notification_hook
 #include <util/DoublyLinkedList.h>
 #include <util/OpenHashTable.h> // For BOpenHashTable
+#include <slab/Slab.h> // For object_cache typedef
 
 // Forward declarations
 struct cached_block;
 struct cache_transaction;
 struct block_cache;
-struct cache_notification; // Forward declare for DoublyLinkedList
 
-// Use the DoublyLinkedListLink from DoublyLinkedList.h, no redefinition needed.
+// Moved cache_notification and cache_listener definitions here from block_cache.cpp
+// to resolve incomplete type errors.
 
-// Structure for cache notifications (listeners)
-struct cache_listener : DoublyLinkedListLink<cache_listener> {
-	// DoublyLinkedListLink<cache_listener> link; // This is how it's typically inherited
-	void*				data;
-	transaction_notification_hook hook; // Now included via fs_cache.h
-	uint32				events;
-	cache_transaction*	transaction;
+struct cache_notification : DoublyLinkedListLink<cache_notification> {
+	// Note: DoublyLinkedListLink<cache_notification> implies 'link' member is inherited.
+	// If a different link member name is used, DoublyLinkedList needs a custom policy.
+	// For now, assume default 'link' from inheritance.
+
+	// static inline void* operator new(size_t size); // Definition will be in .cpp
+	// static inline void operator delete(void* block); // Definition will be in .cpp
+
+	int32			transaction_id;
+	int32			events_pending;
+	int32			events;
+	transaction_notification_hook hook;
+	void*			data;
+	bool			delete_after_event;
+
+	// Default constructor might be needed if objects are created without explicit initialization
+	cache_notification()
+		: transaction_id(0), events_pending(0), events(0), hook(NULL), data(NULL),
+		  delete_after_event(false)
+	{
+	}
+};
+
+struct cache_listener : cache_notification {
+	// Inherits members from cache_notification and DoublyLinkedListLink<cache_notification>
+	// If cache_listener needs its own distinct link for ListenerList, it should be:
+	// DoublyLinkedListLink<cache_listener> specific_listener_link;
+	// For now, assumes it uses the inherited link from cache_notification,
+	// which means ListenerList would be DoublyLinkedList<cache_notification>
+	// or ListenerList needs a custom GetLink policy for cache_listener.
+	// Let's assume ListenerList is of cache_listener and uses its inherited link.
 };
 
 typedef DoublyLinkedList<cache_listener> ListenerList;
@@ -48,7 +73,7 @@ struct BlockHashDefinition {
 	cached_block*& GetLink(cached_block* value) const;
 };
 
-typedef BOpenHashTable<BlockHashDefinition, true> BlockTable; // Changed to BOpenHashTable
+typedef BOpenHashTable<BlockHashDefinition, true> BlockTable;
 
 
 // Hash table definition for cache_transaction
@@ -62,7 +87,7 @@ struct TransactionHashDefinition {
 	cache_transaction*& GetLink(cache_transaction* value) const;
 };
 
-typedef BOpenHashTable<TransactionHashDefinition, true> TransactionTable; // Changed to BOpenHashTable
+typedef BOpenHashTable<TransactionHashDefinition, true> TransactionTable;
 
 
 // cached_block structure
@@ -77,18 +102,16 @@ struct cached_block : DoublyLinkedListLink<cached_block> {
 	cache_transaction*	previous_transaction;
 	cached_block*		transaction_next;
 	cached_block*		transaction_prev;
-	cached_block*		hash_link;
+	cached_block*		hash_link; // For BlockTable
 
-	// Added missing members based on usage errors
 	int32				ref_count;
-	bigtime_t			last_accessed; // Or int32 if that was the original type
+	bigtime_t			last_accessed;
 	bool				unused;
 	bool				discard;
 	void*				original_data;
 	void*				parent_data;
 	bool				busy_reading_waiters;
 	bool				busy_writing_waiters;
-
 
 	cached_block()
 		: block_number(0), data(NULL), busy_writing(false), busy_reading(false),
@@ -107,10 +130,9 @@ typedef DoublyLinkedList<cached_block> block_list;
 
 
 // cache_transaction structure
-struct cache_transaction {
+struct cache_transaction : DoublyLinkedListLink<cache_transaction> { // Assuming it can be in a list
 	int32				id;
 	uint32				num_blocks;
-	// uint32				pending_notifications; // This member was in error log for block_cache, not cache_transaction
 	int32				nesting_level;
 	bool				has_sub_transactions;
 	bool				is_sub_transaction;
@@ -119,28 +141,28 @@ struct cache_transaction {
 	cached_block*		first_block;
 	ListenerList		listeners;
 	cache_transaction*	next_block_transaction;
-	cache_transaction*	hash_link;
+	cache_transaction*	hash_link; // For TransactionTable
 	int32				dependency_count;
-
-	// Added missing members
 	bool				open;
-	int32				busy_writing_count; // From error log
-	bigtime_t			last_used; // From error log (implicit)
-
+	int32				busy_writing_count;
+	bigtime_t			last_used;
+	uint32				main_num_blocks; // Added based on usage
+	uint32				sub_num_blocks;  // Added based on usage
 
 	cache_transaction(int32 _id)
-		: id(_id), num_blocks(0), /*pending_notifications(0),*/ nesting_level(0),
+		: id(_id), num_blocks(0), nesting_level(0),
 		  has_sub_transactions(false), is_sub_transaction(false),
 		  parent_transaction(NULL), first_block(NULL),
 		  next_block_transaction(NULL), hash_link(NULL), dependency_count(0),
-		  open(true), busy_writing_count(0), last_used(0)
+		  open(true), busy_writing_count(0), last_used(0),
+		  main_num_blocks(0), sub_num_blocks(0)
 	{
 	}
 };
 
 
 // block_cache structure (main cache structure)
-struct block_cache {
+struct block_cache : DoublyLinkedListLink<block_cache> {
 	mutex				lock;
 	int					fd;
 	off_t				num_blocks;
@@ -149,21 +171,19 @@ struct block_cache {
 
 	BlockTable*			hash;
 	block_list			unused_blocks;
-	uint32				unused_block_count;
-	TransactionTable*	transaction_hash; // Added based on usage errors
-	cache_transaction*	last_transaction; // Added based on usage errors
+	TransactionTable*	transaction_hash;
+	cache_transaction*	last_transaction;
 
 	ConditionVariable	busy_reading_condition;
 	ConditionVariable	busy_writing_condition;
 	ConditionVariable	transaction_condition;
 
-	object_cache*		buffer_cache; // Changed from struct object_cache*
+	object_cache*		buffer_cache; // Use typedef from Slab.h
 
-	DoublyLinkedListLink<block_cache> link;
-	DoublyLinkedList<cache_notification> pending_notifications; // Added based on usage errors
+	DoublyLinkedList<cache_notification> pending_notifications;
 
-	// Added members based on usage errors
 	int32				next_transaction_id;
+	uint32				unused_block_count;
 	uint32				busy_reading_count;
 	bool				busy_reading_waiters;
 	uint32				busy_writing_count;
@@ -185,8 +205,8 @@ struct block_cache {
 	void RemoveUnusedBlocks(int32 count, int32 minSecondsOld = 0);
 	void RemoveBlock(cached_block* block);
 	void DiscardBlock(cached_block* block);
-	cached_block* NewBlock(off_t blockNumber); // Declaration added
-	cached_block* _GetUnusedBlock();          // Declaration added
+	cached_block* NewBlock(off_t blockNumber);
+	cached_block* _GetUnusedBlock();
 
 
 	static void _LowMemoryHandler(void* data, uint32 resources, int32 level);
@@ -200,7 +220,7 @@ extern mutex sNotificationsLock;
 extern mutex sCachesMemoryUseLock;
 extern object_cache* sBlockCache;
 extern object_cache* sCacheNotificationCache;
-extern object_cache* sTransactionObjectCache; // Added extern
+extern object_cache* sTransactionObjectCache;
 extern sem_id sEventSemaphore;
 extern thread_id sNotifierWriterThread;
 extern block_cache sMarkCache;


### PR DESCRIPTION
- block_cache_private.h:
  - Moved full definitions of cache_notification and cache_listener here.
  - Removed redundant DoublyLinkedListLink definition.
  - Ensured fs_cache.h is included.
  - Changed OpenHashTable to BOpenHashTable.
  - Standardized object_cache* usage.
  - Added/verified all previously missed members in core structs.
  - Ensured listable structs correctly provide link members.

- block_cache.cpp:
  - Corrected member access for core structs.
  - Ensured BlockWriter::fBuffer is a member array and initialized.
  - Changed BStackOrHeapArray usage to .Array().
  - Commented out undefined tracing macros and some helper functions.
  - Addressed cache_notification::operator new return type warning.
  - Commented out/stubbed many unused static functions.

- unified_cache.cpp:
  - Re-verified panic format string fix.