### PR TITLE
Fix: Refactor C++17 extensions for C++14 compatibility

### DIFF
--- a/src/kits/network/libnetservices2/HttpParser.cpp
+++ b/src/kits/network/libnetservices2/HttpParser.cpp
@@ -611,14 +611,14 @@ HttpBodyDecompression::ParseBody(HttpBuffer& buffer, HttpTransferFunction writeT
 
 	if (readEnd || parseResults.complete) {
 		// No more bytes expected so flush out the final bytes
-		if (auto status = fDecompressingStream->Flush(); status != B_OK) {
+		auto status = fDecompressingStream->Flush();
+		if (status != B_OK) {
 			throw BNetworkRequestError(
 				"BZlibDecompressionStream::Flush()", BNetworkRequestError::SystemError, status);
 		}
 	}
 
 	size_t bytesWritten = 0;
-	// if (auto bodySize = fDecompressorStorage->Position(); bodySize > 0) { // C++17 if-initializer
 	auto bodySize = fDecompressorStorage->Position();
 	if (bodySize > 0) {
 		bytesWritten

--- a/src/kits/network/libnetservices2/HttpTime.cpp
+++ b/src/kits/network/libnetservices2/HttpTime.cpp
@@ -165,7 +165,9 @@ BHttpTime::ToString(BHttpTimeFormat outputFormat) const
 	expirationTm.tm_yday = 0;
 	expirationTm.tm_isdst = 0;
 
-	for (auto& [format, formatString]: kDateFormats) {
+	for (const auto& entry : kDateFormats) {
+		BHttpTimeFormat format = entry.first;
+		const char* formatString = entry.second;
 		if (format != outputFormat)
 			continue;
 
@@ -193,7 +195,9 @@ BHttpTime::_Parse(const BString& dateString)
 	struct tm expireTime = {};
 
 	bool found = false;
-	for (auto& [format, formatString]: kDateFormats) {
+	for (const auto& entry : kDateFormats) {
+		BHttpTimeFormat format = entry.first;
+		const char* formatString = entry.second;
 		const char* result = strptime(dateString.String(), formatString, &expireTime);
 
 		if (result == dateString.String() + dateString.Length()) {


### PR DESCRIPTION
- Modified if-initializers in HttpParser.cpp to be C++14 compliant.
- Replaced structured bindings in HttpTime.cpp with C++14 compatible constructs.