### PR TITLE
Fix: Attempt to resolve kernel_util.o and musl complex build errors

### DIFF
--- a/src/system/Jamfile
+++ b/src/system/Jamfile
@@ -1,7 +1,11 @@
 SubDir HAIKU_TOP src system ;
 
 SubInclude HAIKU_TOP src system boot ;
-SubInclude HAIKU_TOP src system kernel ;
+
+# Ensure kernel util rules are loaded before kernel main Jamfile, just in case.
+SubInclude HAIKU_TOP src system kernel util ;
+
+SubInclude HAIKU_TOP src system kernel ; # This already includes util again, but Jam handles duplicates.
 SubInclude HAIKU_TOP src system glue ;
 SubInclude HAIKU_TOP src system libroot ;
 SubInclude HAIKU_TOP src system libnetwork ;

--- a/src/system/kernel/lib/Jamfile
+++ b/src/system/kernel/lib/Jamfile
@@ -54,6 +54,12 @@ local muslSources =
 	rand_r.c
 	;
 
+local muslComplexSources =
+	ccosh.c
+	csinh.c
+;
+muslSources += $(muslComplexSources) ;
+
 SourceHdrs $(muslSources) :
 	[ FDirName $(posixSources) musl include ]
 	[ FDirName $(posixSources) musl internal ]
@@ -153,6 +159,7 @@ KernelMergeObject kernel_lib_posix.o :
 
 SEARCH on [ FGristFiles $(muslSources) ] += [ FDirName $(posixSources) musl misc ] ;
 SEARCH on [ FGristFiles $(muslSources) ] += [ FDirName $(posixSources) musl prng ] ;
+SEARCH on [ FGristFiles $(muslComplexSources) ] = [ FDirName $(posixSources) musl complex ] ;
 
 # misc
 


### PR DESCRIPTION
This commit includes two changes aimed at fixing the `minimum-raw` build:

1.  Re-applies the fix to `src/system/kernel/lib/Jamfile` to correctly include `ccosh.c` and `csinh.c` from `musl/complex` and provide the necessary `SEARCH` path. This addresses the "don't know how to make ...ccosh.c" errors.

2.  Adds a speculative fix to `src/system/Jamfile` to explicitly `SubInclude HAIKU_TOP src system kernel util ;` before including `src/system/kernel/Jamfile`. This is an attempt to ensure the rules from `src/system/kernel/util/Jamfile` (for `kernel_util.o`) are processed, even if the standard include from `src/system/kernel/Jamfile` might be failing in specific build configurations.