### PR TITLE
Fix various scheduler and load average bugs

### DIFF
--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -250,7 +250,7 @@ RUN_QUEUE_CLASS_NAME::ConstIterator::_FindNextPriority()
 
 	if (fPriority > 0 && currentBit != 31) {
 		// Mask bits at currentBit+1 and above, keep bits 0..currentBit
-		val &= (1UL << (currentBit + 1)) - 1;
+		val &= (uint32)((1ULL << (currentBit + 1)) - 1);
 	} else if (fPriority == 0) {
 		// If we finished bit 0, this word is done.
 		val = 0;

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -741,8 +741,7 @@ CoreEntry::RemoveCPU(CPUEntry* cpu, ThreadProcessing& threadPostProcessing)
 	ASSERT(fCPUCount > 0);
 	ASSERT(atomic_get(&fIdleCPUCount) > 0);
 
-	if (fCPUHeap.GetKey(cpu) == B_IDLE_PRIORITY)
-		atomic_add(&fIdleCPUCount, -1);
+	atomic_add(&fIdleCPUCount, -1);
 	fCPUSet.ClearBitAtomic(cpu->ID());
 	if (atomic_add(&fCPUCount, -1) == 1) {
 		// core has been disabled

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -664,9 +664,8 @@ PackageEntry::CoreWakesUp(CoreEntry* core)
 	atomic_add(&fIdleCoreCount, -1);
 	int32 oldMask = atomic_and((int32*)&fIdleCoreMask, ~(1U << core->PackageIndex()));
 
-	int32 expectedMask = atomic_get((int32*)&fEnabledCoreMask);
-	if (oldMask == expectedMask) {
-		// package wakes up (first core)
+	if ((oldMask & ~(1U << core->PackageIndex())) == 0) {
+		// package wakes up (last core)
 		fNode->PackageWakesUp(this);
 	}
 }

--- a/src/system/kernel/scheduler/scheduler_load.cpp
+++ b/src/system/kernel/scheduler/scheduler_load.cpp
@@ -42,7 +42,7 @@ _LoadavgUpdate(void *data, int iteration)
 	InterruptsSpinLocker locker(sLoadAvgLock);
 	for (int i = 0; i < 3; i++) {
 		sAverageRunnable.ldavg[i]
-			= (sCExp[i] * sAverageRunnable.ldavg[i] + threadCount * kFScale * (kFScale - sCExp[i]))
+			= (sCExp[i] * sAverageRunnable.ldavg[i] + threadCount * (kFScale - sCExp[i]))
 			>> kFShift;
 	}
 }

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -334,7 +334,7 @@ ThreadData::ComputeQuantum() const
 	// Context-aware quantum scaling: scale by interactivity score (0.5x - 1.5x)
 	quantum = quantum * (1500 - fInteractivityScore) / 1000;
 
-	return std::max(quantum, kMinGranularity);
+	return std::max(quantum, floorQuantum);
 }
 
 


### PR DESCRIPTION
Fixed five scheduler bugs: package wakeup condition, unbalanced idle CPU count during removal, run-queue iterator overflow, incorrect load average formula, and insufficient quantum clamping for interactive threads.

---
*PR created automatically by Jules for task [17610859545658965693](https://jules.google.com/task/17610859545658965693) started by @tonestone57*