### PR TITLE
Attempt to set C++11 standard for setmime.cpp using AppendToTargetFlags

### DIFF
--- a/src/bin/Jamfile
+++ b/src/bin/Jamfile
@@ -156,7 +156,7 @@ StdBinCommands
 	: be : $(haiku-utils_rsrc) ;
 
 # standard commands that need libbe.so, libstdc++.so
-Object src/bin/setmime.cpp : <cxxflags>-std=c++11 ;
+AppendToTargetFlags setmime : CXXFLAGS : -std=c++11 ;
 StdBinCommands
 	copyattr.cpp
 	setmime.cpp


### PR DESCRIPTION
This commit modifies src/bin/Jamfile to use:
AppendToTargetFlags setmime : CXXFLAGS : -std=c++11 ;

to specify the C++11 standard for compiling setmime.cpp. This is to address errors in <unique_ptr.h> related to C++11 features.