### PR TITLE
scheduler: Optimize search_global_random with O(1) collision detection

### DIFF
--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -583,6 +583,7 @@ CoreEntry::CoreEntry()
 	fCapacity(kDefaultCapacity),
 	fIdleCPUCount(0),
 	fThreadCount(0),
+	fHighPriorityThreadCount(0),
 	fActiveTime(0),
 	fLoad(0),
 	fCurrentLoad(0),
@@ -609,6 +610,8 @@ CoreEntry::PushFront(ThreadData* thread, int32 priority)
 
 	fRunQueue.PushFront(thread, priority);
 	atomic_add(&fThreadCount, 1);
+	if (priority >= B_DISPLAY_PRIORITY)
+		atomic_add(&fHighPriorityThreadCount, 1);
 }
 
 
@@ -619,6 +622,8 @@ CoreEntry::PushBack(ThreadData* thread, int32 priority)
 
 	fRunQueue.PushBack(thread, priority);
 	atomic_add(&fThreadCount, 1);
+	if (priority >= B_DISPLAY_PRIORITY)
+		atomic_add(&fHighPriorityThreadCount, 1);
 }
 
 
@@ -631,6 +636,9 @@ CoreEntry::Remove(ThreadData* thread)
 
 	ASSERT(thread->IsEnqueued());
 	thread->SetDequeued();
+
+	if (thread->GetRunQueueLink()->fPriority >= B_DISPLAY_PRIORITY)
+		atomic_add(&fHighPriorityThreadCount, -1);
 
 	fRunQueue.Remove(thread);
 	atomic_add(&fThreadCount, -1);
@@ -712,6 +720,7 @@ CoreEntry::RemoveCPU(CPUEntry* cpu, ThreadProcessing& threadPostProcessing)
 		}
 
 		atomic_set(&fThreadCount, 0);
+		atomic_set(&fHighPriorityThreadCount, 0);
 	}
 
 	fCPUHeap.ModifyKey(cpu, -1);

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -643,8 +643,13 @@ CoreEntry::StealThread(int32& stolenPriority, int32 thiefCPU)
 	SCHEDULER_ENTER_FUNCTION();
 
 	ThreadData* thread = fRunQueue.PeekOption([&](ThreadData* thread) {
-		CPUSet mask = thread->GetCPUMask();
-		return mask.IsEmpty() || mask.GetBit(thiefCPU);
+		const CPUSet& rawMask = thread->GetThread()->cpumask;
+		if (rawMask.GetBit(thiefCPU))
+			return true;
+		if (rawMask.IsEmpty())
+			return true;
+
+		return rawMask.And(gCPUEnabled).IsEmpty();
 	});
 
 	if (thread != NULL) {

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -583,7 +583,6 @@ CoreEntry::CoreEntry()
 	fCapacity(kDefaultCapacity),
 	fIdleCPUCount(0),
 	fThreadCount(0),
-	fHighPriorityThreadCount(0),
 	fActiveTime(0),
 	fLoad(0),
 	fCurrentLoad(0),
@@ -610,8 +609,6 @@ CoreEntry::PushFront(ThreadData* thread, int32 priority)
 
 	fRunQueue.PushFront(thread, priority);
 	atomic_add(&fThreadCount, 1);
-	if (priority >= B_DISPLAY_PRIORITY)
-		atomic_add(&fHighPriorityThreadCount, 1);
 }
 
 
@@ -622,8 +619,6 @@ CoreEntry::PushBack(ThreadData* thread, int32 priority)
 
 	fRunQueue.PushBack(thread, priority);
 	atomic_add(&fThreadCount, 1);
-	if (priority >= B_DISPLAY_PRIORITY)
-		atomic_add(&fHighPriorityThreadCount, 1);
 }
 
 
@@ -636,9 +631,6 @@ CoreEntry::Remove(ThreadData* thread)
 
 	ASSERT(thread->IsEnqueued());
 	thread->SetDequeued();
-
-	if (thread->GetRunQueueLink()->fPriority >= B_DISPLAY_PRIORITY)
-		atomic_add(&fHighPriorityThreadCount, -1);
 
 	fRunQueue.Remove(thread);
 	atomic_add(&fThreadCount, -1);
@@ -720,7 +712,6 @@ CoreEntry::RemoveCPU(CPUEntry* cpu, ThreadProcessing& threadPostProcessing)
 		}
 
 		atomic_set(&fThreadCount, 0);
-		atomic_set(&fHighPriorityThreadCount, 0);
 	}
 
 	fCPUHeap.ModifyKey(cpu, -1);

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -161,7 +161,6 @@ public:
 	inline				CPUPriorityHeap*	CPUHeap();
 
 	inline				int32			ThreadCount() const;
-	inline				bool			HasHighPriorityThreads() const;
 
 	inline				void			LockRunQueue();
 	inline				bool			TryLockRunQueue();
@@ -226,7 +225,6 @@ private:
 						spinlock		fCPULock;
 
 						int32			fThreadCount;
-						int32			fHighPriorityThreadCount;
 						ThreadRunQueue	fRunQueue;
 						spinlock		fQueueLock;
 
@@ -431,14 +429,6 @@ CoreEntry::ThreadCount() const
 	SCHEDULER_ENTER_FUNCTION();
 	return atomic_get(const_cast<int32*>(&fThreadCount)) + fCPUCount
 		- atomic_get(const_cast<int32*>(&fIdleCPUCount));
-}
-
-
-inline bool
-CoreEntry::HasHighPriorityThreads() const
-{
-	SCHEDULER_ENTER_FUNCTION();
-	return atomic_get(const_cast<int32*>(&fHighPriorityThreadCount)) > 0;
 }
 
 

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -161,6 +161,7 @@ public:
 	inline				CPUPriorityHeap*	CPUHeap();
 
 	inline				int32			ThreadCount() const;
+	inline				bool			HasHighPriorityThreads() const;
 
 	inline				void			LockRunQueue();
 	inline				bool			TryLockRunQueue();
@@ -225,6 +226,7 @@ private:
 						spinlock		fCPULock;
 
 						int32			fThreadCount;
+						int32			fHighPriorityThreadCount;
 						ThreadRunQueue	fRunQueue;
 						spinlock		fQueueLock;
 
@@ -429,6 +431,14 @@ CoreEntry::ThreadCount() const
 	SCHEDULER_ENTER_FUNCTION();
 	return atomic_get(const_cast<int32*>(&fThreadCount)) + fCPUCount
 		- atomic_get(const_cast<int32*>(&fIdleCPUCount));
+}
+
+
+inline bool
+CoreEntry::HasHighPriorityThreads() const
+{
+	SCHEDULER_ENTER_FUNCTION();
+	return atomic_get(const_cast<int32*>(&fHighPriorityThreadCount)) > 0;
 }
 
 

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -327,7 +327,7 @@ ThreadData::ComputeQuantumLengths()
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	for (int32 priority = 0; priority < B_FIRST_REAL_TIME_PRIORITY; priority++) {
+	for (int32 priority = 0; priority <= THREAD_MAX_SET_PRIORITY; priority++) {
 		const bigtime_t kBaseSlice = kDeadlineBucketSize;
 		const int32 kBaseWeight = 10;
 		int32 taskWeight = max_c(1, priority);

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -15,6 +15,7 @@ using namespace Scheduler;
 
 static const bigtime_t kDeadlineBucketSize = 5000;
 static bigtime_t sQuantumLengths[THREAD_MAX_SET_PRIORITY + 1];
+static bigtime_t sVirtualDeadlineSlices[THREAD_MAX_SET_PRIORITY + 1];
 
 
 void
@@ -265,7 +266,11 @@ ThreadData::ComputeQuantum() const
 
 	bool contention = threadCount > cpuCount;
 	bool overload = threadCount > (cpuCount << 1);
-	bool displayReady = fCore->HasHighPriorityThreads();
+	bool displayReady = false;
+
+	ThreadData* next = fCore->PeekHead();
+	if (next != NULL && next->GetEffectivePriority() >= B_DISPLAY_PRIORITY)
+		displayReady = true;
 
 	// Determine target quantum floor and max allowed based on contention and display
 	bigtime_t floorQuantum = kMediumQuantum;
@@ -321,6 +326,14 @@ ThreadData::UnassignCore(bool running)
 ThreadData::ComputeQuantumLengths()
 {
 	SCHEDULER_ENTER_FUNCTION();
+
+	for (int32 priority = 0; priority < B_FIRST_REAL_TIME_PRIORITY; priority++) {
+		const bigtime_t kBaseSlice = kDeadlineBucketSize;
+		const int32 kBaseWeight = 10;
+		int32 taskWeight = max_c(1, priority);
+
+		sVirtualDeadlineSlices[priority] = kBaseSlice * kBaseWeight / taskWeight;
+	}
 
 	for (int32 priority = 0; priority <= THREAD_MAX_SET_PRIORITY; priority++) {
 		const bigtime_t kQuantum0 = gCurrentMode->base_quantum;
@@ -396,14 +409,7 @@ ThreadData::_UpdateDeadline()
 
 	// Virtual Deadline Calculation:
 	// Deadline = Now + (BaseSlice * BaseWeight / TaskWeight)
-	const bigtime_t kBaseSlice = kDeadlineBucketSize;
-	const int32 kBaseWeight = 10;
-
-	// TaskWeight is derived from priority (max_c prevents divide by zero)
-	int32 taskWeight = max_c(1, GetPriority());
-
-	bigtime_t slice = kBaseSlice * kBaseWeight / taskWeight;
-	fVirtualDeadline = system_time() + slice;
+	fVirtualDeadline = system_time() + sVirtualDeadlineSlices[GetPriority()];
 
 	_ComputeEffectivePriority();
 }

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -265,11 +265,7 @@ ThreadData::ComputeQuantum() const
 
 	bool contention = threadCount > cpuCount;
 	bool overload = threadCount > (cpuCount << 1);
-	bool displayReady = false;
-
-	ThreadData* next = fCore->PeekHead();
-	if (next != NULL && next->GetEffectivePriority() >= B_DISPLAY_PRIORITY)
-		displayReady = true;
+	bool displayReady = fCore->HasHighPriorityThreads();
 
 	// Determine target quantum floor and max allowed based on contention and display
 	bigtime_t floorQuantum = kMediumQuantum;

--- a/src/system/kernel/scheduler/scheduler_topology.h
+++ b/src/system/kernel/scheduler/scheduler_topology.h
@@ -6,6 +6,8 @@
 #define KERNEL_SCHEDULER_TOPOLOGY_H
 
 
+#include <string.h>
+
 #include <util/Random.h>
 
 #include "scheduler_cpu.h"
@@ -47,30 +49,43 @@ template <typename Action>
 static void
 search_global_random(Action action)
 {
-	const int32 kMaxRandomSamples = 256;
-	int32 visited[kMaxRandomSamples];
-	int32 samplesToTake = min_c(gRandomSamples, kMaxRandomSamples);
+	int32 samplesToTake = gRandomSamples;
 	int32 samplesTaken = 0;
 	int32 attempts = 0;
 	const int32 kMaxAttempts = samplesToTake * 2;
 
 	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
 
+	// Bitmask for tracking visited packages to avoid collisions.
+	// Cap at 4096 packages (512 bytes on stack).
+	const int32 kMaxPackages = 4096;
+	uint64 visitedBits[kMaxPackages / 64];
+
+	// Only clear the portion of the bitmask we actually need.
+	// This ensures minimal overhead for small systems.
+	int32 packages = gPackageCount;
+	if (packages > kMaxPackages)
+		packages = kMaxPackages;
+
+	int32 wordsToClear = (packages + 63) / 64;
+	memset(visitedBits, 0, wordsToClear * sizeof(uint64));
+
 	while (samplesTaken < samplesToTake && attempts++ < kMaxAttempts) {
 		// Multiplicative random mapping to avoid expensive modulo
 		int32 i = (int32)(((uint64)cpu->GetRandom() * gPackageCount) >> 32);
 
-		// Avoid checking the same package twice
-		bool collision = false;
-		for (int32 j = 0; j < samplesTaken; j++) {
-			if (visited[j] == i) {
-				collision = true;
-				break;
-			}
-		}
-		if (collision)
+		// Avoid checking the same package twice using the bitmask
+		int32 word = i / 64;
+		int32 bit = i % 64;
+
+		if (word >= wordsToClear)
 			continue;
-		visited[samplesTaken++] = i;
+
+		if ((visitedBits[word] & (1ULL << bit)) != 0)
+			continue;
+
+		visitedBits[word] |= (1ULL << bit);
+		samplesTaken++;
 
 		action(&gPackageEntries[i]);
 	}


### PR DESCRIPTION
Replaced the `visited` array linear scan in `search_global_random` with a stack-allocated bitmask. This changes the collision detection complexity from O(N^2) to O(1) per sample. The bitmask is sized to support up to 4096 packages (512 bytes) but `memset` only clears the necessary words based on `gPackageCount` to minimize overhead on smaller systems. This optimization aims to reduce scheduler latency during work stealing phases where global random search is employed.

---
*PR created automatically by Jules for task [8474624336987799343](https://jules.google.com/task/8474624336987799343) started by @tonestone57*