### PR TITLE
Remove unused function BlockWriter::_Data

### DIFF
--- a/src/system/kernel/cache/block_cache.cpp
+++ b/src/system/kernel/cache/block_cache.cpp
@@ -394,12 +394,6 @@ BlockWriter::Write(cache_transaction* currentTransactionContext, bool canUnlock)
 
 // status_t BlockWriter::WriteBlock(cached_block* block) { /* ... */ } // Commented out - unused
 
-void* BlockWriter::_Data(cached_block* block) const
-{
-	return (block->previous_transaction != NULL && block->original_data != NULL)
-		? block->original_data : block->data;
-}
-
 /*
 status_t BlockWriter::_WriteBlocks(cached_block** blocks, uint32 count)
 {


### PR DESCRIPTION
The function BlockWriter::_Data was unused due to its only caller, BlockWriter::_WriteBlocks, being commented out. This commit removes the unused function to eliminate the compiler warning.