### PR TITLE
Conditionally compile libroot's debug_printf into kernel for KDEBUG b…

### DIFF
--- a/src/system/kernel/lib/Jamfile
+++ b/src/system/kernel/lib/Jamfile
@@ -26,6 +26,10 @@ local sources =
 	wait_for_objects.cpp
 	;
 
+if $(TARGET_SYMBOLS_LEVEL) >= 2 {
+	sources += debug.c ;
+}
+
 SourceHdrs $(sources) : $(librootOSSources) ;
 
 KernelMergeObject kernel_os_main.o : $(sources)


### PR DESCRIPTION
…uilds

When KDEBUG is enabled (typically in builds with TARGET_SYMBOLS_LEVEL >= 2), kernel code such as VMCache.cpp uses `debug_printf` as declared in `headers/os/kernel/OS.h`.

Previously, no kernel-side definition for this `debug_printf` was being linked for PPC (and likely other architectures), leading to an undefined reference error during kernel linking.

This change modifies `src/system/kernel/lib/Jamfile` to include `src/system/libroot/os/debug.c` (which provides a suitable definition of `debug_printf` that uses `_kern_debug_output`) in the `kernel_os_main.o` object when `TARGET_SYMBOLS_LEVEL >= 2`.

This resolves the linker error and allows debug builds for PPC to proceed. The `debug_printf` in OS.h is noted as a temporary debug helper, so a longer-term solution might involve refactoring its callers to use `dprintf`.