### PR TITLE
Fix: Add missing include path for EFI headers in x86 boot arch

### DIFF
--- a/src/system/boot/arch/x86/Jamfile
+++ b/src/system/boot/arch/x86/Jamfile
@@ -8,6 +8,7 @@ local platform ;
 for platform in [ MultiBootSubDirSetup bios_ia32 efi pxe_ia32 ] {
 	on $(platform) {
 		SubDirHdrs $(HAIKU_TOP) src system boot platform $(TARGET_BOOT_PLATFORM) ;
+		UsePrivateHeaders [ FDirName kernel platform ] ;
 
 		DEFINES = $(defines) ;
 


### PR DESCRIPTION
The compilation of src/system/boot/arch/x86/arch_hpet.cpp failed because the included efi_platform.h could not find <efi/system-table.h>.

This was due to src/system/boot/arch/x86/Jamfile not providing the necessary base include path for headers located in headers/private/kernel/platform/.

This commit adds 'UsePrivateHeaders [ FDirName kernel platform ] ;' to src/system/boot/arch/x86/Jamfile for the EFI platform build, ensuring that headers/private/kernel/platform/ is added to the include search paths. This allows the compiler to correctly resolve <efi/system-table.h> to
headers/private/kernel/platform/efi/system-table.h.