### PR TITLE
Add -std=c++11 flag for setmime.cpp to fix build errors

### DIFF
--- a/src/bin/Jamfile
+++ b/src/bin/Jamfile
@@ -156,6 +156,7 @@ StdBinCommands
 	: be : $(haiku-utils_rsrc) ;
 
 # standard commands that need libbe.so, libstdc++.so
+Object src/bin/setmime.cpp : <cxxflags>-std=c++11 ;
 StdBinCommands
 	copyattr.cpp
 	setmime.cpp


### PR DESCRIPTION
Updated src/bin/Jamfile to add the -std=c++11 compiler flag for setmime.cpp. This is intended to resolve compilation errors in C++ standard library headers like <unique_ptr.h> by ensuring C++11 features are enabled.