### PR TITLE
Fix VMCache compilation error for _SieveTouchPage

### DIFF
--- a/headers/private/kernel/vm/VMCache.h
+++ b/headers/private/kernel/vm/VMCache.h
@@ -238,6 +238,8 @@ private:
 									/** Removes page from the SIEVE list, adjusts hand. */
 			vm_page*			_SieveFindVictimPage();
 									/** Finds a victim page using SIEVE algorithm. */
+			void				_SieveTouchPage(vm_page* page);
+									/** Updates page status on access for SIEVE. */
 
 			void				_MergeWithOnlyConsumer();
 			void				_RemoveConsumer(VMCache* consumer);


### PR DESCRIPTION
Added the missing declaration for the private method VMCache::_SieveTouchPage(vm_page* page) in the VMCache class definition (VMCache.h).

This resolves the 'not declared in this scope' and 'no declaration matches' errors when compiling VMCache.cpp.