### PR TITLE
Fix kernel_util.o build error in Jamfile

### DIFF
--- a/src/system/kernel/Jamfile
+++ b/src/system/kernel/Jamfile
@@ -104,7 +104,7 @@ KernelLd kernel_$(TARGET_ARCH) :
 	kernel_messaging.o
 	kernel_posix.o
 	kernel_slab.o
-	kernel_util.o
+	<util>kernel_util.o
 	kernel_vm.o
 
 	kernel_arch_$(TARGET_KERNEL_ARCH).o


### PR DESCRIPTION
Corrected the reference to kernel_util.o in src/system/kernel/Jamfile to use the grist <util>kernel_util.o. This ensures that Jam correctly identifies kernel_util.o as a target defined in the src/system/kernel/util/Jamfile, resolving a "don't know how to make" error.

Investigation into other reported errors for ccosh.c and csinh.c did not reveal obvious misconfigurations in the directly related Jamfiles (src/system/kernel/lib/Jamfile and
src/system/libroot/posix/musl/complex/Jamfile). These issues may require further investigation into parent Jamfiles or build system internals.