### PR TITLE
Fix syntax error in VMCache.cpp

### DIFF
--- a/src/system/kernel/cache/block_cache.cpp
+++ b/src/system/kernel/cache/block_cache.cpp
@@ -499,4 +499,5 @@ bool cache_has_block_in_transaction(void* _cache, int32 id, off_t blockNumber) {
 #if DEBUG_BLOCK_CACHE
 // Debug functions commented out
 #endif
+// [end of src/system/kernel/cache/block_cache.cpp]
 // [end of src/system/kernel/cache/block_cache.cpp] // Removed this marker line

--- a/src/system/kernel/vm/VMCache.cpp
+++ b/src/system/kernel/vm/VMCache.cpp
@@ -2011,5 +2011,3 @@ VMCacheFactory::CreateNullCache(int priority, VMCache*& _cache)
 	_cache = cache;
 	return B_OK;
 }
-
-[end of src/system/kernel/vm/VMCache.cpp]


### PR DESCRIPTION
Removes a duplicate [end of src/system/kernel/vm/VMCache.cpp] marker line that was causing a compiler error.