### PR TITLE
Add <cstdint> for SIZE_MAX in HttpBuffer.h

### DIFF
--- a/src/kits/network/libnetservices2/HttpBuffer.h
+++ b/src/kits/network/libnetservices2/HttpBuffer.h
@@ -10,7 +10,8 @@
 // #include <optional> // C++17, removed
 // #include <string_view> // C++17, removed. Will use BString or const char* + length.
 #include <vector>
-#include <cstddef> // For SIZE_MAX
+#include <cstddef> // For size_t
+#include <cstdint> // For SIZE_MAX
 
 class BDataIO;
 class BString;


### PR DESCRIPTION
HttpBuffer.h uses SIZE_MAX as a default argument for some methods. SIZE_MAX was not found in scope on some compiler toolchains (x86_64 reported, potentially others).

This change adds the <cstdint> header, which reliably defines SIZE_MAX, to ensure portability and resolve the compilation error.