### PR TITLE
Refactor netservices2 to be C++14 compatible

### DIFF
--- a/headers/private/netservices2/ExclusiveBorrow.h
+++ b/headers/private/netservices2/ExclusiveBorrow.h
@@ -34,7 +34,7 @@ class BorrowAdmin
 private:
 	static constexpr uint8 kOwned = 0x1;
 	static constexpr uint8 kBorrowed = 0x2;
-	std::atomic<uint8> fState = kOwned;
+	std::atomic<uint8> fState{kOwned}; // Direct initialization
 
 protected:
 	virtual ~BorrowAdmin() = default;

--- a/headers/private/netservices2/HttpRequest.h
+++ b/headers/private/netservices2/HttpRequest.h
@@ -9,7 +9,7 @@
 #include <memory>
 // #include <optional> // C++17, removed
 // #include <string_view> // C++17, removed
-#include <variant> // Will be handled in a later step
+// #include <variant> // C++17, replaced
 
 #include <ErrorsExt.h>
 #include <String.h>
@@ -59,11 +59,14 @@ public:
 			// const std::string_view Method() const noexcept; // C++17
 			const BString&		MethodString() const noexcept; // Returns BString if custom, or string representation of Verb
 			bool				IsCustom() const noexcept;
-			Verb				GetVerb() const; // Assumes !IsCustom()
+			Verb				GetVerb() const; // Assumes !IsCustom(), throws if custom.
 
 private:
-			std::variant<Verb, BString> fMethod; // To be replaced later
-			BString fMethodStringInternal; // Cache for string form
+			// std::variant<Verb, BString> fMethod; // Replaced with fVerbValue, fCustomMethodString, fIsCustomMethod
+			Verb				fVerbValue;
+			BString				fCustomMethodString;
+			bool				fIsCustomMethod;
+			BString				fMethodStringInternal; // Cache for string form of Verb, or copy of fCustomMethodString
 };
 
 


### PR DESCRIPTION
Replaced C++17 features:
- std::variant with explicit members and a boolean flag.
- std::optional with a (value + bool hasValue) pattern.
- std::string_view with BString or const char*.
- std::byte with char or unsigned char.
- Removed ""sv string literals.
- Corrected std::atomic initialization.

These changes address compilation errors encountered when building with -std=gnu++14.