### PR TITLE
Link kernel_util.o to resolve BList linker errors in network stack

### DIFF
--- a/src/add-ons/kernel/network/stack/Jamfile
+++ b/src/add-ons/kernel/network/stack/Jamfile
@@ -4,6 +4,7 @@ UseHeaders $(TARGET_PRIVATE_KERNEL_HEADERS) : true ;
 UsePrivateHeaders net shared ;
 
 KernelAddon stack :
+	$(HAIKU_TOP)/src/system/kernel/util/kernel_util.o
 	ancillary_data.cpp
 	datalink.cpp
 	device_interfaces.cpp
@@ -18,7 +19,6 @@ KernelAddon stack :
 	stack.cpp
 	stack_interface.cpp
 	utility.cpp
-	$(HAIKU_TOP)/src/system/kernel/util/list.cpp
 
 	# for test purposes
 	#simple_net_buffer.cpp


### PR DESCRIPTION
Added $(HAIKU_TOP)/src/system/kernel/util/kernel_util.o to the source/object list for the 'stack' kernel add-on in its Jamfile.

kernel_util.o is a KernelMergeObject that includes the compiled code for src/system/kernel/util/list.cpp, which provides BList and _PointerList_ implementations.

This change ensures these necessary C++ support symbols are linked into the network stack add-on, resolving previous 'undefined reference' errors.