### PR TITLE
scheduler: Upgrade Per-CPU RNG seeding with 64-bit splitmix logic

### DIFF
--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -106,8 +106,10 @@ CPUEntry::Init(int32 id, CoreEntry* core)
 	fCPUNumber = id;
 	fCore = core;
 	// Mix id into high bits to avoid correlation if system_time is similar
+	// Step 1: Initial entropy mix
 	uint64 seed = system_time() ^ ((uint64)id << 16) ^ ((uint64)id * 0xBF58476D1CE4E5B9ULL);
-	seed = (seed ^ (seed >> 30)) * 0xBF58476D1CE4E5B9ULL;
+	// Step 2: Final mixing (using a different constant)
+	seed = (seed ^ (seed >> 30)) * 0x94D049BB133111EBULL;
 	uint32 finalSeed = (uint32)(seed ^ (seed >> 32));
 	fRandomState = finalSeed ? finalSeed : 1;
 }

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -93,7 +93,7 @@ CPUEntry::CPUEntry()
 	fMeasureActiveTime(0),
 	fMeasureTime(0),
 	fUpdateLoadEvent(false),
-	fRandomState(0x12345678)
+	fRandomState(1)
 {
 	B_INITIALIZE_RW_SPINLOCK(&fSchedulerModeLock);
 	B_INITIALIZE_SPINLOCK(&fQueueLock);
@@ -106,9 +106,10 @@ CPUEntry::Init(int32 id, CoreEntry* core)
 	fCPUNumber = id;
 	fCore = core;
 	// Mix id into high bits to avoid correlation if system_time is similar
-	fRandomState = (uint32)system_time() ^ (id << 16) ^ (id * 31337) ^ 1;
-	if (fRandomState == 0)
-		fRandomState = 0x12345678;
+	uint64 seed = system_time() ^ ((uint64)id << 16) ^ ((uint64)id * 0xBF58476D1CE4E5B9ULL);
+	seed = (seed ^ (seed >> 30)) * 0xBF58476D1CE4E5B9ULL;
+	uint32 finalSeed = (uint32)(seed ^ (seed >> 32));
+	fRandomState = finalSeed ? finalSeed : 1;
 }
 
 


### PR DESCRIPTION
Upgraded the Per-CPU RNG initialization logic to compute a 64-bit seed (as requested), but folded it safely into the existing 32-bit state (`fRandomState`) to avoid 64-bit operational overhead on 32-bit architectures during hot-path RNG sequence generation (`CPUEntry::GetRandom()`).

---
*PR created automatically by Jules for task [6274719604125738293](https://jules.google.com/task/6274719604125738293) started by @tonestone57*