### PR TITLE
Fix remaining scheduler issues (3, 6, 7, 9)

### DIFF
--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -236,30 +236,30 @@ RUN_QUEUE_CLASS_NAME::ConstIterator::_FindNextPriority()
 {
 	ASSERT(fList != NULL);
 
+	// Nothing exists below priority 0.
+	if (fPriority == 0) {
+		fNext = NULL;
+		return;
+	}
+
 	const uint32* bitmap = fList->GetBitmap();
 
-	int i = (fPriority > 0 ? fPriority - 1 : 0) / 32;
-	uint32 val = bitmap[i];
+	// Highest priority we may consider is (fPriority - 1), which lives in
+	// word 'i' at bit 'topBit'.
+	int i = (int)(fPriority - 1) / 32;
+	int topBit = (int)(fPriority - 1) % 32;  // 0..31
 
-	// Mask out higher priorities (bits >= current bit index) in current word
-	// because we are looking for the *next* priority lower than fPriority.
-	// fPriority is the one we just finished.
-	// We want to check fPriority - 1 down to 0.
-
-	int currentBit = fPriority > 0 ? (fPriority - 1) % 32 : 0;
-
-	if (fPriority > 0 && currentBit != 31) {
-		// Mask bits at currentBit+1 and above, keep bits 0..currentBit
-		val &= (1UL << (currentBit + 1)) - 1;
-	} else if (fPriority == 0) {
-		// If we finished bit 0, this word is done.
-		val = 0;
-	}
+	// Keep only bits 0..topBit in the starting word.  We use a 64-bit
+	// literal (2ULL << topBit) instead of (1UL << (topBit + 1)) to avoid
+	// undefined behaviour when topBit == 31: shifting a 32-bit value by
+	// 32 is UB on 32-bit targets even though the old guard (currentBit != 31)
+	// prevented it from being evaluated, because the guard itself was fragile.
+	uint32 val = bitmap[i] & (uint32)((2ULL << topBit) - 1);
 
 	while (true) {
 		if (val != 0) {
 			int bit = fls(val) - 1;
-			fPriority = i * 32 + bit;
+			fPriority = (unsigned int)(i * 32 + bit);
 			fNext = fList->GetHead(fPriority);
 			return;
 		}

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -188,10 +188,13 @@ UpdatePriorityBoostScalable(CoreEntry* core, CPUEntry* cpu)
 				int count = 0;
 
 				while (thread != NULL && count++ < kMaxThreadsToCheckPerQueue) {
+					// Capture successor BEFORE _UpdatePriorityBoost(): that call
+					// may Remove(thread) + PushBack(thread, newPriority), clearing
+					// thread->fNext.  'next' remains valid because:
+					//  - We hold CPURunQueueLocker (no concurrent mutation).
+					//  - Only thread's own link fields change; next is unaffected.
 					ThreadData* next = thread->GetRunQueueLink()->fNext;
 					thread->_UpdatePriorityBoost();
-					// If thread moved, it was removed from this queue.
-					// 'next' is correct either way.
 					thread = next;
 				}
 
@@ -227,6 +230,7 @@ UpdatePriorityBoostScalable(CoreEntry* core, CPUEntry* cpu)
 				int count = 0;
 
 				while (thread != NULL && count++ < kMaxThreadsToCheckPerQueue) {
+					// See CPU RunQueue loop above for why 'next' is captured first.
 					ThreadData* next = thread->GetRunQueueLink()->fNext;
 					thread->_UpdatePriorityBoost();
 					thread = next;

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -465,6 +465,11 @@ CPUEntry::_TryStealWork()
 		return stolen;
 
 	// Phase 3: The Global Hail Mary (Random)
+	// stolen is guaranteed NULL by the early return above, but reset it
+	// explicitly so the phase boundary is self-documenting and safe against
+	// future refactoring that might restructure or inline the guard.
+	stolen = NULL;
+
 	// Target: Any core in the system (4096 cores).
 	// Method: Logarithmic Formula
 	// Why: This is the last resort. If the local node is empty, you are willing to pay

--- a/src/system/kernel/scheduler/scheduler_topology.h
+++ b/src/system/kernel/scheduler/scheduler_topology.h
@@ -83,16 +83,20 @@ search_global_random(Action action)
 		int32 word = i / 64;
 		int32 bit = i % 64;
 
-		// Only check collision if within our stack bitmask range
+		// Deduplication: skip packages already probed this call (within the
+		// stack bitmask range).  For indices beyond kStackBitmaskSize we
+		// cannot deduplicate cheaply, but we still count the probe towards
+		// the budget so the loop terminates in at most kMaxAttempts steps
+		// regardless of gPackageCount.  Previously, indices >= kStackBitmaskSize
+		// never incremented samplesTaken, causing the loop to always run the
+		// full kMaxAttempts (2x samplesToTake) on systems with > 1024 packages.
 		if (i < kStackBitmaskSize) {
 			if ((visitedBits[word] & (1ULL << bit)) != 0)
 				continue;
 			visitedBits[word] |= (1ULL << bit);
-			samplesTaken++;
 		}
-		// Note: if i >= kStackBitmaskSize, samplesTaken is NOT incremented
-		// so un-deduplicated samples don't count towards the budget.
-		// The loop is strictly bounded by attempts < kMaxAttempts, preventing runaway.
+		// Always count towards the budget (with or without deduplication).
+		samplesTaken++;
 
 		if (action(&gPackageEntries[i]))
 			break;


### PR DESCRIPTION
Applied four fixes to the Haiku scheduler files based on the provided audit patch. These changes address undefined behavior in the run queue iterator, an accounting bug in topology search, state management in work stealing, and documentation of locking invariants.

---
*PR created automatically by Jules for task [154159931312740835](https://jules.google.com/task/154159931312740835) started by @tonestone57*