### PR TITLE
Link radix.c to resolve rn_* symbol errors in network stack

### DIFF
--- a/src/add-ons/kernel/network/stack/Jamfile
+++ b/src/add-ons/kernel/network/stack/Jamfile
@@ -13,7 +13,7 @@ KernelAddon stack :
 	net_socket.cpp
 	notifications.cpp
 	link.cpp
-	#radix.c
+	radix.c
 	routes.cpp
 	stack.cpp
 	stack_interface.cpp


### PR DESCRIPTION
Uncommented radix.c in the Jamfile for the stack kernel add-on. This file provides the implementations for radix tree functions (rn_init, rn_inithead, etc.), resolving the undefined reference linker errors for these symbols when compiling routes.cpp.