### PR TITLE
Fix: Resolve multiple build errors for minimum-raw target

### DIFF
--- a/src/system/Jamfile
+++ b/src/system/Jamfile
@@ -1,7 +1,25 @@
 SubDir HAIKU_TOP src system ;
 
 SubInclude HAIKU_TOP src system boot ;
+
+# Kernel sub-components first, so their rules are known
+SubInclude HAIKU_TOP src system kernel arch ;
+SubInclude HAIKU_TOP src system kernel cache ;
+SubInclude HAIKU_TOP src system kernel debug ;
+SubInclude HAIKU_TOP src system kernel device_manager ;
+SubInclude HAIKU_TOP src system kernel disk_device_manager ;
+SubInclude HAIKU_TOP src system kernel fs ;
+SubInclude HAIKU_TOP src system kernel lib ;
+SubInclude HAIKU_TOP src system kernel messaging ;
+SubInclude HAIKU_TOP src system kernel platform ;
+SubInclude HAIKU_TOP src system kernel posix ;
+SubInclude HAIKU_TOP src system kernel slab ;
+SubInclude HAIKU_TOP src system kernel util ;
+SubInclude HAIKU_TOP src system kernel vm ;
+
+# Then the main kernel Jamfile that links them
 SubInclude HAIKU_TOP src system kernel ;
+
 SubInclude HAIKU_TOP src system glue ;
 SubInclude HAIKU_TOP src system libroot ;
 SubInclude HAIKU_TOP src system libnetwork ;

--- a/src/system/boot/arch/x86/Jamfile
+++ b/src/system/boot/arch/x86/Jamfile
@@ -8,7 +8,12 @@ local platform ;
 for platform in [ MultiBootSubDirSetup bios_ia32 efi pxe_ia32 ] {
 	on $(platform) {
 		SubDirHdrs $(HAIKU_TOP) src system boot platform $(TARGET_BOOT_PLATFORM) ;
-		UsePrivateHeaders [ FDirName kernel platform ] ;
+		UsePrivateHeaders [ FDirName kernel platform ] ; # For efi's <efi/system-table.h>
+
+		if $(TARGET_BOOT_PLATFORM) = pxe_ia32 {
+			# pxe_ia32 reuses bios_ia32 mmu.h and other headers from its source dir
+			SubDirHdrs $(HAIKU_TOP) src system boot platform bios_ia32 ;
+		}
 
 		DEFINES = $(defines) ;
 

--- a/src/system/kernel/lib/Jamfile
+++ b/src/system/kernel/lib/Jamfile
@@ -58,6 +58,12 @@ local muslSources =
 	rand_r.c
 	;
 
+local muslComplexSources =
+	ccosh.c
+	csinh.c
+;
+muslSources += $(muslComplexSources) ;
+
 SourceHdrs $(muslSources) :
 	[ FDirName $(posixSources) musl include ]
 	[ FDirName $(posixSources) musl internal ]
@@ -157,6 +163,7 @@ KernelMergeObject kernel_lib_posix.o :
 
 SEARCH on [ FGristFiles $(muslSources) ] += [ FDirName $(posixSources) musl misc ] ;
 SEARCH on [ FGristFiles $(muslSources) ] += [ FDirName $(posixSources) musl prng ] ;
+SEARCH on [ FGristFiles $(muslComplexSources) ] = [ FDirName $(posixSources) musl complex ] ;
 
 # misc
 


### PR DESCRIPTION
This commit addresses several issues preventing the `minimum-raw` target from building successfully, particularly for `bios_ia32` and `pxe_ia32` boot platforms.

1.  Ensured `mmu.h` is found for `pxe_ia32`: The `src/system/boot/arch/x86/Jamfile` was confirmed to correctly add the `bios_ia32` platform header path when `TARGET_BOOT_PLATFORM` is `pxe_ia32`, as `pxe_ia32` reuses `mmu.h` from `bios_ia32`.

2.  Resolved "don't know how to make kernel_*.o" errors: Modified `src/system/Jamfile` to properly `SubInclude` all necessary kernel subdirectories (e.g., `src/system/kernel/vm`, `src/system/kernel/cache`, `src/system/kernel/fs`, etc.). Previously, only `src/system/kernel/Jamfile` was included, but not its component subdirectories, so Jam could not find the rules to build individual kernel object files.

3.  Fixed "don't know how to make ...ccosh.c" errors: Modified `src/system/kernel/lib/Jamfile` to explicitly include `ccosh.c` and `csinh.c` (from `src/system/libroot/posix/musl/complex/`) in the `kernel_lib_posix.o` build. Added the necessary `SEARCH` rule to allow Jam to locate these source files.