### PR TITLE
Further C++14 compatibility changes for netservices2

### DIFF
--- a/src/kits/network/libnetservices2/HttpBuffer.cpp
+++ b/src/kits/network/libnetservices2/HttpBuffer.cpp
@@ -198,7 +198,7 @@ HttpBuffer::Data(size_t& length) const noexcept
 HttpBuffer&
 HttpBuffer::operator<<(const BString& data)
 {
-	if (data.Length() > (fBuffer.capacity() - fBuffer.size())) { // Changed .length() to .Length()
+	if (static_cast<size_t>(data.Length()) > (fBuffer.capacity() - fBuffer.size())) {
 		throw BNetworkRequestError(__PRETTY_FUNCTION__, BNetworkRequestError::ProtocolError,
 			"No capacity left in buffer to append data.");
 	}

--- a/src/kits/network/libnetservices2/HttpParser.cpp
+++ b/src/kits/network/libnetservices2/HttpParser.cpp
@@ -17,6 +17,7 @@
 
 // using namespace std::literals; // For sv suffix, removed
 using namespace BPrivate::Network;
+// Re-evaluating HttpParser.cpp for subtle syntax issues.
 
 
 // #pragma mark -- HttpParser
@@ -204,7 +205,8 @@ HttpParser::ParseFields(HttpBuffer& buffer, BHttpFields& fields)
 		// (this is the default)
 		fStreamState = HttpInputStreamState::Body;
 		fBodyType = HttpBodyType::VariableSize; // Explicitly set for clarity
-	}
+	} // Closes the main else related to (fBodyType == HttpBodyType::NoContent)
+	// } // This was the diff from before, which was incorrect, it should be above the switch
 
 	// Set up the body parser based on the logic above.
 	switch (fBodyType) {

--- a/src/kits/network/libnetservices2/HttpRequest.cpp
+++ b/src/kits/network/libnetservices2/HttpRequest.cpp
@@ -629,7 +629,7 @@ BHttpRequest::SerializeHeaderTo(HttpBuffer& buffer) const
 		outputFields.AddField(
 			"Content-Type", fData->requestBodyValue.mimeType.String()); // Removed "sv" and string_view
 		if (fData->requestBodyValue.hasSize)
-			outputFields.AddField("Content-Length", std::to_string(fData->requestBodyValue.sizeValue)); // Removed "sv"
+			outputFields.AddField("Content-Length", BString() << fData->requestBodyValue.sizeValue);
 		else
 			throw BRuntimeError(__PRETTY_FUNCTION__,
 				"Transfer body with unknown content length; chunked transfer not supported");


### PR DESCRIPTION
Addresses additional errors found after initial C++14 refactor:
- Fixed signed/unsigned warning in HttpBuffer.cpp.
- Corrected AddField call type mismatch in HttpRequest.cpp.
- Refactored HttpFields.h/cpp and HttpSerializer.h/cpp to remove std::string_view, std::optional, and std::byte, aligning with C++14 patterns.

KNOWN ISSUE: HttpParser.cpp still has critical syntax errors (likely an unclosed scope in ParseFields or similar) that prevent its compilation. These errors cause cascading parsing failures for subsequent definitions in that file. Further debugging is required for HttpParser.cpp.