### PR TITLE
Fix C++14 compatibility and various compilation errors

### DIFF
--- a/src/kits/network/libnetservices2/HttpParser.cpp
+++ b/src/kits/network/libnetservices2/HttpParser.cpp
@@ -35,7 +35,7 @@ HttpParser::SetNoContent() noexcept
 	if (fStreamState > HttpInputStreamState::Fields)
 		debugger("Cannot set the parser to no content after parsing of the body has started");
 	fBodyType = HttpBodyType::NoContent;
-};
+}
 
 
 /*!
@@ -361,10 +361,10 @@ HttpRawBodyParser::HttpRawBodyParser()
 /*!
 	\brief Construct a HttpRawBodyParser with expected \a bodyBytesTotal size.
 */
-HttpRawBodyParser::HttpRawBodyParser(off_t bodyBytesTotal, bool hasTotal)
+HttpRawBodyParser::HttpRawBodyParser(off_t bodyBytesTotalValue, bool hasTotalValue)
 	:
-	fBodyBytesTotalValue(bodyBytesTotal),
-	fHasBodyBytesTotal(hasTotal)
+	fBodyBytesTotalValue(bodyBytesTotalValue),
+	fHasBodyBytesTotal(hasTotalValue)
 {
 }
 

--- a/src/kits/network/libnetservices2/HttpRequest.cpp
+++ b/src/kits/network/libnetservices2/HttpRequest.cpp
@@ -629,7 +629,7 @@ BHttpRequest::SerializeHeaderTo(HttpBuffer& buffer) const
 		outputFields.AddField(
 			"Content-Type", fData->requestBodyValue.mimeType.String()); // Removed "sv" and string_view
 		if (fData->requestBodyValue.hasSize)
-			outputFields.AddField("Content-Length", BString() << fData->requestBodyValue.sizeValue);
+			outputFields.AddField("Content-Length", (BString() << fData->requestBodyValue.sizeValue).String());
 		else
 			throw BRuntimeError(__PRETTY_FUNCTION__,
 				"Transfer body with unknown content length; chunked transfer not supported");


### PR DESCRIPTION
- Modified HttpParser.cpp, HttpRequest.cpp, HttpSession.cpp to ensure C++14 compatibility.
- Addressed issues such as std::atomic initialization, C++17 feature usage (if-initializers, structured bindings, std::byte), ambiguous function calls, and incorrect API usage for BString and BodyBytesTotal methods.
- Removed an extraneous semicolon in HttpParser.cpp.
- The goal is to resolve the compilation errors reported for the PPC Haiku build.