### PR TITLE
Attempt to fix setmime.cpp compilation by locally setting CXXFLAGS to…

### DIFF
--- a/src/bin/Jamfile
+++ b/src/bin/Jamfile
@@ -156,12 +156,14 @@ StdBinCommands
 	: be : $(haiku-utils_rsrc) ;
 
 # standard commands that need libbe.so, libstdc++.so
-AppendToTargetFlags setmime : CXXFLAGS : -std=c++11 ;
+local savedCxxFlags = $(CXXFLAGS) ;
+CXXFLAGS += -std=c++11 ;
 StdBinCommands
 	copyattr.cpp
 	setmime.cpp
 	xres.cpp
 	: be [ TargetLibstdc++ ] : $(haiku-utils_rsrc) ;
+CXXFLAGS = $(savedCxxFlags) ;
 
 # Haiku-specific apps which need libbe.so, libstdc++.so
 StdBinCommands


### PR DESCRIPTION
… include -std=c++11.

This change modifies src/bin/Jamfile to temporarily add -std=c++11 to the CXXFLAGS for the StdBinCommands rule that processes setmime.cpp, copyattr.cpp, and xres.cpp. The CXXFLAGS are restored afterwards. This is aimed at resolving C++11 header errors for setmime.cpp.