### PR TITLE
Build: Fix path resolution for generic musl complex math sources

### DIFF
--- a/src/system/libroot/posix/musl/complex/Jamfile
+++ b/src/system/libroot/posix/musl/complex/Jamfile
@@ -16,27 +16,30 @@ for architectureObject in [ MultiArchSubDirSetup ] {
 			TARGET_CC_x86_gcc2 = $(TARGET_CC_x86) -Wa,-mrelax-relocations=no -Wno-unused-but-set-variable ;
 		}
 
+		# Explicitly grist sources with <> to prevent default architectural grist application
+		# by FGristFiles within MergeObject. This ensures they are sourced from the
+		# generic 'complex' directory.
 		local complexSources =
-			__cexp.c __cexpf.c
-			cabs.c cabsf.c cabsl.c
-			cacosh.c cacoshf.c
-			carg.c cargf.c cargl.c
-			catan.c catanf.c catanl.c
-			catanh.c catanhf.c catanhl.c
-			ccos.c ccosf.c ccosl.c
-			ccosh.c ccoshf.c
-			cexp.c cexpf.c
-			cimag.c cimagf.c cimagl.c
-			conj.c conjf.c conjl.c
-			cproj.c cprojf.c cprojl.c
-			creal.c crealf.c creall.c
-			csin.c csinf.c csinl.c
-			csinh.c csinhf.c
-			csqrt.c csqrtf.c
-			ctan.c ctanf.c ctanl.c
-			ctanh.c ctanhf.c
+			<>__cexp.c <>__cexpf.c
+			<>cabs.c <>cabsf.c <>cabsl.c
+			<>cacosh.c <>cacoshf.c
+			<>carg.c <>cargf.c <>cargl.c
+			<>catan.c <>catanf.c <>catanl.c
+			<>catanh.c <>catanhf.c <>catanhl.c
+			<>ccos.c <>ccosf.c <>ccosl.c
+			<>ccosh.c <>ccoshf.c
+			<>cexp.c <>cexpf.c
+			<>cimag.c <>cimagf.c <>cimagl.c
+			<>conj.c <>conjf.c <>conjl.c
+			<>cproj.c <>cprojf.c <>cprojl.c
+			<>creal.c <>crealf.c <>creall.c
+			<>csin.c <>csinf.c <>csinl.c
+			<>csinh.c <>csinhf.c
+			<>csqrt.c <>csqrtf.c
+			<>ctan.c <>ctanf.c <>ctanl.c
+			<>ctanh.c <>ctanhf.c
 		;
-		MergeObject <$(architecture)>posix_musl_complex.o : $(complexSources:G=<$(SUBDIR)>) ;
+		MergeObject <$(architecture)>posix_musl_complex.o : $(complexSources) ;
 
 		if $(architecture) = x86_gcc2 {
 			TARGET_CC_x86_gcc2 = $(original_TARGET_CC_x86_gcc2) ;


### PR DESCRIPTION
Corrects the Jamfile for musl complex math functions (src/system/libroot/posix/musl/complex/Jamfile) to ensure that generic C source files (e.g., ccosh.c, csinh.c) are sourced from the common 'complex/' directory for all architectures.

This is achieved by adding an empty grist (`<>`) to each source file in the MergeObject rule. This prevents the default architectural `$(GRIST)` from being applied by FGristFiles, which was causing Jam to incorrectly look for these files in architecture-specific subdirectories (e.g., .../complex/x86_64/ccosh.c).

This change resolves "don't know how to make ..." errors for these musl files on architectures like x86_64, ppc, and m68k. It is expected to allow successful compilation of dependent bootloader components, which in turn should fix the "Unknown path to handle adding to image" errors encountered during image and haiku_loader.hpkg assembly.