### PR TITLE
Fix m68k Amiga ClearScreen call site

### DIFF
--- a/src/system/boot/platform/amiga_m68k/console.cpp
+++ b/src/system/boot/platform/amiga_m68k/console.cpp
@@ -173,7 +173,7 @@ void
 ConsoleHandle::Clear()
 {
 	Move(&gScreen->RastPort, 0, sScreenTopOffset);
-	ClearScreen(&gScreen->RastPort);
+	Amiga_ClearScreen(&gScreen->RastPort);
 }
 
 


### PR DESCRIPTION
Updated the call to ClearScreen in ConsoleHandle::Clear() within src/system/boot/platform/amiga_m68k/console.cpp to use the renamed Amiga_ClearScreen macro. This should resolve the compilation error where ClearScreen was not declared in this scope.