### PR TITLE
Fix: Build libnetservices2 with C++17 for ppc

### DIFF
--- a/src/kits/network/libnetservices2/Jamfile
+++ b/src/kits/network/libnetservices2/Jamfile
@@ -26,7 +26,7 @@ for architectureObject in [ MultiArchSubDirSetup ] {
 		}
 
 		# Explicitly set C++ standard per architecture for this kit
-		if $(architecture) = sparc || $(architecture) = m68k || $(architecture) = ppc {
+		if $(architecture) = sparc || $(architecture) = m68k {
 			C++FLAGS on *.cpp = $(cleanCxxFlags) -std=gnu++14 ;
 		} else {
 			C++FLAGS on *.cpp = $(cleanCxxFlags) -std=gnu++17 ;


### PR DESCRIPTION
The ppc architecture requires C++17 features, but was being compiled with C++14. This change updates the Jamfile to use C++17 for ppc.