### PR TITLE
scheduler: fix various bugs and regressions

### DIFF
--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -237,7 +237,7 @@ RUN_QUEUE_CLASS_NAME::ConstIterator::_FindNextPriority()
 
 	const uint32* bitmap = fList->GetBitmap();
 
-	int i = fPriority / 32;
+	int i = (fPriority > 0 ? fPriority - 1 : 0) / 32;
 	uint32 val = bitmap[i];
 
 	// Mask out higher priorities (bits >= current bit index) in current word

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -102,7 +102,7 @@ check_package_small_task(PackageEntry* entry, CoreEntry*& core, int32& bestLoad)
 
 
 static CoreEntry*
-choose_small_task_core(int32 nodeID)
+choose_small_task_core()
 {
 	SCHEDULER_ENTER_FUNCTION();
 
@@ -133,9 +133,10 @@ choose_small_task_core(int32 nodeID)
 	}
 
 	if (core == NULL)
-		return sSmallTaskCore != NULL ? (CoreEntry*)atomic_pointer_get(&sSmallTaskCore[nodeID]) : NULL;
+		return NULL;
 
 	if (sSmallTaskCore != NULL) {
+		int32 nodeID = core->Package()->Node()->ID();
 		CoreEntry* smallTaskCore
 			= (CoreEntry*)atomic_pointer_test_and_set(&sSmallTaskCore[nodeID], core,
 				(CoreEntry*)NULL);
@@ -421,7 +422,7 @@ rebalance(const ThreadData* threadData)
 		int32 nodeID = core->Package()->Node()->ID();
 		if (sSmallTaskCore != NULL && atomic_pointer_get(&sSmallTaskCore[nodeID]) == core) {
 			atomic_pointer_set(&sSmallTaskCore[nodeID], (CoreEntry*)NULL);
-			CoreEntry* smallTaskCore = choose_small_task_core(nodeID);
+			CoreEntry* smallTaskCore = choose_small_task_core();
 
 			if (threadLoad > coreLoad / 3 || smallTaskCore == NULL
 					|| (useMask && !smallTaskCore->CPUMask().Matches(mask))) {
@@ -491,7 +492,7 @@ rebalance(const ThreadData* threadData)
 		return core;
 
 	int32 nodeID = core->Package()->Node()->ID();
-	CoreEntry* smallTaskCore = choose_small_task_core(nodeID);
+	CoreEntry* smallTaskCore = choose_small_task_core();
 	if (smallTaskCore == NULL || (useMask && !smallTaskCore->CPUMask().Matches(mask)))
 		return core;
 	return smallTaskCore->GetLoad() + threadLoad < kHighLoad
@@ -569,7 +570,7 @@ rebalance_irqs(bool idle)
 
 		if (tryRandom) {
 			// Phase 2: Local Node
-			CoreEntry* currentCore = CoreEntry::GetCore(cpu->cpu_num);
+			currentCore = CoreEntry::GetCore(cpu->cpu_num);
 			if (currentCore != NULL) {
 				SchedulerNode* node = currentCore->Package()->Node();
 				search_local_node(node, [&](PackageEntry* entry) {

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -704,6 +704,7 @@ scheduler_set_cpu_enabled(int32 cpuID, bool enabled)
 		{
 			CoreCPUHeapLocker heapLocker(core);
 			cpu->Start();
+			core->AddCPU(cpu);
 		}
 		gCPU[cpuID].disabled = false;
 		gCPUEnabled.SetBitAtomic(cpuID);
@@ -798,6 +799,11 @@ build_topology_mappings(int32& cpuCount, int32& coreCount, int32& packageCount,
 	int32& nodeCount)
 {
 	cpuCount = smp_get_num_cpus();
+
+	delete[] sCPUToCore;
+	delete[] sCPUToCluster;
+	delete[] sPackageToNode;
+	delete[] sCPUToPackage;
 
 	sCPUToCore = new(std::nothrow) int32[cpuCount];
 	sCPUToCluster = new(std::nothrow) int32[cpuCount];

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -122,7 +122,6 @@ CPUEntry::Start()
 	fLoad = 0;
 	fMeasureTime = system_time();
 	fMeasureActiveTime = 0;
-	fCore->AddCPU(this);
 }
 
 
@@ -695,7 +694,7 @@ CoreEntry::StealThread(int32& stolenPriority, int32 thiefCPU)
 		if (rawMask.IsEmpty())
 			return true;
 
-		return rawMask.And(gCPUEnabled).IsEmpty();
+		return false;
 	});
 
 	if (thread != NULL) {
@@ -736,7 +735,8 @@ CoreEntry::RemoveCPU(CPUEntry* cpu, ThreadProcessing& threadPostProcessing)
 	ASSERT(fCPUCount > 0);
 	ASSERT(atomic_get(&fIdleCPUCount) > 0);
 
-	atomic_add(&fIdleCPUCount, -1);
+	if (fCPUHeap.GetKey(cpu) == B_IDLE_PRIORITY)
+		atomic_add(&fIdleCPUCount, -1);
 	fCPUSet.ClearBitAtomic(cpu->ID());
 	if (atomic_add(&fCPUCount, -1) == 1) {
 		// unassign threads

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -719,8 +719,8 @@ PackageEntry::GetLeastIdlePackage()
 		const int kMaxAttempts = 4 + (31 - __builtin_clz(gPackageCount));
 
 		while (attempts++ < kMaxAttempts) {
-			int32 i = CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom()
-				% gPackageCount;
+			int32 i = (int32)(((uint64)CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom()
+				* gPackageCount) >> 32);
 			PackageEntry* current = &gPackageEntries[i];
 			int32 currentIdleCoreCount
 				= atomic_get((int32*)&current->fIdleCoreCount);
@@ -739,7 +739,8 @@ PackageEntry::GetLeastIdlePackage()
 	// Fallback to linear scan (limit attempts)
 	const int32 kMaxFallbackAttempts = 64;
 	int32 startIndex = (gPackageCount > kRandomSearchThreshold)
-		? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom() % gPackageCount
+		? (int32)(((uint64)CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom()
+			* gPackageCount) >> 32)
 		: 0;
 	int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
 


### PR DESCRIPTION
This submission resolves a sequence of 8 bugs within the kernel scheduler, encompassing issues from logical errors like variable shadowing and off-by-one errors to memory leaks and invalid state transitions during CPU hotplugging.

Key Fixes Include:
- Addressed a missing argument (`nodeID`) in `choose_small_task_core()` call by properly identifying the `nodeID` of the previous core.
- Corrected logic in `ConstIterator::_FindNextPriority()` to properly transition priority word boundaries.
- Repaired an underflow risk with `fIdleCPUCount` decrementing in `CoreEntry::RemoveCPU()`.
- Addressed a potential double-insertion bug for `CPUEntry::Start()` and `scheduler_set_cpu_enabled()`.
- Exchanged expensive modulo math with performant multiplicative mapping in `PackageEntry::GetLeastIdlePackage()`.
- Added required array deletion to fix `sCPUToCluster` leak when re-building topology.
- Closed an overly-permissive edge case regarding thread affinity stealing.
- Restored expected `rebalance_irqs()` function scope logic by eliminating local shadowed variables.

---
*PR created automatically by Jules for task [7427083108428570560](https://jules.google.com/task/7427083108428570560) started by @tonestone57*