### PR TITLE
Refactor netservices2 for C++14 compatibility (expanded scope)

### DIFF
--- a/headers/private/netservices2/HttpFields.h
+++ b/headers/private/netservices2/HttpFields.h
@@ -9,7 +9,7 @@
 #include <list>
 // #include <optional> // C++17, removed
 // #include <string_view> // C++17, removed
-#include <variant> // Will be handled in a later step
+// #include <variant> // C++17, unused in this file
 #include <vector>
 
 #include <ErrorsExt.h>

--- a/src/kits/network/libnetservices2/HttpBuffer.cpp
+++ b/src/kits/network/libnetservices2/HttpBuffer.cpp
@@ -8,6 +8,7 @@
 
 #include "HttpBuffer.h"
 
+#include <algorithm> // For std::search
 #include <DataIO.h>
 #include <NetServicesDefs.h>
 #include <String.h>
@@ -197,7 +198,7 @@ HttpBuffer::Data(size_t& length) const noexcept
 HttpBuffer&
 HttpBuffer::operator<<(const BString& data)
 {
-	if (data.length() > (fBuffer.capacity() - fBuffer.size())) {
+	if (data.Length() > (fBuffer.capacity() - fBuffer.size())) { // Changed .length() to .Length()
 		throw BNetworkRequestError(__PRETTY_FUNCTION__, BNetworkRequestError::ProtocolError,
 			"No capacity left in buffer to append data.");
 	}

--- a/src/kits/network/libnetservices2/HttpRequest.cpp
+++ b/src/kits/network/libnetservices2/HttpRequest.cpp
@@ -411,17 +411,18 @@ BHttpRequest::SetFields(const BHttpFields& fields)
 		fData = std::make_unique<Data>();
 
 	for (auto& field: fields) {
-		// field.Name() returns BString, so we need to compare with const char*
+		// field.Name() returns const FieldName&. We need to compare with const char* reservedName.
+		// FieldName has operator==(const BString&).
 		bool isReserved = false;
 		for (const char* reservedName : fReservedOptionalFieldNames) {
-			if (field.Name() == reservedName) {
+			if (field.Name() == BString(reservedName)) { // Explicitly convert reservedName to BString
 				isReserved = true;
 				break;
 			}
 		}
 		if (isReserved) {
 			throw BHttpFields::InvalidInput(
-				__PRETTY_FUNCTION__, field.Name());
+				__PRETTY_FUNCTION__, field.Name().GetString()); // Use GetString() for BString output
 		}
 	}
 	fData->optionalFields = fields;

--- a/src/kits/network/libnetservices2/HttpSerializer.h
+++ b/src/kits/network/libnetservices2/HttpSerializer.h
@@ -8,7 +8,7 @@
 
 
 #include <functional>
-#include <optional>
+// #include <optional> // C++17, replaced
 
 class BDataIO;
 
@@ -19,7 +19,8 @@ namespace Network {
 class BHttpRequest;
 class HttpBuffer;
 
-using HttpTransferFunction = std::function<size_t(const std::byte*, size_t)>;
+// using HttpTransferFunction = std::function<size_t(const std::byte*, size_t)>; // C++17
+using HttpTransferFunction = std::function<size_t(const unsigned char*, size_t)>;
 
 
 enum class HttpSerializerState { Uninitialized, Header, ChunkHeader, Body, Done };
@@ -35,7 +36,8 @@ public:
 
 			size_t				Serialize(HttpBuffer& buffer, BDataIO* target);
 
-			std::optional<off_t> BodyBytesTotal() const noexcept;
+			// std::optional<off_t> BodyBytesTotal() const noexcept; // C++17
+			off_t				BodyBytesTotal(bool& hasTotal) const noexcept;
 			off_t				BodyBytesTransferred() const noexcept;
 			bool				Complete() const noexcept;
 
@@ -47,7 +49,9 @@ private:
 			HttpSerializerState	fState = HttpSerializerState::Uninitialized;
 			BDataIO*			fBody = nullptr;
 			off_t				fTransferredBodySize = 0;
-			std::optional<off_t> fBodySize;
+			// std::optional<off_t> fBodySize; // C++17
+			off_t				fBodySizeValue;
+			bool				fHasBodySize;
 };
 
 
@@ -58,10 +62,13 @@ HttpSerializer::IsInitialized() const noexcept
 }
 
 
-inline std::optional<off_t>
-HttpSerializer::BodyBytesTotal() const noexcept
+inline off_t
+HttpSerializer::BodyBytesTotal(bool& hasTotal) const noexcept
 {
-	return fBodySize;
+	hasTotal = fHasBodySize;
+	if (fHasBodySize)
+		return fBodySizeValue;
+	return -1; // Or some other indicator for "not known"
 }
 
 


### PR DESCRIPTION
Replaced C++17 features across multiple files in libnetservices2, including HttpRequest, HttpParser, HttpBuffer, HttpResult, HttpFields, HttpSerializer, and ExclusiveBorrow.

Changes include:
- std::variant replaced with explicit members and a boolean flag.
- std::optional replaced with a (value + bool hasValue) pattern.
- std::string_view replaced with BString or const char*.
- std::byte replaced with char or unsigned char.
- Removed ""sv string literals and std::literals namespace usage.
- Corrected std::atomic initialization.
- Ensured necessary includes like <algorithm> for std::search.
- Corrected BString::Length() calls.

These changes address compilation errors encountered when building with -std=gnu++14 and aim for C++14 compatibility.