### PR TITLE
Partial C++14 refactor: std::optional, std::byte, std::string_view (h…

### DIFF
--- a/headers/private/netservices2/HttpFields.h
+++ b/headers/private/netservices2/HttpFields.h
@@ -7,9 +7,9 @@
 #define _B_HTTP_FIELDS_H_
 
 #include <list>
-#include <optional>
-#include <string_view>
-#include <variant>
+// #include <optional> // C++17, removed
+// #include <string_view> // C++17, removed
+#include <variant> // Will be handled in a later step
 #include <vector>
 
 #include <ErrorsExt.h>
@@ -49,18 +49,23 @@ public:
 			const Field&		operator[](size_t index) const;
 
 	// Modifiers
-			void				AddField(const std::string_view& name,
-									const std::string_view& value);
+			// void				AddField(const std::string_view& name, // C++17
+			// 						const std::string_view& value); // C++17
+			void				AddField(const BString& name, const BString& value);
+			void				AddField(const char* name, const char* value); // For literals
 			void				AddField(BString& field);
 			void				AddFields(std::initializer_list<Field> fields);
-			void				RemoveField(const std::string_view& name) noexcept;
+			// void				RemoveField(const std::string_view& name) noexcept; // C++17
+			void				RemoveField(const BString& name) noexcept;
 			void				RemoveField(ConstIterator it) noexcept;
 			void				MakeEmpty() noexcept;
 
 	// Querying
-			ConstIterator		FindField(const std::string_view& name) const noexcept;
+			// ConstIterator		FindField(const std::string_view& name) const noexcept; // C++17
+			ConstIterator		FindField(const BString& name) const noexcept;
 			size_t				CountFields() const noexcept;
-			size_t				CountFields(const std::string_view& name) const noexcept;
+			// size_t				CountFields(const std::string_view& name) const noexcept; // C++17
+			size_t				CountFields(const BString& name) const noexcept;
 
 	// Range-based iteration
 			ConstIterator		begin() const noexcept;
@@ -88,23 +93,28 @@ class BHttpFields::FieldName
 public:
 	// Comparison
 			bool				operator==(const BString& other) const noexcept;
-			bool				operator==(const std::string_view& other) const noexcept;
+			// bool				operator==(const std::string_view& other) const noexcept; // C++17
 			bool				operator==(const FieldName& other) const noexcept;
 
 	// Conversion
-	operator					std::string_view() const;
+	// operator					std::string_view() const; // C++17
+	operator					const BString&() const; // Or provide a BString Name() const;
+	const BString&				GetString() const; // Explicit getter
 
 private:
 	friend class BHttpFields;
 
 								FieldName() noexcept;
-								FieldName(const std::string_view& name) noexcept;
+								// FieldName(const std::string_view& name) noexcept; // C++17
+								FieldName(const BString& name) noexcept;
+								FieldName(const char* name) noexcept; // For literals
 								FieldName(const FieldName& other) noexcept;
 								FieldName(FieldName&&) noexcept;
 			FieldName&			operator=(const FieldName& other) noexcept;
 			FieldName&			operator=(FieldName&&) noexcept;
 
-			std::string_view	fName;
+			// std::string_view	fName; // C++17
+			BString				fNameString;
 };
 
 
@@ -113,8 +123,10 @@ class BHttpFields::Field
 public:
 	// Constructors
 								Field() noexcept;
-								Field(const std::string_view& name, const std::string_view& value);
-								Field(BString& field);
+								// Field(const std::string_view& name, const std::string_view& value); // C++17
+								Field(const BString& name, const BString& value);
+								Field(const char* name, const char* value); // For literals
+								Field(BString& field); // Assumes "Name: Value"
 								Field(const Field& other);
 								Field(Field&&) noexcept;
 
@@ -124,19 +136,24 @@ public:
 
 	// Access Operators
 			const FieldName&	Name() const noexcept;
-			std::string_view	Value() const noexcept;
-			std::string_view	RawField() const noexcept;
-			bool				IsEmpty() const noexcept;
+			// std::string_view	Value() const noexcept; // C++17
+			const BString&		Value() const noexcept;
+			// std::string_view	RawField() const noexcept; // C++17
+			const BString&		RawField() const noexcept; // Returns fRawFieldString
+			bool				IsEmpty() const noexcept; // Checks fHasRawField
 
 private:
 	friend class BHttpFields;
 
-								Field(BString&& rawField);
+								Field(BString&& rawField); // Assumes "Name: Value" or just "NameValue" if no ':'
 
-			std::optional<BString> fRawField;
+			// std::optional<BString> fRawField; // C++17
+			BString fRawFieldString; // If not set, IsEmpty() will be true. Stores "Name: Value".
+			bool fHasRawField = false;
 
 			FieldName			fName;
-			std::string_view	fValue;
+			// std::string_view	fValue; // This will be handled later // C++17
+			BString				fValueString; // Derived from fRawFieldString
 };
 
 

--- a/headers/private/netservices2/HttpRequest.h
+++ b/headers/private/netservices2/HttpRequest.h
@@ -7,9 +7,9 @@
 #define _B_HTTP_REQUEST_H_
 
 #include <memory>
-#include <optional>
-#include <string_view>
-#include <variant>
+// #include <optional> // C++17, removed
+// #include <string_view> // C++17, removed
+#include <variant> // Will be handled in a later step
 
 #include <ErrorsExt.h>
 #include <String.h>
@@ -40,7 +40,9 @@ public:
 
 	// Constructors & Destructor
 								BHttpMethod(Verb verb) noexcept;
-								BHttpMethod(const std::string_view& method);
+								// BHttpMethod(const std::string_view& method); // C++17
+								BHttpMethod(const BString& method);
+								BHttpMethod(const char* method); // For literals
 								BHttpMethod(const BHttpMethod& other);
 								BHttpMethod(BHttpMethod&& other) noexcept;
 								~BHttpMethod();
@@ -54,10 +56,14 @@ public:
 			bool				operator!=(const Verb& other) const noexcept;
 
 	// Get the method as a string
-			const std::string_view Method() const noexcept;
+			// const std::string_view Method() const noexcept; // C++17
+			const BString&		MethodString() const noexcept; // Returns BString if custom, or string representation of Verb
+			bool				IsCustom() const noexcept;
+			Verb				GetVerb() const; // Assumes !IsCustom()
 
 private:
-			std::variant<Verb, BString> fMethod;
+			std::variant<Verb, BString> fMethod; // To be replaced later
+			BString fMethodStringInternal; // Cache for string form
 };
 
 
@@ -112,8 +118,10 @@ public:
 			void				SetFields(const BHttpFields& fields);
 			void				SetMaxRedirections(uint8 maxRedirections);
 			void				SetMethod(const BHttpMethod& method);
+			// void				SetRequestBody(std::unique_ptr<BDataIO> input, BString mimeType,
+			// 						std::optional<off_t> size); // C++17
 			void				SetRequestBody(std::unique_ptr<BDataIO> input, BString mimeType,
-									std::optional<off_t> size);
+									off_t size, bool hasSize); // if hasSize is false, size is ignored
 			void				SetStopOnError(bool stopOnError);
 			void				SetTimeout(bigtime_t timeout);
 			void				SetUrl(const BUrl& url);
@@ -140,8 +148,12 @@ private:
 struct BHttpRequest::Body {
 			std::unique_ptr<BDataIO> input;
 			BString				mimeType;
-			std::optional<off_t> size;
-			std::optional<off_t> startPosition;
+			// std::optional<off_t> size; // C++17
+			off_t sizeValue;
+			bool hasSize;
+			// std::optional<off_t> startPosition; // C++17
+			off_t startPositionValue;
+			bool hasStartPosition;
 };
 
 

--- a/headers/private/netservices2/HttpResult.h
+++ b/headers/private/netservices2/HttpResult.h
@@ -7,7 +7,7 @@
 #define _B_HTTP_RESULT_H_
 
 #include <memory>
-#include <optional>
+// #include <optional> // C++17, removed
 
 #include <String.h>
 
@@ -23,7 +23,9 @@ struct HttpResultPrivate;
 
 
 struct BHttpBody {
-			std::optional<BString> text;
+			// std::optional<BString> text; // C++17
+			BString text; // If text is not set, it will be empty. Use text.IsEmpty() to check.
+			bool hasText = false; // Indicates if text is set
 };
 
 

--- a/src/kits/network/libnetservices2/HttpBuffer.h
+++ b/src/kits/network/libnetservices2/HttpBuffer.h
@@ -7,9 +7,10 @@
 #define _B_HTTP_BUFFER_H_
 
 #include <functional>
-#include <optional>
-#include <string_view>
+// #include <optional> // C++17, removed
+// #include <string_view> // C++17, removed. Will use BString or const char* + length.
 #include <vector>
+#include <cstddef> // For SIZE_MAX
 
 class BDataIO;
 class BString;
@@ -19,7 +20,8 @@ namespace BPrivate {
 
 namespace Network {
 
-using HttpTransferFunction = std::function<size_t(const std::byte*, size_t)>;
+// using HttpTransferFunction = std::function<size_t(const std::byte*, size_t)>; // C++17
+using HttpTransferFunction = std::function<size_t(const unsigned char*, size_t)>;
 
 
 class HttpBuffer
@@ -28,25 +30,30 @@ public:
 								HttpBuffer(size_t capacity = 8 * 1024);
 
 			ssize_t				ReadFrom(BDataIO* source,
-									std::optional<size_t> maxSize = std::nullopt);
+									size_t maxSize = SIZE_MAX);
 			size_t				WriteTo(HttpTransferFunction func,
-									std::optional<size_t> maxSize = std::nullopt);
+									size_t maxSize = SIZE_MAX);
 			void				WriteExactlyTo(HttpTransferFunction func,
-									std::optional<size_t> maxSize = std::nullopt);
-			std::optional<BString> GetNextLine();
+									size_t maxSize = SIZE_MAX);
+			// std::optional<BString> GetNextLine(); // C++17
+			BString GetNextLine(bool& hasLine); // Returns empty string if no line, hasLine will be false.
 
 			size_t				RemainingBytes() const noexcept;
 
 			void				Flush() noexcept;
 			void				Clear() noexcept;
 
-			std::string_view	Data() const noexcept;
+			// std::string_view	Data() const noexcept; // C++17
+			const unsigned char* Data(size_t& length) const noexcept; // Returns pointer and length
 
 	// load data into the buffer
-			HttpBuffer&			operator<<(const std::string_view& data);
+			// HttpBuffer&			operator<<(const std::string_view& data); // C++17
+			HttpBuffer&			operator<<(const BString& data);
+			HttpBuffer&			operator<<(const char* data); // For string literals
 
 private:
-			std::vector<std::byte> fBuffer;
+			// std::vector<std::byte> fBuffer; // C++17
+			std::vector<unsigned char> fBuffer;
 			size_t				fCurrentOffset = 0;
 };
 

--- a/src/kits/network/libnetservices2/HttpParser.h
+++ b/src/kits/network/libnetservices2/HttpParser.h
@@ -8,7 +8,7 @@
 
 
 #include <functional>
-#include <optional>
+// #include <optional> // C++17, removed
 
 #include <HttpResult.h>
 
@@ -20,7 +20,8 @@ namespace BPrivate {
 
 namespace Network {
 
-using HttpTransferFunction = std::function<size_t(const std::byte*, size_t)>;
+// using HttpTransferFunction = std::function<size_t(const std::byte*, size_t)>; // C++17
+using HttpTransferFunction = std::function<size_t(const unsigned char*, size_t)>;
 
 
 enum class HttpInputStreamState { StatusLine, Fields, Body, Done };
@@ -56,7 +57,8 @@ public:
 
 	// Details on the body status
 			bool				HasContent() const noexcept;
-			std::optional<off_t> BodyBytesTotal() const noexcept;
+			// std::optional<off_t> BodyBytesTotal() const noexcept; // C++17
+			off_t				BodyBytesTotal(bool& hasTotal) const noexcept; // Returns -1 if no total, hasTotal will be false.
 			off_t				BodyBytesTransferred() const noexcept;
 			bool				Complete() const noexcept;
 
@@ -77,7 +79,8 @@ public:
 	virtual						BodyParseResult ParseBody(HttpBuffer& buffer,
 									HttpTransferFunction writeToBody, bool readEnd) = 0;
 
-	virtual	std::optional<off_t> TotalBodySize() const noexcept;
+	// virtual	std::optional<off_t> TotalBodySize() const noexcept; // C++17
+	virtual	off_t				TotalBodySize(bool& hasTotal) const noexcept; // Returns -1 if no total, hasTotal will be false.
 
 			off_t				TransferredBodySize() const noexcept;
 
@@ -90,13 +93,16 @@ class HttpRawBodyParser : public HttpBodyParser
 {
 public:
 								HttpRawBodyParser();
-								HttpRawBodyParser(off_t bodyBytesTotal);
+								HttpRawBodyParser(off_t bodyBytesTotal, bool hasTotal);
 	virtual	BodyParseResult		ParseBody(HttpBuffer& buffer, HttpTransferFunction writeToBody,
 									bool readEnd) override;
-	virtual	std::optional<off_t> TotalBodySize() const noexcept override;
+	// virtual	std::optional<off_t> TotalBodySize() const noexcept override; // C++17
+	virtual	off_t				TotalBodySize(bool& hasTotal) const noexcept override; // Returns -1 if no total, hasTotal will be false.
 
 private:
-			std::optional<off_t> fBodyBytesTotal;
+			// std::optional<off_t> fBodyBytesTotal; // C++17
+			off_t fBodyBytesTotalValue;
+			bool fHasBodyBytesTotal;
 };
 
 
@@ -120,7 +126,8 @@ public:
 	virtual	BodyParseResult		ParseBody(HttpBuffer& buffer, HttpTransferFunction writeToBody,
 									bool readEnd) override;
 
-	virtual	std::optional<off_t> TotalBodySize() const noexcept;
+	// virtual	std::optional<off_t> TotalBodySize() const noexcept; // C++17
+	virtual	off_t				TotalBodySize(bool& hasTotal) const noexcept; // Returns -1 if no total, hasTotal will be false.
 
 private:
 			std::unique_ptr<HttpBodyParser> fBodyParser;

--- a/src/kits/network/libnetservices2/HttpPrivate.h
+++ b/src/kits/network/libnetservices2/HttpPrivate.h
@@ -6,7 +6,7 @@
 #ifndef _B_HTTP_PRIVATE_H_
 #define _B_HTTP_PRIVATE_H_
 
-#include <string_view>
+// #include <string_view> // C++17, removed
 
 #include <HttpRequest.h>
 #include <Url.h>
@@ -25,13 +25,16 @@ namespace Network {
 	\returns \c true if the string is valid, or \c false if it is not.
 */
 static inline bool
-validate_http_token_string(const std::string_view& string)
+// validate_http_token_string(const std::string_view& string) // C++17
+validate_http_token_string(const BString& string)
 {
-	for (auto it = string.cbegin(); it < string.cend(); it++) {
-		if (*it <= 31 || *it == 127 || *it == '(' || *it == ')' || *it == '<' || *it == '>'
-			|| *it == '@' || *it == ',' || *it == ';' || *it == '\\' || *it == '"' || *it == '/'
-			|| *it == '[' || *it == ']' || *it == '?' || *it == '=' || *it == '{' || *it == '}'
-			|| *it == ' ')
+	// for (auto it = string.cbegin(); it < string.cend(); it++) { // C++11 iterators for BString
+	for (int32 i = 0; i < string.Length(); i++) {
+		char ch = string[i];
+		if (ch <= 31 || ch == 127 || ch == '(' || ch == ')' || ch == '<' || ch == '>'
+			|| ch == '@' || ch == ',' || ch == ';' || ch == '\\' || ch == '"' || ch == '/'
+			|| ch == '[' || ch == ']' || ch == '?' || ch == '=' || ch == '{' || ch == '}'
+			|| ch == ' ') // Corrected from *it to ch
 			return false;
 	}
 	return true;


### PR DESCRIPTION
…eaders and some .cpp)

This commit includes initial changes to refactor the codebase from C++17 to C++14 compatibility.

Key changes made so far:

1.  **`std::optional`**:
    *   Replaced `std::optional` in all relevant header files (`HttpResult.h`, `HttpBuffer.h`, `HttpParser.h`, `HttpFields.h`, `HttpRequest.h`).
    *   Strategy: Use boolean flags (e.g., `hasValue`) alongside the data member, or sentinel values (`SIZE_MAX`, -1) with boolean out-parameters in function signatures (e.g., `getValue(bool& hasValue)`).

2.  **`std::byte`**:
    *   Replaced `std::byte` with `unsigned char` in `HttpBuffer.h`, `HttpParser.h`, and relevant parts of `HttpParser.cpp` (lambda in `HttpBodyDecompression::ParseBody`).

3.  **`std::string_view` and `sv` literals**:
    *   Removed `#include <string_view>` from headers.
    *   `HttpBuffer.h`:
        *   `Data()` now returns `const unsigned char*` and `size_t& length`.
        *   `operator<<` overloaded for `const BString&` and `const char*`.
    *   `HttpFields.h`:
        *   Replaced `std::string_view` parameters and return types in `BHttpFields`, `BHttpFields::FieldName`, and `BHttpFields::Field` with `BString`, `const char*`, or by modifying internal storage (e.g., `fNameString`, `fValueString`).
    *   `HttpRequest.h`:
        *   Replaced `std::string_view` in `BHttpMethod` with `BString` or `const char*` for constructors and `MethodString()` accessor.
    *   `HttpPrivate.h`:
        *   `validate_http_token_string` now accepts `const BString&`.
    *   `HttpParser.cpp`:
        *   Removed `using namespace std::literals`.
        *   Replaced `sv` literals in `FindField`, `CountFields` calls, and string comparisons with direct `BString` or `const char*` comparisons.
        *   Adjusted logic for `Content-Length` parsing to use `BString` instead of `std::string`.

Work is still in progress. The next steps involve completing the `std::string_view` replacements in `.cpp` files, refactoring `std::variant`, fully implementing the `std::optional` logic in `.cpp` files, and addressing C++17-specific syntax like if-initializers. I encountered a syntax error when trying to use `request_user_input` to get feedback on the current state before proceeding further with the `.cpp` implementations.