### PR TITLE
Fix: Include cstdio for printf in block_cache_private.h

### DIFF
--- a/src/system/kernel/cache/block_cache_private.h
+++ b/src/system/kernel/cache/block_cache_private.h
@@ -11,6 +11,7 @@
 
 #include <slab/Slab.h> // For object_cache typedef
 #include <fs_cache.h> // For transaction_notification_hook
+#include <cstdio> // For printf
 
 #include <block_cache.h> // Public API
 #include <condition_variable.h>


### PR DESCRIPTION
TRACE_ALWAYS macro uses printf when not in kernel mode, which requires the <cstdio> header for its declaration.

Attempted to configure and build, but encountered environment issues preventing full verification of the build process.