### PR TITLE
Build: Fix m68k compilation of musl complex math functions

### DIFF
--- a/src/system/libroot/posix/musl/complex/Jamfile
+++ b/src/system/libroot/posix/musl/complex/Jamfile
@@ -16,7 +16,7 @@ for architectureObject in [ MultiArchSubDirSetup ] {
 			TARGET_CC_x86_gcc2 = $(TARGET_CC_x86) -Wa,-mrelax-relocations=no -Wno-unused-but-set-variable ;
 		}
 
-		MergeObject <$(architecture)>posix_musl_complex.o :
+		local complexSources =
 			__cexp.c __cexpf.c
 			cabs.c cabsf.c cabsl.c
 			cacosh.c cacoshf.c
@@ -35,7 +35,8 @@ for architectureObject in [ MultiArchSubDirSetup ] {
 			csqrt.c csqrtf.c
 			ctan.c ctanf.c ctanl.c
 			ctanh.c ctanhf.c
-			;
+		;
+		MergeObject <$(architecture)>posix_musl_complex.o : $(complexSources:G=<$(SUBDIR)>) ;
 
 		if $(architecture) = x86_gcc2 {
 			TARGET_CC_x86_gcc2 = $(original_TARGET_CC_x86_gcc2) ;


### PR DESCRIPTION
Ensures that generic musl complex math source files (e.g., ccosh.c, csinh.c) are correctly located from their common directory (src/system/libroot/posix/musl/complex/) when building for the m68k architecture.

This is achieved by explicitly gristing the source file paths with <$(SUBDIR)> in the MergeObject rule within
src/system/libroot/posix/musl/complex/Jamfile.

This fixes "don't know how to make ..." errors and should allow the <m68k>posix_musl_complex.o object to build, which is a likely dependency for m68k bootloaders. This, in turn, is expected to help resolve subsequent "Unknown path to handle adding to image" errors during the packaging of m68k bootloader components.