### PR TITLE
Fix kernel_util.o build order and revert musl complex change

### DIFF
--- a/src/system/kernel/Jamfile
+++ b/src/system/kernel/Jamfile
@@ -79,6 +79,24 @@ KernelMergeObject kernel_core.o :
 	: $(TARGET_KERNEL_PIC_CCFLAGS)
 ;
 
+# SubIncludes for kernel components must happen before they are referenced.
+SubInclude HAIKU_TOP src system kernel arch ;
+SubInclude HAIKU_TOP src system kernel cache ;
+SubInclude HAIKU_TOP src system kernel device_manager ;
+SubInclude HAIKU_TOP src system kernel debug ;
+SubInclude HAIKU_TOP src system kernel disk_device_manager ;
+SubInclude HAIKU_TOP src system kernel fs ;
+SubInclude HAIKU_TOP src system kernel lib ;
+SubInclude HAIKU_TOP src system kernel messaging ;
+SubInclude HAIKU_TOP src system kernel posix ;
+SubInclude HAIKU_TOP src system kernel slab ;
+SubInclude HAIKU_TOP src system kernel util ;
+SubInclude HAIKU_TOP src system kernel vm ;
+
+if $(TARGET_KERNEL_PLATFORM) {
+	SubInclude HAIKU_TOP src system kernel platform $(TARGET_KERNEL_PLATFORM) ;
+}
+
 # We need to specify the dependency on the generated syscalls files explicitly.
 Includes [ FGristFiles syscalls.cpp ]
 	:
@@ -125,24 +143,6 @@ KernelLd kernel_$(TARGET_ARCH) :
 	  $(TARGET_KERNEL_PIC_LINKFLAGS) --no-undefined
 	:
 ;
-
-# SubIncludes for kernel components must happen before they are referenced.
-SubInclude HAIKU_TOP src system kernel arch ;
-SubInclude HAIKU_TOP src system kernel cache ;
-SubInclude HAIKU_TOP src system kernel device_manager ;
-SubInclude HAIKU_TOP src system kernel debug ;
-SubInclude HAIKU_TOP src system kernel disk_device_manager ;
-SubInclude HAIKU_TOP src system kernel fs ;
-SubInclude HAIKU_TOP src system kernel lib ;
-SubInclude HAIKU_TOP src system kernel messaging ;
-SubInclude HAIKU_TOP src system kernel posix ;
-SubInclude HAIKU_TOP src system kernel slab ;
-SubInclude HAIKU_TOP src system kernel util ;
-SubInclude HAIKU_TOP src system kernel vm ;
-
-if $(TARGET_KERNEL_PLATFORM) {
-	SubInclude HAIKU_TOP src system kernel platform $(TARGET_KERNEL_PLATFORM) ;
-}
 
 if $(HAIKU_ARCH) in x86_64 arm {
 	# Cannot relink everything as a shared object on x86_64 as shared library

--- a/src/system/libroot/posix/musl/complex/Jamfile
+++ b/src/system/libroot/posix/musl/complex/Jamfile
@@ -24,14 +24,14 @@ for architectureObject in [ MultiArchSubDirSetup ] {
 			catan.c catanf.c catanl.c
 			catanh.c catanhf.c catanhl.c
 			ccos.c ccosf.c ccosl.c
-			./ccosh.c ccoshf.c
+			ccosh.c ccoshf.c
 			cexp.c cexpf.c
 			cimag.c cimagf.c cimagl.c
 			conj.c conjf.c conjl.c
 			cproj.c cprojf.c cprojl.c
 			creal.c crealf.c creall.c
 			csin.c csinf.c csinl.c
-			./csinh.c csinhf.c
+			csinh.c csinhf.c
 			csqrt.c csqrtf.c
 			ctan.c ctanf.c ctanl.c
 			ctanh.c ctanhf.c


### PR DESCRIPTION
This commit includes:
1.  src/system/kernel/Jamfile: Corrected the order of SubInclude directives to ensure that kernel components (e.g., system/kernel/util) are included before objects they define (e.g., kernel_util.o) are referenced in KernelLd rules. This fixes a "don't know how to make ../src/system/kernel/util/kernel_util.o" error.

2.  src/system/libroot/posix/musl/complex/Jamfile: Reverted the previous change that added "./" prefixes to ccosh.c and csinh.c. The original error message format indicates a deeper issue with how Jam resolves these source files under x86_64 gristing, which this change did not fix and made the error message worse.

Further diagnosis indicates that "Unknown path to handle adding to image" errors for bios_ia32/pxe_ia32 are likely due to missing linker scripts (e.g., platform_bios_ia32.ld, platform_pxe_ia32.ld) in src/system/boot/arch/x86/. These files are necessary for building the respective haiku_loader variants.