### PR TITLE
Fix various compilation errors in file_cache and block_cache

### DIFF
--- a/src/system/kernel/cache/block_cache.cpp
+++ b/src/system/kernel/cache/block_cache.cpp
@@ -437,9 +437,6 @@ block_cache::block_cache(int _fd, off_t _numBlocks, size_t _blockSize, bool _rea
 	busy_reading_count(0), busy_reading_waiters(false),
 	busy_writing_count(0), busy_writing_waiters(false),
 	last_block_write(0), last_block_write_duration(0), num_dirty_blocks(0)
-	busy_reading_count(0), busy_reading_waiters(false),
-	busy_writing_count(0), busy_writing_waiters(false),
-	last_block_write(0), last_block_write_duration(0), num_dirty_blocks(0)
 {
 	// It's critical that mutex_init is called for lock before it's used.
 	// The current structure has lock as a direct member, so it should be initialized
@@ -478,7 +475,7 @@ status_t block_cache::Init()
 	hash = new(std::nothrow) BlockTable();
 	if (hash == NULL)
 		return B_NO_MEMORY;
-	status_t status = hash->InitCheck(); // Assuming InitCheck or similar exists
+	status_t status = hash->Init();
 	if (status != B_OK) {
 		delete hash;
 		hash = NULL;
@@ -491,7 +488,7 @@ status_t block_cache::Init()
 		hash = NULL;
 		return B_NO_MEMORY;
 	}
-	status = transaction_hash->InitCheck(); // Assuming InitCheck
+	status = transaction_hash->Init();
 	if (status != B_OK) {
 		delete transaction_hash;
 		transaction_hash = NULL;

--- a/src/system/kernel/cache/file_cache.cpp
+++ b/src/system/kernel/cache/file_cache.cpp
@@ -245,9 +245,11 @@ add_to_iovec(generic_io_vec* vecs, uint32 &index, uint32 max,
 	}
 
 	if (index == max) {
-		ASSERT_PRINT("add_to_iovec: no more space for iovecs! index: %" B_PRIu32 ", max: %" B_PRIu32, index, max);
+		ASSERT_PRINT(false, "add_to_iovec: no more space for iovecs! index: %" B_PRIu32 ", max: %" B_PRIu32, index, max);
 		// This should not be reached if MAX_IO_VECS and chunking logic are correct.
 		// Return an error rather than panicking in a release build.
+		// The ASSERT_PRINT above will panic in KDEBUG builds.
+		// The dprintf below is for non-KDEBUG builds or for additional logging.
 		dprintf("add_to_iovec: Error - no more space for iovecs! index: %" B_PRIu32 ", max: %" B_PRIu32 "\n", index, max);
 		// How to return an error? This function doesn't return status.
 		// The callers would need to check vecCount against their expectation.


### PR DESCRIPTION
- Corrected ASSERT_PRINT macro usage in file_cache.cpp by providing a condition.
- Removed duplicated lines in block_cache.cpp constructor's member initializer list.
- Replaced InitCheck() with Init() for BOpenHashTable instances in block_cache.cpp based on Haiku API conventions.