### PR TITLE
Fix variable name in HttpSession.cpp

### DIFF
--- a/src/kits/network/libnetservices2/HttpSession.cpp
+++ b/src/kits/network/libnetservices2/HttpSession.cpp
@@ -362,7 +362,7 @@ BHttpSession::Impl::DataThreadFunc(void* arg)
 			continue;
 		else if (waitStatus < 0) {
 			// Something went inexplicably wrong
-			throw BSystemError("wait_for_objects()", status);
+			throw BSystemError("wait_for_objects()", waitStatus);
 		}
 
 		// First check if the change is in acquiring the sem, meaning that


### PR DESCRIPTION
- Corrected 'status' to 'waitStatus' in a BSystemError call in HttpSession.cpp.
- Further investigation into HttpParser.cpp's persistent brace mismatch error did not reveal a definitive cause in the visible source code; this issue likely requires deeper inspection of the build environment or preprocessor output.