### PR TITLE
Scheduler Hot-Path Optimizations and Correctness Fixes

### DIFF
--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -10,6 +10,7 @@
 
 
 #include <util/BitUtils.h>
+#include <util/atomic.h>
 
 #include "scheduler_profiler.h"
 
@@ -299,7 +300,7 @@ RUN_QUEUE_CLASS_NAME::PeekMaximum() const
 	SCHEDULER_ENTER_FUNCTION();
 
 	for (int i = kBitmapSize - 1; i >= 0; i--) {
-		uint32 val = fBitmap[i];
+		uint32 val = atomic_get((int32*)&fBitmap[i]);
 		if (val != 0) {
 			if (i == kBitmapSize - 1 && (MaxPriority % 32 != 31)) {
 				val &= (1UL << (MaxPriority % 32 + 1)) - 1;
@@ -311,8 +312,13 @@ RUN_QUEUE_CLASS_NAME::PeekMaximum() const
 			unsigned int priority = i * 32 + bit;
 
 			ASSERT(priority <= MaxPriority);
-			ASSERT(fHeads[priority] != NULL);
-			return fHeads[priority];
+#if B_HAIKU_64_BIT
+			Element* head = (Element*)atomic_get64((int64*)&fHeads[priority]);
+#else
+			Element* head = (Element*)atomic_get((int32*)&fHeads[priority]);
+#endif
+			ASSERT(head != NULL);
+			return head;
 		}
 	}
 

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -94,7 +94,7 @@ UpdatePriorityBoostScalable(CoreEntry* core, CPUEntry* cpu)
 	const int kMaxThreadsToCheckPerQueue = 5;
 
 	// Check CPU RunQueue
-	{
+	if (cpu->ThreadCount() > 0) {
 		CPURunQueueLocker locker(cpu);
 		const ThreadRunQueue* runQueue = cpu->RunQueue();
 		const uint32* bitmap = runQueue->GetBitmap();
@@ -133,7 +133,7 @@ UpdatePriorityBoostScalable(CoreEntry* core, CPUEntry* cpu)
 	}
 
 	// Check Core RunQueue
-	{
+	if (core->CoreRunQueueThreadCount() > 0) {
 		CoreRunQueueLocker locker(core);
 		const ThreadRunQueue* runQueue = core->RunQueue();
 		const uint32* bitmap = runQueue->GetBitmap();

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -1037,13 +1037,8 @@ PackageEntry::PeekMaximumLoadCore(const CPUSet* mask) const
 	int32 startBit = 0;
 
 	if (count > 1) {
-		int32 k = CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom() % count;
-		// Find k-th set bit
-		native_cpu_mask_t tempMask = enabledMask;
-		for (int32 j = 0; j < k; j++) {
-			tempMask &= ~((native_cpu_mask_t)1 << scheduler_ctz(tempMask));
-		}
-		startBit = scheduler_ctz(tempMask);
+		startBit = (int32)(((uint64)CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom()
+			* kMaxCoresPerPackage) >> 32);
 	}
 
 	// Split mask into two parts to randomize start position

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -167,7 +167,7 @@ public:
 	inline				int32			PackageIndex() const
 											{ return fPackageIndex; }
 	inline				int32			CPUCount() const
-											{ return fCPUCount; }
+											{ return atomic_get(const_cast<int32*>(&fCPUCount)); }
 	inline				const CPUSet&	CPUMask() const
 											{ return fCPUSet; }
 
@@ -180,6 +180,8 @@ public:
 	inline				CPUPriorityHeap*	CPUHeap();
 
 	inline				int32			ThreadCount() const;
+	inline				int32			CoreRunQueueThreadCount() const
+											{ return atomic_get(const_cast<int32*>(&fThreadCount)); }
 
 	inline				void			LockRunQueue();
 	inline				bool			TryLockRunQueue();
@@ -527,10 +529,10 @@ CoreEntry::GetLoad() const
 	SCHEDULER_ENTER_FUNCTION();
 
 	int32 cpuCount = atomic_get(const_cast<int32*>(&fCPUCount));
+	int32 load = atomic_get(const_cast<int32*>(&fLoad));
+
 	if (cpuCount <= 0)
 		return kMaxLoad;
-
-	int32 load = atomic_get(const_cast<int32*>(&fLoad));
 
 	// Optimization: Avoid division and multiplication in the common case.
 	if (cpuCount == 1 && fCapacity == kDefaultCapacity)

--- a/src/system/kernel/scheduler/scheduler_topology.h
+++ b/src/system/kernel/scheduler/scheduler_topology.h
@@ -30,7 +30,8 @@ search_local_node(SchedulerNode* node, Action action)
 		return;
 
 	// Limit attempts to avoid duplicate probes on small nodes
-	const int kMaxLocalAttempts = min_c(4, packagesInNode);
+	const int kMaxLocalAttempts = min_c(packagesInNode,
+		4 + (packagesInNode > 1 ? 31 - __builtin_clz(packagesInNode) : 0));
 	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
 	for (int i = 0; i < kMaxLocalAttempts; i++) {
 		// Multiplicative random mapping to avoid expensive modulo


### PR DESCRIPTION
Optimized the Haiku kernel scheduler by reducing lock contention in priority boosting, improving randomization efficiency in core selection, ensuring atomic consistency in load calculations, scaling topology search caps, and fixing data races in the run queue.

---
*PR created automatically by Jules for task [205042629321942747](https://jules.google.com/task/205042629321942747) started by @tonestone57*