### PR TITLE
scheduler: Fix topology visibility, mask duplication, and load tracki…

### DIFF
--- a/src/system/kernel/scheduler/low_latency.cpp
+++ b/src/system/kernel/scheduler/low_latency.cpp
@@ -60,18 +60,8 @@ choose_core(const ThreadData* threadData)
 
 	// Optimization: If the mask is effectively "all enabled CPUs", treat it as no mask
 	// to enable global random sampling instead of slow mask iteration.
-	if (useMask) {
-		const int32 kCPUSetArraySize = (SMP_MAX_CPUS + 31) / 32;
-		bool allEnabled = true;
-		for (int32 i = 0; i < kCPUSetArraySize; i++) {
-			if (mask.Bits(i) != gCPUEnabled.Bits(i)) {
-				allEnabled = false;
-				break;
-			}
-		}
-		if (allEnabled)
-			useMask = false;
-	}
+	if (useMask && Scheduler::IsAllEnabledMask(mask))
+		useMask = false;
 
 	if (previousCore != NULL && !has_cache_expired(threadData)) {
 		if (!useMask || previousCore->CPUMask().Matches(mask)) {

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -280,18 +280,8 @@ choose_core(const ThreadData* threadData)
 	bool useMask = !mask.IsEmpty();
 
 	// Optimization: If the mask is effectively "all enabled CPUs", treat it as no mask
-	if (useMask) {
-		const int32 kCPUSetArraySize = (SMP_MAX_CPUS + 31) / 32;
-		bool allEnabled = true;
-		for (int32 i = 0; i < kCPUSetArraySize; i++) {
-			if (mask.Bits(i) != gCPUEnabled.Bits(i)) {
-				allEnabled = false;
-				break;
-			}
-		}
-		if (allEnabled)
-			useMask = false;
-	}
+	if (useMask && Scheduler::IsAllEnabledMask(mask))
+		useMask = false;
 
 	// try to pack all threads on one core
 	core = choose_small_task_core();

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -78,6 +78,7 @@ static object_cache* sThreadDataCache;
 static int32* sCPUToCore;
 static int32* sCPUToPackage;
 static int32* sPackageToNode;
+static int32* sCPUToCluster = NULL;
 
 
 static void
@@ -791,8 +792,6 @@ get_topology_id(int32 cpuID)
 	return sCPUToPackage[cpuID];
 }
 
-
-static int32* sCPUToCluster = NULL;
 
 static status_t
 build_topology_mappings(int32& cpuCount, int32& coreCount, int32& packageCount,

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -199,6 +199,16 @@ public:
 		return sCurrentMode->maximum_latency;
 	}
 
+	static inline bool IsAllEnabledMask(const CPUSet& mask)
+	{
+		const int32 kCPUSetArraySize = (SMP_MAX_CPUS + 31) / 32;
+		for (int32 i = 0; i < kCPUSetArraySize; i++) {
+			if (mask.Bits(i) != gCPUEnabled.Bits(i))
+				return false;
+		}
+		return true;
+	}
+
 private:
 	static scheduler_mode sCurrentModeID;
 	static scheduler_mode_operations* sCurrentMode;

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -812,23 +812,29 @@ CoreEntry::_UpdateLoad(bool forceUpdate)
 		return;
 
 	bigtime_t now = system_time();
-	bool intervalEnded = now >= kLoadMeasureInterval + fLastLoadUpdate;
+	bigtime_t lastUpdate = atomic_get64(&fLastLoadUpdate);
+	bool intervalEnded = now >= kLoadMeasureInterval + lastUpdate;
 
-	if (!intervalEnded && !forceUpdate)
+	if (intervalEnded || forceUpdate) {
+		if (atomic_test_and_set64(&fLastLoadUpdate, now, lastUpdate)
+				!= lastUpdate) {
+			return;
+		}
+	} else
 		return;
 
-	if (intervalEnded) {
-		// No locking needed for atomic updates of fLoad.
-		// fCurrentLoad is updated atomically.
-		fLoad = fCurrentLoad;
-		if (cpuCount > 0) {
-			int32 load = fLoad / cpuCount;
-			load = (int64)load * kDefaultCapacity / fCapacity;
-			atomic_set(&fPackage->fCoreLoads[fPackageIndex],
-				std::min(load, kMaxLoad));
-		}
-		atomic_add((int32*)&fLoadMeasurementEpoch, 1);
-		fLastLoadUpdate = now;
+	// Increment epoch first to claim current fCurrentLoad and prevent
+	// concurrent AddLoad from double counting towards fLoad.
+	atomic_add((int32*)&fLoadMeasurementEpoch, 1);
+
+	int32 currentLoad = atomic_get(&fCurrentLoad);
+	atomic_set(&fLoad, currentLoad);
+
+	if (cpuCount > 0) {
+		int32 load = currentLoad / cpuCount;
+		load = (int64)load * kDefaultCapacity / fCapacity;
+		atomic_set(&fPackage->fCoreLoads[fPackageIndex],
+			std::min(load, kMaxLoad));
 	}
 }
 


### PR DESCRIPTION
…ng race

#18. Relocate sCPUToCluster static pointer in scheduler.cpp to ensure declare-before-use for traverse_topology_tree.

#19. Extract duplicated "all enabled CPUs" mask optimization into Scheduler::IsAllEnabledMask in scheduler_common.h.

#20. Synchronize CoreEntry::_UpdateLoad using atomic_test_and_set64 on fLastLoadUpdate to prevent spurious re-updates from concurrent calls. Also ensure fLoad and fLoadMeasurementEpoch are updated atomically relative to each other.