### PR TITLE
Diagnostic: Comment out HttpParser::ParseFields body

### DIFF
--- a/src/kits/network/libnetservices2/HttpParser.cpp
+++ b/src/kits/network/libnetservices2/HttpParser.cpp
@@ -100,6 +100,7 @@ HttpParser::ParseStatus(HttpBuffer& buffer, BHttpStatus& status)
 bool
 HttpParser::ParseFields(HttpBuffer& buffer, BHttpFields& fields)
 {
+	/* Entire body commented out for diagnostics
 	if (fStreamState != HttpInputStreamState::Fields)
 		debugger("The parser is not expecting header fields at this point");
 
@@ -247,6 +248,8 @@ HttpParser::ParseFields(HttpBuffer& buffer, BHttpFields& fields)
 		}
 	}
 	return true;
+	*/
+	return false; // Diagnostic: return a default value
 }
 
 


### PR DESCRIPTION
To help diagnose a persistent parsing error in HttpParser.cpp (suspected unclosed brace), the entire body of the HttpParser::ParseFields method has been commented out and replaced with a simple 'return false;'.

This will help determine if the parsing issue originates within this function's body or is external to it.