### PR TITLE
Fix m68k ELF header type mismatch in kernel/elf.cpp

### DIFF
--- a/src/system/kernel/elf.cpp
+++ b/src/system/kernel/elf.cpp
@@ -1265,7 +1265,7 @@ insert_preloaded_image(preloaded_elf_image *preloadedImage, bool kernel)
 	status_t status;
 
 	// Copy the header to an aligned local variable to avoid unaligned access.
-	Elf64_Ehdr header_copy = preloadedImage->elf_header;
+	elf_ehdr header_copy = preloadedImage->elf_header;
 	status = verify_eheader(&header_copy);
 	if (status != B_OK)
 		return status;


### PR DESCRIPTION
Changed the type of the `header_copy` variable in the `insert_preloaded_image` function from `Elf64_Ehdr` to `elf_ehdr`.

This resolves a compilation error on 32-bit architectures (like m68k) where `preloadedImage->elf_header` (an `Elf32_Ehdr`) was beingssigned to an `Elf64_Ehdr`, and then an `Elf64_Ehdr*` was being passed to `verify_eheader` which expects an `Elf32_Ehdr*` on these platforms.

The `elf_ehdr` type correctly resolves to the architecture-appropriate ELF header type (`Elf32_Ehdr` or `Elf64_Ehdr`), making the code architecture-neutral in this instance.