### PR TITLE
Implement Foreground Urgency Injection

### DIFF
--- a/headers/private/kernel/kscheduler.h
+++ b/headers/private/kernel/kscheduler.h
@@ -86,6 +86,7 @@ void scheduler_set_cpu_enabled(int32 cpu, bool enabled);
 void scheduler_add_listener(struct SchedulerListener* listener);
 void scheduler_remove_listener(struct SchedulerListener* listener);
 
+void scheduler_on_team_foreground_changed(Team* team);
 void scheduler_set_foreground_team(team_id teamID);
 
 void scheduler_init(void);

--- a/src/system/kernel/scheduler/low_latency.cpp
+++ b/src/system/kernel/scheduler/low_latency.cpp
@@ -59,7 +59,7 @@ choose_core(const ThreadData* threadData)
 	bool useMask = !mask.IsEmpty();
 
 	// Thread Coloring: High-priority threads prefer P-cores
-	bool isForeground = threadData->GetThread()->team->fIsForeground;
+	bool isForeground = threadData->fIsForeground;
 	bool preferP = threadData->GetPriority() > B_DISPLAY_PRIORITY || isForeground;
 	bool preferE = threadData->GetPriority() < B_NORMAL_PRIORITY && !isForeground;
 

--- a/src/system/kernel/scheduler/low_latency.cpp
+++ b/src/system/kernel/scheduler/low_latency.cpp
@@ -59,7 +59,7 @@ choose_core(const ThreadData* threadData)
 	bool useMask = !mask.IsEmpty();
 
 	// Thread Coloring: High-priority threads prefer P-cores
-	bool isForeground = threadData->fIsForeground;
+	bool isForeground = threadData->IsForeground();
 	bool preferP = threadData->GetPriority() > B_DISPLAY_PRIORITY || isForeground;
 	bool preferE = threadData->GetPriority() < B_NORMAL_PRIORITY && !isForeground;
 

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -282,7 +282,7 @@ choose_core(const ThreadData* threadData)
 	bool useMask = !mask.IsEmpty();
 
 	// Thread Coloring: High-priority threads prefer P-cores
-	bool isForeground = threadData->GetThread()->team->fIsForeground;
+	bool isForeground = threadData->fIsForeground;
 	bool preferP = threadData->GetPriority() > B_DISPLAY_PRIORITY || isForeground;
 	bool preferE = threadData->GetPriority() < B_NORMAL_PRIORITY && !isForeground;
 

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -282,7 +282,7 @@ choose_core(const ThreadData* threadData)
 	bool useMask = !mask.IsEmpty();
 
 	// Thread Coloring: High-priority threads prefer P-cores
-	bool isForeground = threadData->fIsForeground;
+	bool isForeground = threadData->IsForeground();
 	bool preferP = threadData->GetPriority() > B_DISPLAY_PRIORITY || isForeground;
 	bool preferE = threadData->GetPriority() < B_NORMAL_PRIORITY && !isForeground;
 

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -1495,3 +1495,43 @@ _user_get_scheduler_mode()
 {
 	return Scheduler::Mode();
 }
+
+void
+Scheduler::scheduler_on_team_foreground_changed(Team* team)
+{
+	SCHEDULER_ENTER_FUNCTION();
+
+	// Note: Caller must hold the team's thread list lock (team->fLock via TeamLocker).
+	// We iterate through all threads of the team and re-enqueue them if they are ready.
+
+	for (Thread* thread = team->thread_list.First(); thread != NULL;
+			thread = team->thread_list.GetNext(thread)) {
+		InterruptsSpinLocker locker(thread->scheduler_lock);
+		ThreadData* threadData = thread->scheduler_data;
+
+		if (threadData == NULL || threadData->IsIdle() || threadData->IsRealTime())
+			continue;
+
+		threadData->fIsForeground = team->fIsForeground;
+
+		if (thread->state == B_THREAD_READY) {
+			// Remove from current run queue, update priority/deadline, and re-enqueue.
+			// This ensures the virtual runtime tree/heap consistency and immediate
+			// application of the urgency bonus.
+			if (threadData->Dequeue()) {
+				threadData->ResetPriorityBoost();
+				enqueue(thread, false, NULL);
+			}
+		} else if (thread->state == B_THREAD_RUNNING) {
+			// For running threads, just update their internal state.
+			// The next reschedule will handle the change.
+			threadData->ResetPriorityBoost();
+		}
+	}
+}
+
+extern "C" void
+scheduler_on_team_foreground_changed(Team* team)
+{
+	Scheduler::scheduler_on_team_foreground_changed(team);
+}

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -1497,7 +1497,7 @@ _user_get_scheduler_mode()
 }
 
 void
-Scheduler::scheduler_on_team_foreground_changed(Team* team)
+scheduler_on_team_foreground_changed(Team* team)
 {
 	SCHEDULER_ENTER_FUNCTION();
 
@@ -1518,12 +1518,12 @@ Scheduler::scheduler_on_team_foreground_changed(Team* team)
 			// application of the urgency bonus.
 			// Dequeue must happen before updating the flag that determines queue position.
 			bool dequeued = threadData->Dequeue();
-			threadData->fIsForeground = team->fIsForeground;
+			threadData->SetForeground(team->fIsForeground);
 			threadData->ResetPriorityBoost();
 			if (dequeued)
 				enqueue(thread, false, NULL);
 		} else {
-			threadData->fIsForeground = team->fIsForeground;
+			threadData->SetForeground(team->fIsForeground);
 			if (thread->state == B_THREAD_RUNNING) {
 				// For running threads, just update their internal state.
 				// The next reschedule will handle the change.
@@ -1531,10 +1531,4 @@ Scheduler::scheduler_on_team_foreground_changed(Team* team)
 			}
 		}
 	}
-}
-
-extern "C" void
-scheduler_on_team_foreground_changed(Team* team)
-{
-	Scheduler::scheduler_on_team_foreground_changed(team);
 }

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -1512,20 +1512,23 @@ Scheduler::scheduler_on_team_foreground_changed(Team* team)
 		if (threadData == NULL || threadData->IsIdle() || threadData->IsRealTime())
 			continue;
 
-		threadData->fIsForeground = team->fIsForeground;
-
 		if (thread->state == B_THREAD_READY) {
 			// Remove from current run queue, update priority/deadline, and re-enqueue.
 			// This ensures the virtual runtime tree/heap consistency and immediate
 			// application of the urgency bonus.
-			if (threadData->Dequeue()) {
-				threadData->ResetPriorityBoost();
-				enqueue(thread, false, NULL);
-			}
-		} else if (thread->state == B_THREAD_RUNNING) {
-			// For running threads, just update their internal state.
-			// The next reschedule will handle the change.
+			// Dequeue must happen before updating the flag that determines queue position.
+			bool dequeued = threadData->Dequeue();
+			threadData->fIsForeground = team->fIsForeground;
 			threadData->ResetPriorityBoost();
+			if (dequeued)
+				enqueue(thread, false, NULL);
+		} else {
+			threadData->fIsForeground = team->fIsForeground;
+			if (thread->state == B_THREAD_RUNNING) {
+				// For running threads, just update their internal state.
+				// The next reschedule will handle the change.
+				threadData->ResetPriorityBoost();
+			}
 		}
 	}
 }

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -47,11 +47,11 @@ struct ThreadDataVRuntimeCompare {
 			return false;
 
 		bigtime_t aRuntime = a->GetVirtualRuntime();
-		if (a->fIsForeground)
+		if (a->IsForeground())
 			aRuntime -= kForegroundVRuntimeOffset;
 
 		bigtime_t bRuntime = b->GetVirtualRuntime();
-		if (b->fIsForeground)
+		if (b->IsForeground())
 			bRuntime -= kForegroundVRuntimeOffset;
 
 		return aRuntime < bRuntime;
@@ -146,7 +146,6 @@ extern int64 gDeadlineBucketSize;
 
 
 void init_debug_commands();
-void scheduler_on_team_foreground_changed(Team* team);
 void scheduler_update_interaction_state();
 
 
@@ -223,8 +222,6 @@ public:
 		}
 		return true;
 	}
-
-	static void scheduler_on_team_foreground_changed(Team* team);
 
 private:
 	static scheduler_mode sCurrentModeID;

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -32,6 +32,8 @@
 
 namespace Scheduler {
 
+const bigtime_t kForegroundVRuntimeOffset = 5000;
+
 struct ThreadDataVRuntimeCompare {
 	template<typename ThreadData>
 	bool operator()(const ThreadData* a, const ThreadData* b) const
@@ -43,7 +45,16 @@ struct ThreadDataVRuntimeCompare {
 		}
 		if (b->IsRealTime())
 			return false;
-		return a->GetVirtualRuntime() < b->GetVirtualRuntime();
+
+		bigtime_t aRuntime = a->GetVirtualRuntime();
+		if (a->fIsForeground)
+			aRuntime -= kForegroundVRuntimeOffset;
+
+		bigtime_t bRuntime = b->GetVirtualRuntime();
+		if (b->fIsForeground)
+			bRuntime -= kForegroundVRuntimeOffset;
+
+		return aRuntime < bRuntime;
 	}
 };
 
@@ -135,6 +146,7 @@ extern int64 gDeadlineBucketSize;
 
 
 void init_debug_commands();
+void scheduler_on_team_foreground_changed(Team* team);
 void scheduler_update_interaction_state();
 
 
@@ -211,6 +223,8 @@ public:
 		}
 		return true;
 	}
+
+	static void scheduler_on_team_foreground_changed(Team* team);
 
 private:
 	static scheduler_mode sCurrentModeID;

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -46,6 +46,8 @@ ThreadData::_InitBase()
 
 	fVirtualRuntime = 0;
 	fVirtualDeadline = 0;
+
+	fIsForeground = fThread->team->fIsForeground;
 }
 
 
@@ -459,9 +461,15 @@ ThreadData::_ComputeEffectivePriority(bigtime_t now) const
 		// If Deadline is Now (or passed), Urgency is Max.
 		// If Deadline is far, Urgency is 0.
 
+		bigtime_t diff = fVirtualDeadline - now;
+
+		// Urgency Bonus: Grant foreground threads a "head start" in priority.
+		if (fThread->team->fIsForeground)
+			diff -= atomic_get64(&Scheduler::gDeadlineBucketSize);
+
 		const int32 kMaxDynamicPriority = B_FIRST_REAL_TIME_PRIORITY - 1;
 		bigtime_t urgency = kMaxDynamicPriority
-			- (fVirtualDeadline - now) / atomic_get64(&Scheduler::gDeadlineBucketSize);
+			- diff / atomic_get64(&Scheduler::gDeadlineBucketSize);
 		if (urgency < 0) urgency = 0;
 		if (urgency > kMaxDynamicPriority) urgency = kMaxDynamicPriority;
 

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -464,7 +464,7 @@ ThreadData::_ComputeEffectivePriority(bigtime_t now) const
 		bigtime_t diff = fVirtualDeadline - now;
 
 		// Urgency Bonus: Grant foreground threads a "head start" in priority.
-		if (fThread->team->fIsForeground)
+		if (fIsForeground)
 			diff -= atomic_get64(&Scheduler::gDeadlineBucketSize);
 
 		const int32 kMaxDynamicPriority = B_FIRST_REAL_TIME_PRIORITY - 1;

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -528,3 +528,11 @@ ThreadProcessing::~ThreadProcessing()
 {
 }
 
+
+void
+ThreadData::ResetPriorityBoost()
+{
+	SCHEDULER_ENTER_FUNCTION();
+
+	_ComputeEffectivePriority(system_time());
+}

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -120,6 +120,7 @@ private:
 			bool		fEnqueuedInCPURunQueue;
 			bool		fReady;
 			bool		fQuickStartCredit;
+			bool		fIsForeground;
 
 			Thread*		fThread;
 

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -470,7 +470,7 @@ ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption)
 			ThreadData* top = cpu->PeekThread();
 			wasRunQueueEmpty = (top == NULL || top->IsIdle());
 
-			bool isForeground = fThread->team->fIsForeground;
+			bool isForeground = fIsForeground;
 
 			if (fQuickStartCredit || isForeground) {
 				cpu->PushFront(this, priority);
@@ -502,7 +502,7 @@ ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption)
 		ThreadData* top = fCore->PeekThread();
 		wasRunQueueEmpty = (top == NULL || top->IsIdle());
 
-		bool isForeground = fThread->team->fIsForeground;
+		bool isForeground = fIsForeground;
 
 		if (fQuickStartCredit || isForeground) {
 			fCore->PushFront(this, priority);

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -52,7 +52,7 @@ public:
 	SCHEDULER_INLINE	void		StartCPUTime();
 	SCHEDULER_INLINE	void		StopCPUTime();
 
-	SCHEDULER_INLINE	void		ResetPriorityBoost();
+			void		ResetPriorityBoost();
 
 			bool		ChooseCoreAndCPU(CoreEntry*& targetCore,
 							CPUEntry*& targetCPU);
@@ -90,6 +90,12 @@ public:
 	}
 
 	SCHEDULER_INLINE	int32		GetLoad() const	{ return fNeededLoad; }
+
+	SCHEDULER_INLINE	bool		IsForeground() const	{ return fIsForeground; }
+	SCHEDULER_INLINE	void		SetForeground(bool foreground)
+	{
+		fIsForeground = foreground;
+	}
 
 	SCHEDULER_INLINE	CoreEntry*	Core() const	{ return fCore; }
 			void		UnassignCore(bool running = false);
@@ -269,13 +275,6 @@ ThreadData::StopCPUTime()
 }
 
 
-inline void
-ThreadData::ResetPriorityBoost()
-{
-	SCHEDULER_ENTER_FUNCTION();
-
-	_ComputeEffectivePriority(system_time());
-}
 
 
 inline void

--- a/src/system/kernel/team.cpp
+++ b/src/system/kernel/team.cpp
@@ -3016,7 +3016,7 @@ update_session_foreground_status(ProcessSession* session, pid_t foregroundGroup)
 	{
 		InterruptsReadSpinLocker teamsLocker(sTeamHashLock);
 		for (TeamTable::Iterator it = sTeamHash.GetIterator(); Team* t = it.Next();) {
-			if (t->group->Session() == session) {
+			if (t->group != NULL && t->group->Session() == session) {
 				if (teamCount < kMaxTeamsToCollect) {
 					t->AcquireReference();
 					teamsToUpdate[teamCount++] = t;
@@ -3098,6 +3098,9 @@ team_set_foreground_process_group(void* tty, pid_t processGroupID)
 
 	session->foreground_group = processGroupID;
 
+	sessionLocker.Unlock();
+	teamLocker.Unlock();
+
 	update_session_foreground_status(session, processGroupID);
 
 	return B_OK;
@@ -3112,12 +3115,23 @@ scheduler_set_foreground_team(team_id teamID)
 		return;
 	BReference<Team> teamReference(team, true);
 
-	ProcessSession* session = team->group->Session();
+	ProcessSession* session;
+	pid_t groupID;
+	{
+		TeamLocker teamLocker(team);
+		if (team->group == NULL)
+			return;
+		session = team->group->Session();
+		session->AcquireReference();
+		groupID = team->group_id;
+	}
+	BReference<ProcessSession> sessionReference(session, true);
+
 	AutoLocker<ProcessSession> sessionLocker(session);
+	session->foreground_group = groupID;
+	sessionLocker.Unlock();
 
-	session->foreground_group = team->group_id;
-
-	update_session_foreground_status(session, team->group_id);
+	update_session_foreground_status(session, groupID);
 }
 
 

--- a/src/system/kernel/team.cpp
+++ b/src/system/kernel/team.cpp
@@ -1328,6 +1328,8 @@ insert_team_into_group(ProcessGroup* group, Team* team)
 	team->group_id = group->id;
 	team->session_id = group->Session()->id;
 
+	team->fIsForeground = team->group_id == group->Session()->foreground_group;
+
 	group->teams.Add(team, false);
 	group->AcquireReference();
 }
@@ -3007,7 +3009,7 @@ update_team_foreground_status(Team* team, pid_t foregroundGroup)
 static void
 update_session_foreground_status(ProcessSession* session, pid_t foregroundGroup)
 {
-	const int32 kMaxTeamsToCollect = 128;
+	const int32 kMaxTeamsToCollect = 512;
 	Team* teamsToUpdate[kMaxTeamsToCollect];
 	int32 teamCount = 0;
 

--- a/src/system/kernel/team.cpp
+++ b/src/system/kernel/team.cpp
@@ -2998,6 +2998,38 @@ update_team_foreground_status(Team* team, pid_t foregroundGroup)
 		return;
 
 	team->fIsForeground = isForeground;
+
+	// team->fLock must be held by caller (TeamLocker)
+	scheduler_on_team_foreground_changed(team);
+}
+
+
+static void
+update_session_foreground_status(ProcessSession* session, pid_t foregroundGroup)
+{
+	const int32 kMaxTeamsToCollect = 128;
+	Team* teamsToUpdate[kMaxTeamsToCollect];
+	int32 teamCount = 0;
+
+	{
+		InterruptsReadSpinLocker teamsLocker(sTeamHashLock);
+		for (TeamTable::Iterator it = sTeamHash.GetIterator(); Team* t = it.Next();) {
+			if (t->group->Session() == session) {
+				if (teamCount < kMaxTeamsToCollect) {
+					t->AcquireReference();
+					teamsToUpdate[teamCount++] = t;
+				}
+			}
+		}
+	}
+
+	for (int32 i = 0; i < teamCount; i++) {
+		Team* t = teamsToUpdate[i];
+		TeamLocker teamLocker(t);
+		update_team_foreground_status(t, foregroundGroup);
+		teamLocker.Unlock();
+		t->ReleaseReference();
+	}
 }
 
 
@@ -3064,13 +3096,7 @@ team_set_foreground_process_group(void* tty, pid_t processGroupID)
 
 	session->foreground_group = processGroupID;
 
-	// Update all teams in the session
-	InterruptsReadSpinLocker teamsLocker(sTeamHashLock);
-	for (TeamTable::Iterator it = sTeamHash.GetIterator(); Team* team = it.Next();) {
-		if (team->group->Session() == session) {
-			update_team_foreground_status(team, processGroupID);
-		}
-	}
+	update_session_foreground_status(session, processGroupID);
 
 	return B_OK;
 }
@@ -3079,21 +3105,17 @@ team_set_foreground_process_group(void* tty, pid_t processGroupID)
 void
 scheduler_set_foreground_team(team_id teamID)
 {
-	InterruptsReadSpinLocker teamsLocker(sTeamHashLock);
-	Team* team = sTeamHash.Lookup(teamID);
-	if (team != NULL) {
-		ProcessSession* session = team->group->Session();
-		AutoLocker<ProcessSession> sessionLocker(session);
+	Team* team = Team::Get(teamID);
+	if (team == NULL)
+		return;
+	BReference<Team> teamReference(team, true);
 
-		session->foreground_group = team->group_id;
+	ProcessSession* session = team->group->Session();
+	AutoLocker<ProcessSession> sessionLocker(session);
 
-		// Update all teams in the session
-		for (TeamTable::Iterator it = sTeamHash.GetIterator(); Team* t = it.Next();) {
-			if (t->group->Session() == session) {
-				update_team_foreground_status(t, team->group_id);
-			}
-		}
-	}
+	session->foreground_group = team->group_id;
+
+	update_session_foreground_status(session, team->group_id);
 }
 
 


### PR DESCRIPTION
Implemented Foreground Urgency Injection to enhance the responsiveness of the active application. The mechanism uses a combination of Virtual Runtime offsets and dynamic priority boosts, coupled with immediate run-queue re-evaluation upon focus changes. The implementation is optimized for performance and follows kernel safety patterns.

---
*PR created automatically by Jules for task [3812449495130394887](https://jules.google.com/task/3812449495130394887) started by @tonestone57*