### PR TITLE
Attempt to fix unified_cache.cpp compilation errors

### DIFF
--- a/src/system/kernel/cache/unified_cache.h
+++ b/src/system/kernel/cache/unified_cache.h
@@ -106,7 +106,7 @@ struct unified_cache {
     unified_cache_entry*    LookupEntry(uint64 id);
     status_t                InsertEntry(unified_cache_entry* entry);
     void                    RemoveEntry(unified_cache_entry* entry);
-    unified_cache_entry*    EvictEntrySieve2(); // Core SIEVE-2 eviction
+    status_t                EvictEntrySieve2(); // Core SIEVE-2 eviction
     void                    AccessEntrySieve2(unified_cache_entry* entry); // Update on hit
 
     // TODO: Low memory handling


### PR DESCRIPTION
Ensured that EvictEntrySieve2 is declared to return status_t in unified_cache.h to match its definition and usage.

Compiler errors suggest a possible discrepancy between the edited file version and the version used during compilation by the build system.