### PR TITLE
Fix scheduler concurrency, sampling, and load accounting bugs

### DIFF
--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -174,6 +174,9 @@ public:
 	inline				void			LockCPUHeap();
 	inline				void			UnlockCPUHeap();
 
+	inline				void			LockCPU();
+	inline				void			UnlockCPU();
+
 	inline				CPUPriorityHeap*	CPUHeap();
 
 	inline				int32			ThreadCount() const;
@@ -444,6 +447,22 @@ CoreEntry::UnlockCPUHeap()
 }
 
 
+inline void
+CoreEntry::LockCPU()
+{
+	SCHEDULER_ENTER_FUNCTION();
+	acquire_spinlock(&fCPULock);
+}
+
+
+inline void
+CoreEntry::UnlockCPU()
+{
+	SCHEDULER_ENTER_FUNCTION();
+	release_spinlock(&fCPULock);
+}
+
+
 inline CPUPriorityHeap*
 CoreEntry::CPUHeap()
 {
@@ -603,8 +622,9 @@ PackageEntry::CoreWakesUp(CoreEntry* core)
 	atomic_add(&fIdleCoreCount, -1);
 	int32 oldMask = atomic_and((int32*)&fIdleCoreMask, ~(1U << core->PackageIndex()));
 
-	if ((oldMask & ~(1U << core->PackageIndex())) == 0) {
-		// package wakes up (last core)
+	int32 expectedMask = atomic_get((int32*)&fEnabledCoreMask);
+	if (oldMask == expectedMask) {
+		// package wakes up (first core)
 		fNode->PackageWakesUp(this);
 	}
 }

--- a/src/system/kernel/scheduler/scheduler_load.cpp
+++ b/src/system/kernel/scheduler/scheduler_load.cpp
@@ -38,8 +38,6 @@ _LoadavgUpdate(void *data, int iteration)
 	uint64 threadCount = 0;
 	for (int i = 0; i < gCoreCount; i++)
 		threadCount += gCoreEntries[i].ThreadCount();
-	for (int i = 0; i < smp_get_num_cpus(); i++)
-		threadCount += gCPUEntries[i].ThreadCount();
 
 	InterruptsSpinLocker locker(sLoadAvgLock);
 	for (int i = 0; i < 3; i++) {

--- a/src/system/kernel/scheduler/scheduler_locking.h
+++ b/src/system/kernel/scheduler/scheduler_locking.h
@@ -78,6 +78,23 @@ public:
 
 typedef AutoLocker<CoreEntry, CoreCPUHeapLocking> CoreCPUHeapLocker;
 
+
+class CoreCPULocking {
+public:
+	inline bool Lock(CoreEntry* core)
+	{
+		core->LockCPU();
+		return true;
+	}
+
+	inline void Unlock(CoreEntry* core)
+	{
+		core->UnlockCPU();
+	}
+};
+
+typedef AutoLocker<CoreEntry, CoreCPULocking> CoreCPULocker;
+
 class SchedulerModeLocking {
 public:
 	bool Lock(int* /* lockable */)

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -478,6 +478,7 @@ ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption)
 	}
 
 	if (!pinned) {
+		CoreCPULocker cpuLocker(fCore);
 		CoreRunQueueLocker locker(fCore);
 
 		// Check if the Core is still active under the lock

--- a/src/system/kernel/scheduler/scheduler_topology.h
+++ b/src/system/kernel/scheduler/scheduler_topology.h
@@ -81,9 +81,12 @@ search_global_random(Action action)
 			if ((visitedBits[word] & (1ULL << bit)) != 0)
 				continue;
 			visitedBits[word] |= (1ULL << bit);
+			samplesTaken++;
 		}
+		// Note: if i >= kStackBitmaskSize, samplesTaken is NOT incremented
+		// so un-deduplicated samples don't count towards the budget.
+		// The loop is strictly bounded by attempts < kMaxAttempts, preventing runaway.
 
-		samplesTaken++;
 		if (action(&gPackageEntries[i]))
 			break;
 	}


### PR DESCRIPTION
Fixes 4 issues in the Haiku kernel scheduler:
- search_global_random bitmask collision skips indices >= 1024
- ThreadData::Enqueue() race on fCore->CPUCount() check
- _LoadavgUpdate double-counts threads
- PackageEntry::CoreWakesUp wrong bit test for "last core" transition

---
*PR created automatically by Jules for task [5234123482365582455](https://jules.google.com/task/5234123482365582455) started by @tonestone57*