### PR TITLE
NetStack: Fix various compilation errors

### DIFF
--- a/src/add-ons/kernel/network/stack/domains.cpp
+++ b/src/add-ons/kernel/network/stack/domains.cpp
@@ -79,7 +79,8 @@ dump_domains(int argc, char** argv)
 				net_domain_private* domain;
 				int count;
 			};
-			walktree_f_t dump_route_callback_func = [](struct radix_node* node, void* context) -> int {
+			// Use auto for the lambda, it will decay to a function pointer when passed.
+			auto dump_route_callback_func = [](struct radix_node* node, void* context) -> int {
 				DumpContext* ctx = (DumpContext*)context;
 				net_domain_private* currentDomain = ctx->domain;
 				net_route_private* route = net_route_private::FromRadixNode(node);
@@ -119,7 +120,7 @@ dump_domains(int argc, char** argv)
 			};
 
 			// Simpler iteration for duped keys directly from the node returned by walktree
-			walktree_f_t dump_route_callback_func_simplified = [](struct radix_node* rn, void* context) -> int {
+			auto dump_route_callback_func_simplified = [](struct radix_node* rn, void* context) -> int {
 				DumpContext* ctx = (DumpContext*)context;
 				net_domain_private* currentDomain = ctx->domain;
 

--- a/src/add-ons/kernel/network/stack/net_buffer.cpp
+++ b/src/add-ons/kernel/network/stack/net_buffer.cpp
@@ -1408,7 +1408,7 @@ merge_buffer(net_buffer* _buffer, net_buffer* _with, bool after)
 			nodesToPotentiallyReallocate++;
 	}
 
-	BStackOrHeapArray<data_node*> preallocatedNodePtrs(nodesToPotentiallyReallocate);
+	BStackOrHeapArray<data_node*, 16> preallocatedNodePtrs(nodesToPotentiallyReallocate);
 	if (nodesToPotentiallyReallocate > 0 && !preallocatedNodePtrs.IsValid()) {
 		return B_NO_MEMORY;
 	}

--- a/src/add-ons/kernel/network/stack/routes.h
+++ b/src/add-ons/kernel/network/stack/routes.h
@@ -12,7 +12,7 @@
 #include <net_datalink.h>
 #include <net_stack.h>
 
-// #include <util/DoublyLinkedList.h> // No longer using DoublyLinkedList for routes
+#include <util/DoublyLinkedList.h>
 #include <stddef.h> // For offsetof
 #include "radix.h" // For struct radix_node
 


### PR DESCRIPTION
1. `net_buffer.cpp`:
   - Correctly initializes `BStackOrHeapArray` with two template arguments (Type, StackSize) instead of one. Uses a default stack size of 16.

2. `routes.h` / `domains.h`:
   - Uncommented `#include <util/DoublyLinkedList.h>` in `routes.h` to provide the definition for `DoublyLinkedList`.
   - This resolves errors where `DoublyLinkedList` and the typedef `RouteInfoList` (in `domains.h` via `routes.h`) were not recognized.

3. `domains.cpp`:
   - Changed lambda assignments for `dump_route_callback_func` and `dump_route_callback_func_simplified` to use `auto`.
   - This allows the non-capturing lambdas to correctly decay to function pointers of type `walktree_f_t*` (which is `int (*)(struct radix_node *, void *)`) as expected by `rnh_walktree`, resolving 'declaration has extern and is initialized' and 'function is initialized like a variable' errors.