### PR TITLE
Refactor m68k VM code to address C++ compilation errors

### DIFF
--- a/src/system/kernel/arch/m68k/arch_030_mmu.cpp
+++ b/src/system/kernel/arch/m68k/arch_030_mmu.cpp
@@ -12,7 +12,30 @@
 
 #define ARCH_M68K_MMU_TYPE 68030
 
-#include "arch_vm_translation_map_impl.cpp"
+// #include "arch_vm_translation_map_impl.cpp"
+// Let's see what breaks if this is not included.
+// The functions it provides might be needed for m68030_vm_ops (now commented out)
+// or for early boot.
+// M68KVMTranslationMap and a potential M68KVMTranslationMap030 should provide
+// the main map ops.
+
+// Forward declarations for functions that were in arch_vm_translation_map_impl.cpp
+// and might be used by m68030_vm_ops or other early boot code if that ops struct were active.
+// Since m68030_vm_ops is commented out, these might not be strictly necessary anymore
+// unless called directly from other parts of arch_030_mmu.cpp or related boot code.
+struct VMTranslationMap;
+struct kernel_args;
+static void *_m68k_translation_map_get_pgdir(VMTranslationMap *map);
+static status_t m68k_vm_translation_map_init_map(VMTranslationMap *map, bool kernel);
+static status_t m68k_vm_translation_map_init_kernel_map_post_sem(VMTranslationMap *map);
+static status_t m68k_vm_translation_map_init(kernel_args *args);
+static status_t m68k_vm_translation_map_init_post_area(kernel_args *args);
+static status_t m68k_vm_translation_map_init_post_sem(kernel_args *args);
+static status_t m68k_vm_translation_map_early_map(kernel_args *args, addr_t va, addr_t pa, uint8 attributes);
+static status_t early_query(addr_t va, addr_t *_physicalAddress);
+static bool m68k_vm_translation_map_is_kernel_page_accessible(addr_t virtualAddress, uint32 protection);
+// End forward declarations
+
 
 static void
 set_pgdir(void *rt)
@@ -29,7 +52,7 @@ set_pgdir(void *rt)
 	
 }
 
-
+/*
 struct m68k_vm_ops m68030_vm_ops = {
 	_m68k_translation_map_get_pgdir,
 	m68k_vm_translation_map_init_map,
@@ -38,7 +61,7 @@ struct m68k_vm_ops m68030_vm_ops = {
 	m68k_vm_translation_map_init_post_area,
 	m68k_vm_translation_map_init_post_sem,
 	m68k_vm_translation_map_early_map,
-	/*m68k_vm_translation_map_*/early_query,
+	early_query,
 	set_pgdir,
 #if 0
 	m68k_map_address_range,
@@ -47,3 +70,4 @@ struct m68k_vm_ops m68030_vm_ops = {
 #endif
 	m68k_vm_translation_map_is_kernel_page_accessible
 };
+*/

--- a/src/system/kernel/arch/m68k/arch_040_mmu.cpp
+++ b/src/system/kernel/arch/m68k/arch_040_mmu.cpp
@@ -12,7 +12,27 @@
 
 #define ARCH_M68K_MMU_TYPE 68040
 
-#include "arch_vm_translation_map_impl.cpp"
+// #include "arch_vm_translation_map_impl.cpp"
+// Let's see what breaks if this is not included.
+// The functions it provides might be needed for m68040_vm_ops (now commented out)
+// or for early boot. M68KVMTranslationMap040 should provide the main map ops.
+
+// Forward declarations for functions that were in arch_vm_translation_map_impl.cpp
+// and might be used by m68040_vm_ops or other early boot code if that ops struct were active.
+// Since m68040_vm_ops is commented out, these might not be strictly necessary anymore
+// unless called directly from other parts of arch_040_mmu.cpp or related boot code.
+struct VMTranslationMap;
+struct kernel_args;
+static void *_m68k_translation_map_get_pgdir(VMTranslationMap *map);
+static status_t m68k_vm_translation_map_init_map(VMTranslationMap *map, bool kernel);
+static status_t m68k_vm_translation_map_init_kernel_map_post_sem(VMTranslationMap *map);
+static status_t m68k_vm_translation_map_init(kernel_args *args);
+static status_t m68k_vm_translation_map_init_post_area(kernel_args *args);
+static status_t m68k_vm_translation_map_init_post_sem(kernel_args *args);
+static status_t m68k_vm_translation_map_early_map(kernel_args *args, addr_t va, addr_t pa, uint8 attributes);
+static status_t early_query(addr_t va, addr_t *_physicalAddress);
+static bool m68k_vm_translation_map_is_kernel_page_accessible(addr_t virtualAddress, uint32 protection);
+// End forward declarations
 
 static void
 set_pgdir(void *rt)
@@ -27,7 +47,7 @@ set_pgdir(void *rt)
 	
 }
 
-
+/*
 struct m68k_vm_ops m68040_vm_ops = {
 	_m68k_translation_map_get_pgdir,
 	m68k_vm_translation_map_init_map,
@@ -36,7 +56,7 @@ struct m68k_vm_ops m68040_vm_ops = {
 	m68k_vm_translation_map_init_post_area,
 	m68k_vm_translation_map_init_post_sem,
 	m68k_vm_translation_map_early_map,
-	/*m68k_vm_translation_map_*/early_query,
+	early_query,
 	set_pgdir,
 #if 0
 	m68k_map_address_range,
@@ -45,3 +65,4 @@ struct m68k_vm_ops m68040_vm_ops = {
 #endif
 	m68k_vm_translation_map_is_kernel_page_accessible
 };
+*/


### PR DESCRIPTION
This commit attempts to address a series of C++ compilation errors in the m68k VM code, primarily stemming from the transition to a C++ class-based VMTranslationMap and changes to page table entry definitions.

Key changes:
- In arch_vm_translation_map_impl.cpp:
  - Replaced map->arch_data accesses with new class member accesses (fLock, fMapCount, fPagingStructures, etc.) using casts.
  - Removed _scalar suffixes from page table entry type casts.
  - Commented out obsolete vm_translation_map_ops and map->ops usage.
  - Added panic() calls for broken tmap_list logic.
- In arch_030_mmu.cpp and arch_040_mmu.cpp:
  - Commented out obsolete m68k_vm_ops definitions.
  - Commented out the direct inclusion of arch_vm_translation_map_impl.cpp, favoring the M68KVMTranslationMap040 class for 040 operations. Forward declarations were added for potentially still-needed symbols.

Known issues:
- Protected member access errors are expected in arch_vm_translation_map_impl.cpp if its functions are still compiled/linked, as they are C-style functions accessing C++ protected members. Proper refactoring into class methods is needed.
- Global tmap_list management is broken.
- The 030 MMU path may have unresolved dependencies.
- Full compilation and testing were blocked by a missing 'nasm' dependency in the agent's build environment.