### PR TITLE
scheduler: Fix compilation error due to removed gCurrentMode variable

### DIFF
--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -573,7 +573,7 @@ reschedule(int32 nextState)
 		if (!nextThreadData->IsIdle())
 			nextThreadData->Continues();
 		else
-			gCurrentMode->rebalance_irqs(true);
+			Scheduler::RebalanceIRQs(true);
 		nextThreadData->StartQuantum();
 
 		modeLocker.Unlock();

--- a/src/system/kernel/scheduler/scheduler_assessment.md
+++ b/src/system/kernel/scheduler/scheduler_assessment.md
@@ -117,6 +117,7 @@ Further auditing revealed specific fixes implemented directly within the schedul
 *   **Hot-Unplug Safety:** `CPUEntry::UpdatePriority` (`src/system/kernel/scheduler/scheduler_cpu.cpp`) now explicitly handles updates to `B_IDLE_PRIORITY` even if the CPU is marked as disabled. This prevents kernel panics during CPU hot-unplug operations when a core is being taken offline.
 *   **Locking Correctness:** In `scheduler_set_cpu_enabled`, the methods `AddCPU` and `RemoveCPU` (in `CoreEntry`) are now called without holding `fCPULock`. This logic relies on the caller (`scheduler_set_cpu_enabled`) holding the global `InterruptsBigSchedulerLocker` for serialization, avoiding a potential deadlock or double-lock scenario.
 *   **Profiler Safety:** `Profiler::EnterFunction` (`src/system/kernel/scheduler/scheduler_profiler.cpp`) now enforces strict bounds checks on `fFunctionStackPointers`. This prevents buffer overflows and kernel crashes if the function call stack depth exceeds the profiler's pre-allocated storage.
+*   **Refactoring Correctness:** Fixed an issue in `scheduler.cpp` where the idle thread path incorrectly attempted to directly access `gCurrentMode` (which was removed/refactored into the static `Scheduler::sCurrentMode`). It now safely calls `Scheduler::RebalanceIRQs(true)`.
 
 ## 11. Potential Issues & Future Risks
 

--- a/src/system/kernel/scheduler/scheduler_audit_summary.md
+++ b/src/system/kernel/scheduler/scheduler_audit_summary.md
@@ -40,6 +40,10 @@ A comprehensive code audit of the `src/system/kernel/scheduler` subsystem was pe
     *   Limited fallback scans in `choose_core`, `rebalance`, and `rebalance_irqs` to 64 attempts (randomized start).
     *   Updated `search_local_node` and `search_global_random` to use per-CPU RNG and optimized collision detection.
 
+### 9. Static Mode Encapsulation
+*   **Issue:** Global accesses to the scheduler mode configuration (`gCurrentMode`) within `scheduler.cpp` bypassed the `Scheduler` encapsulation and produced compilation errors as `gCurrentMode` was refactored and localized.
+*   **Fix:** Updated the idle thread IRQ rebalancing path to correctly call `Scheduler::RebalanceIRQs(true)` directly, rather than accessing a deleted global variable, restoring proper compilation and ensuring mode isolation.
+
 ## Pending Recommendations
 
 (None)


### PR DESCRIPTION
scheduler: Fix compilation error due to removed gCurrentMode variable

The `gCurrentMode` variable was removed from the scheduler, but `scheduler.cpp` still referenced it in the idle thread rescheduling path.
Updated to use `Scheduler::RebalanceIRQs(true)` directly, which maps to `sCurrentMode->rebalance_irqs(true)` correctly within `scheduler_common.h`.

---
*PR created automatically by Jules for task [7708962225084777409](https://jules.google.com/task/7708962225084777409) started by @tonestone57*