### PR TITLE
Fix fixed-point scaling error in load average

### DIFF
--- a/src/system/kernel/scheduler/scheduler_load.cpp
+++ b/src/system/kernel/scheduler/scheduler_load.cpp
@@ -42,8 +42,8 @@ _LoadavgUpdate(void *data, int iteration)
 	InterruptsSpinLocker locker(sLoadAvgLock);
 	for (int i = 0; i < 3; i++) {
 		sAverageRunnable.ldavg[i]
-			= (sCExp[i] * sAverageRunnable.ldavg[i] + threadCount * (kFScale - sCExp[i]))
-			>> kFShift;
+			= (sCExp[i] * (uint64)sAverageRunnable.ldavg[i]
+				+ (uint64)threadCount * (kFScale - sCExp[i]) * kFScale) >> kFShift;
 	}
 }
 
@@ -52,7 +52,7 @@ status_t
 scheduler_loadavg_init()
 {
 	register_kernel_daemon(_LoadavgUpdate, NULL, 5000);
-		// run the daemon once five second
+		// run the daemon every five seconds
 
 	return B_OK;
 }


### PR DESCRIPTION
Fixed a fixed-point scaling bug in `src/system/kernel/scheduler/scheduler_load.cpp` that caused the system load average to be under-reported by a factor of 2048. 

The fix involves:
1. Scaling the `threadCount` term by `kFScale` before the right shift.
2. Using `uint64` casts to prevent integer overflow during intermediate calculations.
3. Corrected a minor typo in a comment.

Verified the fix with a standalone C++ test case that replicates the logic and confirms the math is now correct.

---
*PR created automatically by Jules for task [7692470224918120252](https://jules.google.com/task/7692470224918120252) started by @tonestone57*