### PR TITLE
Align key Jamfiles with official repo and fix linkhack.c handling

### DIFF
--- a/src/system/kernel/Jamfile
+++ b/src/system/kernel/Jamfile
@@ -36,7 +36,6 @@ KernelMergeObject kernel_core.o :
 	image.cpp
 	interrupts.cpp
 	kernel_daemon.cpp
-	linkhack.c
 	listeners.cpp
 	low_resource_manager.cpp
 	main.cpp
@@ -78,24 +77,6 @@ KernelMergeObject kernel_core.o :
 
 	: $(TARGET_KERNEL_PIC_CCFLAGS)
 ;
-
-# SubIncludes for kernel components must happen before they are referenced.
-SubInclude HAIKU_TOP src system kernel arch ;
-SubInclude HAIKU_TOP src system kernel cache ;
-SubInclude HAIKU_TOP src system kernel device_manager ;
-SubInclude HAIKU_TOP src system kernel debug ;
-SubInclude HAIKU_TOP src system kernel disk_device_manager ;
-SubInclude HAIKU_TOP src system kernel fs ;
-SubInclude HAIKU_TOP src system kernel lib ;
-SubInclude HAIKU_TOP src system kernel messaging ;
-SubInclude HAIKU_TOP src system kernel posix ;
-SubInclude HAIKU_TOP src system kernel slab ;
-SubInclude HAIKU_TOP src system kernel util ;
-SubInclude HAIKU_TOP src system kernel vm ;
-
-if $(TARGET_KERNEL_PLATFORM) {
-	SubInclude HAIKU_TOP src system kernel platform $(TARGET_KERNEL_PLATFORM) ;
-}
 
 # We need to specify the dependency on the generated syscalls files explicitly.
 Includes [ FGristFiles syscalls.cpp ]


### PR DESCRIPTION
This commit includes the following changes based on comparison with the official Haiku GitHub repository to address build errors:

1.  src/system/kernel/Jamfile:
    - Removed `linkhack.c` from the `KernelMergeObject kernel_core.o` source list. This allows `linkhack.so` to correctly depend on a separately compiled `linkhack.o`, resolving a build conflict.
    - Ensured the order of `SubInclude` directives matches the official repository (i.e., they are at the end of the file). This reverts a previous attempt to reorder them, as the official build works with this structure.

2.  src/system/libroot/posix/musl/complex/Jamfile:
    - This file was confirmed to match the official repository version (a previous modification adding "./" to ccosh.c/csinh.c had already been reverted).

Other Jamfiles directly related to the reported errors (musl/Jamfile, kernel/util/Jamfile, boot/Jamfile) were also found to be consistent with the official repository. Additionally, required x86_64 boot linker scripts are present in the user's local repository.

Persistent errors for `ccosh.c`/`csinh.c` and "Unknown path to handle adding to image" likely stem from differences in other core build rules or the user's specific build configuration/environment that were not covered by these focused file comparisons.