### PR TITLE
Fix m68k libroot linker errors for math functions

### DIFF
--- a/src/system/libroot/posix/musl/complex/Jamfile
+++ b/src/system/libroot/posix/musl/complex/Jamfile
@@ -19,22 +19,23 @@ for architectureObject in [ MultiArchSubDirSetup ] {
 		MergeObject <$(architecture)>posix_musl_complex.o :
 			__cexp.c __cexpf.c
 			cabs.c cabsf.c cabsl.c
+			cacos.c cacosf.c
 			cacosh.c cacoshf.c
 			carg.c cargf.c cargl.c
 			catan.c catanf.c catanl.c
 			catanh.c catanhf.c catanhl.c
 			ccos.c ccosf.c ccosl.c
-			ccosh.c ccoshf.c
+			ccosh.c ccoshf.c ccoshl.c
 			cexp.c cexpf.c
 			cimag.c cimagf.c cimagl.c
 			conj.c conjf.c conjl.c
 			cproj.c cprojf.c cprojl.c
 			creal.c crealf.c creall.c
 			csin.c csinf.c csinl.c
-			csinh.c csinhf.c
+			csinh.c csinhf.c csinhl.c
 			csqrt.c csqrtf.c
 			ctan.c ctanf.c ctanl.c
-			ctanh.c ctanhf.c
+			ctanh.c ctanhf.c ctanhl.c
 			;
 
 		if $(architecture) = x86_gcc2 {

--- a/src/system/libroot/posix/musl/complex/cacos.c
+++ b/src/system/libroot/posix/musl/complex/cacos.c
@@ -1,0 +1,12 @@
+#include "complex_impl.h"
+
+// FIXME: Hull et al. "Implementing the complex arcsine and arccosine functions
+// using exception handling" 1997
+
+/* acos(z) = pi/2 - asin(z) */
+
+double complex cacos(double complex z)
+{
+	z = casin(z);
+	return CMPLX(M_PI_2 - creal(z), -cimag(z));
+}

--- a/src/system/libroot/posix/musl/complex/cacosf.c
+++ b/src/system/libroot/posix/musl/complex/cacosf.c
@@ -1,0 +1,11 @@
+#include "complex_impl.h"
+
+// FIXME
+
+static const float float_pi_2 = M_PI_2;
+
+float complex cacosf(float complex z)
+{
+	z = casinf(z);
+	return CMPLXF(float_pi_2 - crealf(z), -cimagf(z));
+}

--- a/src/system/libroot/posix/musl/complex/ccoshl.c
+++ b/src/system/libroot/posix/musl/complex/ccoshl.c
@@ -1,0 +1,7 @@
+#include "complex_impl.h"
+
+//FIXME
+long double complex ccoshl(long double complex z)
+{
+	return ccosh(z);
+}

--- a/src/system/libroot/posix/musl/complex/csinhl.c
+++ b/src/system/libroot/posix/musl/complex/csinhl.c
@@ -1,0 +1,7 @@
+#include "complex_impl.h"
+
+//FIXME
+long double complex csinhl(long double complex z)
+{
+	return csinh(z);
+}

--- a/src/system/libroot/posix/musl/complex/ctanhl.c
+++ b/src/system/libroot/posix/musl/complex/ctanhl.c
@@ -1,0 +1,7 @@
+#include "complex_impl.h"
+
+//FIXME
+long double complex ctanhl(long double complex z)
+{
+	return ctanh(z);
+}

--- a/src/system/libroot/posix/musl/math/m68k/Jamfile
+++ b/src/system/libroot/posix/musl/math/m68k/Jamfile
@@ -33,6 +33,7 @@ local generics =
 	fmax.c fmaxf.c fmaxl.c
 	fmin.c fminf.c fminl.c
 	fmod.c fmodf.c fmodl.c
+	__fpclassify.c __fpclassifyf.c __fpclassifyl.c
 	frexp.c frexpf.c frexpl.c
 	hypot.c hypotf.c hypotl.c
 	ilogb.c ilogbf.c ilogbl.c


### PR DESCRIPTION
- Added __fpclassify.c, __fpclassifyf.c, and __fpclassifyl.c to the m68k math Jamfile to ensure they are compiled and linked.
- Added missing cacos.c, cacosf.c, ccoshl.c, csinhl.c, and ctanhl.c source files from musl to src/system/libroot/posix/musl/complex/.
- Updated the complex Jamfile to include these new files.

These changes address undefined symbol errors related to floating point classification and complex math functions when building libroot for the m68k architecture.