### PR TITLE
Revert Jamfiles to upstream Haiku versions

### DIFF
--- a/src/system/Jamfile
+++ b/src/system/Jamfile
@@ -1,25 +1,7 @@
 SubDir HAIKU_TOP src system ;
 
 SubInclude HAIKU_TOP src system boot ;
-
-# Kernel sub-components first, so their rules are known
-SubInclude HAIKU_TOP src system kernel arch ;
-SubInclude HAIKU_TOP src system kernel cache ;
-SubInclude HAIKU_TOP src system kernel debug ;
-SubInclude HAIKU_TOP src system kernel device_manager ;
-SubInclude HAIKU_TOP src system kernel disk_device_manager ;
-SubInclude HAIKU_TOP src system kernel fs ;
-SubInclude HAIKU_TOP src system kernel lib ;
-SubInclude HAIKU_TOP src system kernel messaging ;
-SubInclude HAIKU_TOP src system kernel platform ;
-SubInclude HAIKU_TOP src system kernel posix ;
-SubInclude HAIKU_TOP src system kernel slab ;
-SubInclude HAIKU_TOP src system kernel util ;
-SubInclude HAIKU_TOP src system kernel vm ;
-
-# Then the main kernel Jamfile that links them
 SubInclude HAIKU_TOP src system kernel ;
-
 SubInclude HAIKU_TOP src system glue ;
 SubInclude HAIKU_TOP src system libroot ;
 SubInclude HAIKU_TOP src system libnetwork ;

--- a/src/system/boot/arch/x86/Jamfile
+++ b/src/system/boot/arch/x86/Jamfile
@@ -8,12 +8,6 @@ local platform ;
 for platform in [ MultiBootSubDirSetup bios_ia32 efi pxe_ia32 ] {
 	on $(platform) {
 		SubDirHdrs $(HAIKU_TOP) src system boot platform $(TARGET_BOOT_PLATFORM) ;
-		UsePrivateHeaders [ FDirName kernel platform ] ; # For efi's <efi/system-table.h>
-
-		if $(TARGET_BOOT_PLATFORM) = pxe_ia32 {
-			# pxe_ia32 reuses bios_ia32 mmu.h and other headers from its source dir
-			SubDirHdrs $(HAIKU_TOP) src system boot platform bios_ia32 ;
-		}
 
 		DEFINES = $(defines) ;
 


### PR DESCRIPTION
This commit reverts the following Jamfiles to their versions from the official Haiku GitHub repository (main branch):
- src/system/boot/arch/x86/Jamfile
- src/system/Jamfile
- src/system/kernel/Jamfile
- src/system/kernel/lib/Jamfile

This is done to establish a baseline for diagnosing persistent build issues with the minimum-raw target. Previous modifications are undone by this action, and further targeted fixes may be necessary after re-evaluating the build output.