### PR TITLE
Fixes and review for disk cache components

### DIFF
--- a/src/system/kernel/cache/vnode_store.cpp
+++ b/src/system/kernel/cache/vnode_store.cpp
@@ -117,7 +117,18 @@ VMVnodeCache::Fault(struct VMAddressSpace* aspace, off_t offset)
 	if (!StoreHasPage(offset))
 		return B_BAD_ADDRESS;
 
-	// vm_soft_fault() reads the page in.
+	// According to the comment, vm_soft_fault() is expected to read the page.
+	// If VMCache::Fault() is reached, it implies vm_soft_fault() might have
+	// already tried to look up the page and found it missing, and is now
+	// calling this as a fallback or for a specific reason.
+	// Returning B_BAD_HANDLER tells the VM layer that this cache doesn't
+	// handle the fault directly in this path.
+	// A more explicit approach might involve this function triggering the read
+	// if the page isn't present, as sketched in review comments.
+	// For now, keeping B_BAD_HANDLER as per existing logic flow implication,
+	// but noting this is a critical point for mmap functionality.
+	// If vm_soft_fault itself is supposed to call VMCache::Read, then
+	// this function might only be called in unexpected scenarios.
 	return B_BAD_HANDLER;
 }
 


### PR DESCRIPTION
This commit includes several fixes and review actions across disk cache files:

block_cache.cpp:
- Added basic initialization for hash tables in Init() and deallocation in the destructor.
- Initialized instance mutex.

file_cache.cpp:
- Changed stack allocations for iovec/page arrays in read/write paths to heap allocations with ArrayDeleter for safety.
- Replaced panic() calls for I/O errors with dprintf and error returns.
- Changed panic() in add_to_iovec to ASSERT_PRINT and dprintf.
- Removed redundant direct SIEVE state manipulation, relying on VMCache.

unified_cache.cpp (standalone cache, not VMCache base for file_cache):
- Clarified entry->data memory management (assuming malloc/free).
- Changed EvictEntrySieve2 to return status_t and updated InsertEntry.
- Ensured AccessEntrySieve2 sets sieve_visited_count to 2 (hot).

vnode_store.cpp:
- Reviewed. Updated comments in VMVnodeCache::Fault() to highlight its stubbed nature and reliance on vm_soft_fault().

Overall: Addressed critical panics, memory safety (stack vs heap), and refined SIEVE-2 logic in the standalone unified_cache. Noted that VMVnodeCache (used by file_cache) inherits SIEVE-2 from VMCache. Several major TODOs and architectural questions remain.