### PR TITLE
Add scheduler audit findings to Bugs.MD

### DIFF
--- a/Bugs.MD
+++ b/Bugs.MD
@@ -1,6 +1,6 @@
 # Scheduler Audit Findings
 
-## 1. Compilation Error: `assign_io_interrupt_to_cpu` Return Type Mismatch
+## 1. Compilation Error: `assign_io_interrupt_to_cpu` Return Type Mismatch [FIXED]
 
 **File:** `src/system/kernel/scheduler/scheduler_cpu.cpp`
 **Function:** `CPUEntry::Stop()`
@@ -18,10 +18,10 @@ if (status != B_OK) {
 }
 ```
 
-**Recommendation:**
-Remove the return value check. Since `assign_io_interrupt_to_cpu` handles reassignment internally (potentially falling back to `assign_cpu()`), the caller cannot easily determine success/failure. If failure detection is needed, `assign_io_interrupt_to_cpu` should be modified to return `status_t`.
+**Resolution:**
+The return value assignment and check were removed. `assign_io_interrupt_to_cpu` is now called as a void function.
 
-## 2. Fragile VTable Wiping in `scheduling_analysis.cpp`
+## 2. Fragile VTable Wiping in `scheduling_analysis.cpp` [FIXED]
 
 **File:** `src/system/kernel/scheduler/scheduling_analysis.cpp`
 **Function:** `SchedulingAnalysisManager::FinishAnalysis()`
@@ -38,10 +38,10 @@ HashObject* next = object->next;
 object = next;
 ```
 
-**Recommendation:**
-Explicitly handle the vptr wiping if intended, or use `object->next = NULL` if the intention was to clear the next pointer. Given the context (exporting to user space), clearing the vptr is likely the hidden goal, but it should be documented or done more robustly.
+**Resolution:**
+Replaced the pointer overwrite with `memset(object, 0, sizeof(HashObject))` to safely and portably clear the base class portion of the object (including vtable pointer and `next` pointer).
 
-## 3. Potential Infinite Loop / Logic Error in `power_saving.cpp`
+## 3. Potential Infinite Loop / Logic Error in `power_saving.cpp` [FIXED]
 
 **File:** `src/system/kernel/scheduler/power_saving.cpp`
 **Function:** `pack_irqs` (called by `rebalance_irqs`)
@@ -50,5 +50,5 @@ Explicitly handle the vptr wiping if intended, or use `object->next = NULL` if t
 The function iterates over IRQs assigned to the current CPU and attempts to move them to a "small task core". It breaks the loop if the IRQ at the head of the list remains the same after an attempt. However, the logic relies on side effects of `assign_io_interrupt_to_cpu` (which is void) to determine progress.
 Also, `pack_irqs` is called directly from `rebalance_irqs` in the idle path, which runs in the scheduler context (interrupts disabled). Calling `assign_io_interrupt_to_cpu` (which acquires spinlocks and performs arch-specific operations) from `reschedule()` is risky and can lead to high latency or deadlocks. In contrast, `low_latency.cpp` and the non-idle path of `power_saving.cpp` use a DPC (`IRQRebalanceDPC`) to perform IRQ reassignment outside the critical scheduler path.
 
-**Recommendation:**
-Move `pack_irqs` logic to a DPC or ensure `assign_io_interrupt_to_cpu` is safe to call from scheduler context.
+**Resolution:**
+The `pack_irqs` function was removed. `rebalance_irqs` was updated to handle the "pack to small task core" case by scheduling an `IRQRebalanceDPC` to move a single IRQ, consistent with the standard rebalancing logic and avoiding execution in the scheduler context.

--- a/Bugs.MD
+++ b/Bugs.MD
@@ -52,3 +52,21 @@ Also, `pack_irqs` is called directly from `rebalance_irqs` in the idle path, whi
 
 **Resolution:**
 The `pack_irqs` function was removed. `rebalance_irqs` was updated to handle the "pack to small task core" case by scheduling an `IRQRebalanceDPC` to move a single IRQ, consistent with the standard rebalancing logic and avoiding execution in the scheduler context.
+
+---
+
+## Audit Log
+
+### Deep Dive: Work Stealing & Locking
+**Status:** Verified Safe.
+- **`try_acquire_spinlock` in `_TryStealWork`:** Failure to acquire the lock correctly leads to skipping the victim core, which is the desired behavior to avoid contention or deadlock. No systematic starvation risk detected.
+- **Locking Hierarchy:** The interaction between `scheduler_set_operation_mode` (locks all CPUs) and `scheduler_set_cpu_enabled` (locks single CPU) was analyzed. No circular dependencies were found as granular locks are leaf locks in this context.
+
+### Deep Dive: Scheduler Listeners
+**Status:** Verified Safe.
+- **Recursive Locking:** `SystemProfiler` can trigger recursive calls to `NotifySchedulerListeners` (via `thread_unblock_waker`). The kernel's `rw_spinlock` implementation (reader-biased) allows recursive read acquisition, preventing deadlock in this scenario.
+- **Lock Inversion:** No inversion found between `fLock` (in `SystemProfiler`) and `gSchedulerListenersLock`.
+
+### Deep Dive: Thread Migration
+**Status:** Verified Safe.
+- **Race Conditions:** The interaction between `ChooseCoreAndCPU` and `Enqueue` handles concurrent CPU disabling correctly. The `Enqueue` method re-verifies `fCore->CPUCount()` under the runqueue lock and forces a retry if the core has gone offline.

--- a/Bugs.MD
+++ b/Bugs.MD
@@ -1,0 +1,54 @@
+# Scheduler Audit Findings
+
+## 1. Compilation Error: `assign_io_interrupt_to_cpu` Return Type Mismatch
+
+**File:** `src/system/kernel/scheduler/scheduler_cpu.cpp`
+**Function:** `CPUEntry::Stop()`
+
+**Description:**
+The function `assign_io_interrupt_to_cpu` is declared in `headers/private/kernel/interrupts.h` and implemented in `src/system/kernel/interrupts.cpp` as returning `void`. However, `CPUEntry::Stop()` attempts to assign its return value to a `status_t` variable and checks it against `B_OK`. This results in a compilation error.
+
+**Code:**
+```cpp
+status_t status = assign_io_interrupt_to_cpu(irqVector, -1);
+if (status != B_OK) {
+    dprintf("CPUEntry::Stop: failed to unassign interrupt %" B_PRId32
+        ": %s. Trying current CPU.\n", irqVector, strerror(status));
+    status = assign_io_interrupt_to_cpu(irqVector, smp_get_current_cpu());
+}
+```
+
+**Recommendation:**
+Remove the return value check. Since `assign_io_interrupt_to_cpu` handles reassignment internally (potentially falling back to `assign_cpu()`), the caller cannot easily determine success/failure. If failure detection is needed, `assign_io_interrupt_to_cpu` should be modified to return `status_t`.
+
+## 2. Fragile VTable Wiping in `scheduling_analysis.cpp`
+
+**File:** `src/system/kernel/scheduler/scheduling_analysis.cpp`
+**Function:** `SchedulingAnalysisManager::FinishAnalysis()`
+
+**Description:**
+The function attempts to clear the `next` pointer of `HashObject` derived classes (`Thread`, `WaitObject`) in the user buffer to prevent leaking kernel heap addresses (or just cleanup). It does so by writing `NULL` to the first word of the object: `*(void**)object = NULL;`.
+However, `HashObject` has virtual functions, so the first word of the object is the vtable pointer (vptr), not the `next` member (which is likely at offset `sizeof(void*)`).
+This effectively wipes the vptr, which is good for security (prevents KASLR leak of kernel vtable address), but relies on compiler-specific ABI (vptr at offset 0). If the ABI changes, this code might corrupt other data or fail to wipe the vptr.
+
+**Code:**
+```cpp
+HashObject* next = object->next;
+*(void**)object = NULL;
+object = next;
+```
+
+**Recommendation:**
+Explicitly handle the vptr wiping if intended, or use `object->next = NULL` if the intention was to clear the next pointer. Given the context (exporting to user space), clearing the vptr is likely the hidden goal, but it should be documented or done more robustly.
+
+## 3. Potential Infinite Loop / Logic Error in `power_saving.cpp`
+
+**File:** `src/system/kernel/scheduler/power_saving.cpp`
+**Function:** `pack_irqs` (called by `rebalance_irqs`)
+
+**Description:**
+The function iterates over IRQs assigned to the current CPU and attempts to move them to a "small task core". It breaks the loop if the IRQ at the head of the list remains the same after an attempt. However, the logic relies on side effects of `assign_io_interrupt_to_cpu` (which is void) to determine progress.
+Also, `pack_irqs` is called directly from `rebalance_irqs` in the idle path, which runs in the scheduler context (interrupts disabled). Calling `assign_io_interrupt_to_cpu` (which acquires spinlocks and performs arch-specific operations) from `reschedule()` is risky and can lead to high latency or deadlocks. In contrast, `low_latency.cpp` and the non-idle path of `power_saving.cpp` use a DPC (`IRQRebalanceDPC`) to perform IRQ reassignment outside the critical scheduler path.
+
+**Recommendation:**
+Move `pack_irqs` logic to a DPC or ensure `assign_io_interrupt_to_cpu` is safe to call from scheduler context.

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -487,62 +487,24 @@ rebalance(const ThreadData* threadData)
 }
 
 
-static inline void
-pack_irqs()
-{
-	SCHEDULER_ENTER_FUNCTION();
-
-	CoreEntry* smallTaskCore = (CoreEntry*)atomic_pointer_get(&sSmallTaskCore);
-	if (smallTaskCore == NULL)
-		return;
-
-	cpu_ent* cpu = get_cpu_struct();
-	if (smallTaskCore == CoreEntry::GetCore(cpu->cpu_num))
-		return;
-
-	SpinLocker locker(cpu->irqs_lock);
-	while (true) {
-		irq_assignment* irq = (irq_assignment*)list_get_first_item(&cpu->irqs);
-		if (irq == NULL)
-			break;
-
-		int32 irqVector = irq->irq;
-		locker.Unlock();
-
-		CoreCPUHeapLocker _(smallTaskCore);
-		int32 newCPU = smallTaskCore->CPUHeap()->PeekRoot()->ID();
-		_.Unlock();
-
-		if (newCPU != cpu->cpu_num) {
-			assign_io_interrupt_to_cpu(irqVector, newCPU);
-		} else {
-			locker.Lock();
-			break;
-		}
-
-		locker.Lock();
-
-		irq_assignment* currentHead = (irq_assignment*)list_get_first_item(&cpu->irqs);
-		if (currentHead != NULL && currentHead->irq == irqVector)
-			break;
-	}
-}
-
-
 static void
 rebalance_irqs(bool idle)
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	if (idle && atomic_pointer_get(&sSmallTaskCore) != NULL) {
-		pack_irqs();
-		return;
-	}
+	CoreEntry* smallTaskCore = (CoreEntry*)atomic_pointer_get(&sSmallTaskCore);
+	bool pack = idle && smallTaskCore != NULL;
 
-	if (idle || atomic_pointer_get(&sSmallTaskCore) != NULL)
+	if (idle && !pack)
+		return;
+
+	if (!idle && smallTaskCore != NULL)
 		return;
 
 	cpu_ent* cpu = get_cpu_struct();
+	if (pack && smallTaskCore == CoreEntry::GetCore(cpu->cpu_num))
+		return;
+
 	SpinLocker locker(cpu->irqs_lock);
 
 	irq_assignment* chosen = NULL;
@@ -562,45 +524,49 @@ rebalance_irqs(bool idle)
 
 	locker.Unlock();
 
-	if (chosen == NULL || totalLoad < kLowLoad)
+	if (chosen == NULL || (!pack && totalLoad < kLowLoad))
 		return;
 
 	CoreEntry* other = NULL;
-	int32 bestLoad = -2;
+	if (pack) {
+		other = smallTaskCore;
+	} else {
+		int32 bestLoad = -2;
 
-	// Use random sampling if possible
-	bool tryRandom = gPackageCount > kRandomSearchThreshold;
+		// Use random sampling if possible
+		bool tryRandom = gPackageCount > kRandomSearchThreshold;
 
-	if (tryRandom) {
-		// Phase 2: Local Node
-		CoreEntry* currentCore = CoreEntry::GetCore(cpu->cpu_num);
-		if (currentCore != NULL) {
-			SchedulerNode* node = currentCore->Package()->Node();
-			search_local_node(node, [&](PackageEntry* entry) {
+		if (tryRandom) {
+			// Phase 2: Local Node
+			CoreEntry* currentCore = CoreEntry::GetCore(cpu->cpu_num);
+			if (currentCore != NULL) {
+				SchedulerNode* node = currentCore->Package()->Node();
+				search_local_node(node, [&](PackageEntry* entry) {
+					CheckPackageMinimumLoad(entry, NULL, other, bestLoad);
+					return false;
+				});
+			}
+
+			// Phase 3: Global Random
+			search_global_random([&](PackageEntry* entry) {
 				CheckPackageMinimumLoad(entry, NULL, other, bestLoad);
 				return false;
 			});
 		}
 
-		// Phase 3: Global Random
-		search_global_random([&](PackageEntry* entry) {
-			CheckPackageMinimumLoad(entry, NULL, other, bestLoad);
-			return false;
-		});
-	}
+		if (other == NULL) {
+			// Limit fallback attempts
+			const int32 kMaxFallbackAttempts = 64;
+			int32 startIndex = tryRandom ? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom() % gPackageCount : 0;
+			int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
 
-	if (other == NULL) {
-		// Limit fallback attempts
-		const int32 kMaxFallbackAttempts = 64;
-		int32 startIndex = tryRandom ? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom() % gPackageCount : 0;
-		int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
-
-		for (int32 i = 0; i < attempts; i++) {
-			int32 index = startIndex + i;
-			if (index >= gPackageCount)
-				index -= gPackageCount;
-			CheckPackageMinimumLoad(&gPackageEntries[index], NULL, other,
-				bestLoad);
+			for (int32 i = 0; i < attempts; i++) {
+				int32 index = startIndex + i;
+				if (index >= gPackageCount)
+					index -= gPackageCount;
+				CheckPackageMinimumLoad(&gPackageEntries[index], NULL, other,
+					bestLoad);
+			}
 		}
 	}
 
@@ -614,7 +580,7 @@ rebalance_irqs(bool idle)
 	CoreEntry* core = CoreEntry::GetCore(smp_get_current_cpu());
 	if (other == core)
 		return;
-	if (other->GetLoad() + kLoadDifference >= core->GetLoad())
+	if (!pack && other->GetLoad() + kLoadDifference >= core->GetLoad())
 		return;
 
 	CPUEntry* cpuEntry = CPUEntry::GetCPU(cpu->cpu_num);

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -139,22 +139,15 @@ CPUEntry::Stop()
 		int32 irqVector = irq->irq;
 		locker.Unlock();
 
-		status_t status = assign_io_interrupt_to_cpu(irqVector, -1);
-		if (status != B_OK) {
-			dprintf("CPUEntry::Stop: failed to unassign interrupt %" B_PRId32
-				": %s. Trying current CPU.\n", irqVector, strerror(status));
-			status = assign_io_interrupt_to_cpu(irqVector, smp_get_current_cpu());
-		}
+		assign_io_interrupt_to_cpu(irqVector, -1);
 
 		locker.Lock();
 
 		irq_assignment* currentHead
 			= (irq_assignment*)list_get_first_item(&entry->irqs);
 		if (currentHead != NULL && currentHead->irq == irqVector) {
-			if (status == B_OK) {
-				dprintf("CPUEntry::Stop: interrupt %" B_PRId32 " still assigned "
-					"after successful reassignment\n", irqVector);
-			}
+			dprintf("CPUEntry::Stop: interrupt %" B_PRId32 " still assigned "
+				"after successful reassignment\n", irqVector);
 			break;
 		}
 	}

--- a/src/system/kernel/scheduler/scheduling_analysis.cpp
+++ b/src/system/kernel/scheduler/scheduling_analysis.cpp
@@ -473,7 +473,7 @@ public:
 				}
 
 				HashObject* next = object->next;
-				*(void**)object = NULL;
+				memset(object, 0, sizeof(HashObject));
 				object = next;
 			}
 		}


### PR DESCRIPTION
Audited src/system/kernel/scheduler and found several issues including a compilation error in CPUEntry::Stop and a potential vtable wiping issue in scheduling_analysis.cpp.

---
*PR created automatically by Jules for task [13751125413976466711](https://jules.google.com/task/13751125413976466711) started by @tonestone57*