### PR TITLE
Link kernel's list.cpp to resolve BList linker errors in network stack

### DIFF
--- a/src/add-ons/kernel/network/stack/Jamfile
+++ b/src/add-ons/kernel/network/stack/Jamfile
@@ -18,6 +18,7 @@ KernelAddon stack :
 	stack.cpp
 	stack_interface.cpp
 	utility.cpp
+	$(HAIKU_TOP)/src/system/kernel/util/list.cpp
 
 	# for test purposes
 	#simple_net_buffer.cpp


### PR DESCRIPTION
Added $(HAIKU_TOP)/src/system/kernel/util/list.cpp to the sources for the 'stack' kernel add-on in its Jamfile.

This provides the implementations for BList and _PointerList_ methods, resolving the 'undefined reference' linker errors that occurred when routes.cpp used BObjectList.