### PR TITLE
Core-type scheduler fixes and improvements

### DIFF
--- a/src/system/kernel/scheduler/low_latency.cpp
+++ b/src/system/kernel/scheduler/low_latency.cpp
@@ -58,11 +58,16 @@ choose_core(const ThreadData* threadData)
 	CPUSet mask = threadData->GetCPUMask();
 	bool useMask = !mask.IsEmpty();
 
-	// Thread Coloring: High-priority threads prefer Performance cores
+	// Thread Coloring: only meaningful on heterogeneous systems.
+	// On homogeneous systems (gMinCoreType == gMaxCoreType) the type-filtered
+	// search is equivalent to the general min-load search and adds overhead
+	// without benefit. Skip it entirely.
 	bool isForeground = threadData->IsForeground();
 	int32 priority = threadData->GetPriority();
-	bool preferMax = priority > B_DISPLAY_PRIORITY || isForeground;
-	bool preferMin = priority < B_NORMAL_PRIORITY && !isForeground;
+	bool preferMax = (priority > B_DISPLAY_PRIORITY || isForeground)
+		&& (gMinCoreType != gMaxCoreType);
+	bool preferMin = (priority < B_NORMAL_PRIORITY && !isForeground)
+		&& (gMinCoreType != gMaxCoreType);
 
 	// Optimization: If the mask is effectively "all enabled CPUs", treat it as no mask
 	// to enable global random sampling instead of slow mask iteration.
@@ -181,15 +186,57 @@ choose_core(const ThreadData* threadData)
 				}
 			}
 
+			// Prevent overloading E-cores: if the best E-core candidate is already
+			// heavily utilized, fall through to the general min-load search rather
+			// than pile more threads onto an overloaded E-core cluster.
+			if (preferMin && core != NULL && core->GetScore() > kHighLoad)
+				core = NULL;
+
 			// For Performance cores, respect load threshold (80%).
-			// For Efficiency cores, we just take the best one if we really want Efficiency cores.
 			if (preferMax && core != NULL && core->GetLoad() > 800)
 				core = NULL;
 		}
-	}
 
-	if (core != NULL)
-		return core;
+		if (core != NULL)
+			return core;
+
+		// 3-type intermediate fallback: when P-cores are all overloaded and
+		// STANDARD cores exist, try them before falling to the fully unfiltered
+		// search (which might return an E-core for a high-priority thread).
+		if (preferMax && gHasStandardCores) {
+			int32 stdBestScore = -1;
+			bool tryRandomStd = gPackageCount > kRandomSearchThreshold;
+
+			if (tryRandomStd && !useMask) {
+				search_global_random([&](PackageEntry* entry) {
+					CheckPackageMinimumLoad(entry, NULL, core, stdBestScore,
+						CORE_TYPE_STANDARD);
+					return false;
+				});
+			} else if (useMask) {
+				CheckMaskedPackagesMinimumLoad(mask, core, stdBestScore,
+					CORE_TYPE_STANDARD);
+			}
+
+			if (core == NULL) {
+				int32 startIndex = tryRandomStd
+					? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom()
+						% gPackageCount
+					: 0;
+				int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
+				for (int32 i = 0; i < attempts; i++) {
+					int32 index = startIndex + i;
+					if (index >= gPackageCount)
+						index -= gPackageCount;
+					CheckPackageMinimumLoad(&gPackageEntries[index], NULL, core,
+						stdBestScore, CORE_TYPE_STANDARD);
+				}
+			}
+
+			if (core != NULL)
+				return core;
+		}
+	}
 
 	// Check Home Package (NUMA/Memory Affinity)
 	// If the previous core was not suitable (or cache expired), we try to return
@@ -442,6 +489,34 @@ rebalance(const ThreadData* threadData)
 		} else if (currentPackageID == homePackageID && otherPackageID != homePackageID) {
 			// Penalty for leaving home: double the threshold.
 			threshold *= 2;
+		}
+	}
+
+	// Type-affinity guard: on heterogeneous systems, resist migrating a
+	// thread off its preferred core type. choose_core places high-priority
+	// threads on P-cores; without this guard rebalance undoes that on every
+	// scheduling quantum by finding a lightly loaded E-core and moving the
+	// thread there.
+	//
+	// We increase the migration threshold rather than blocking migration
+	// entirely, so that severely overloaded P-cores can still shed load to
+	// other types in extreme conditions.
+	if (gMinCoreType != gMaxCoreType) {
+		bool isFgRebal = threadData->IsForeground();
+		int32 prioRebal = threadData->GetPriority();
+		CoreType wantedType
+			= (prioRebal > B_DISPLAY_PRIORITY || isFgRebal)
+				? gMaxCoreType
+				: (prioRebal < B_NORMAL_PRIORITY && !isFgRebal)
+					? gMinCoreType
+					: CORE_TYPE_UNKNOWN;
+
+		if (wantedType != CORE_TYPE_UNKNOWN
+				&& core->Type() == wantedType
+				&& other->Type() != wantedType) {
+			// Require a load difference twice the normal threshold before
+			// accepting a cross-type migration.
+			threshold = max_c(threshold, kLoadDifference * 2);
 		}
 	}
 

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -621,6 +621,8 @@ rebalance(const ThreadData* threadData)
 		}
 		ASSERT(other != NULL);
 
+		int32 threshold = kLoadDifference >> 1;
+
 		// Type-affinity guard: resist cross-type migration on heterogeneous
 		// systems to preserve the placement made by choose_core. Without this,
 		// a high-priority thread on a P-core is immediately rebalanced to a
@@ -642,17 +644,13 @@ rebalance(const ThreadData* threadData)
 				// Require double the normal load difference before accepting a
 				// cross-type migration. A severely overloaded P-core can still
 				// shed threads; a mildly overloaded one cannot.
-				int32 adjustment = kLoadDifference;
-				int32 coreNewScore = coreScore - threadLoad;
-				int32 otherNewScore = other->GetScore() + threadLoad;
-				if (coreNewScore - otherNewScore < (kLoadDifference >> 1) + adjustment)
-					return core;
+				threshold += kLoadDifference;
 			}
 		}
 
 		int32 coreNewScore = coreScore - threadLoad;
 		int32 otherNewScore = other->GetScore() + threadLoad;
-		return coreNewScore - otherNewScore >= kLoadDifference >> 1 ? other : core;
+		return coreNewScore - otherNewScore >= threshold ? other : core;
 	}
 
 	if (coreScore >= kMediumLoad)

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -106,6 +106,62 @@ choose_small_task_core()
 {
 	SCHEDULER_ENTER_FUNCTION();
 
+	// On heterogeneous systems, small-task packing should prefer E-cores
+	// (gMinCoreType) to keep P-cores available for high-priority foreground
+	// work. On homogeneous systems packType is UNKNOWN and we fall through to
+	// the general packing logic.
+	if (sSmallTaskCore != NULL && gMinCoreType != gMaxCoreType) {
+		CoreEntry* eCore = NULL;
+		int32 eBestScore = -1;
+
+		bool tryRandom = gPackageCount > kRandomSearchThreshold;
+		if (tryRandom) {
+			search_global_random([&](PackageEntry* entry) {
+				CoreEntry* candidate
+					= entry->PeekMaximumLoadCore(NULL, gMinCoreType);
+				if (candidate != NULL && candidate->GetScore() < kHighLoad) {
+					int32 score = candidate->GetScore();
+					if (eCore == NULL || score > eBestScore) {
+						eCore = candidate;
+						eBestScore = score;
+					}
+				}
+				return false;
+			});
+		}
+
+		if (eCore == NULL) {
+			const int32 kMaxFallback = kMaxFallbackAttempts;
+			int32 start = tryRandom
+				? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom()
+					% gPackageCount
+				: 0;
+			for (int32 i = 0; i < min_c(gPackageCount, kMaxFallback); i++) {
+				int32 idx = start + i;
+				if (idx >= gPackageCount) idx -= gPackageCount;
+				CoreEntry* candidate
+					= gPackageEntries[idx].PeekMaximumLoadCore(NULL, gMinCoreType);
+				if (candidate != NULL && candidate->GetScore() < kHighLoad) {
+					int32 score = candidate->GetScore();
+					if (eCore == NULL || score > eBestScore) {
+						eCore = candidate;
+						eBestScore = score;
+					}
+				}
+			}
+		}
+
+		// If a suitable E-core was found, pin sSmallTaskCore to it and return.
+		// Fall through to the general packing logic only when no E-core has
+		// capacity (all E-cores are already heavily loaded).
+		if (eCore != NULL) {
+			int32 nodeID = eCore->Package()->Node()->ID();
+			CoreEntry* smallTaskCore = (CoreEntry*)atomic_pointer_test_and_set(
+				&sSmallTaskCore[nodeID], eCore, (CoreEntry*)NULL);
+			return smallTaskCore == NULL ? eCore : smallTaskCore;
+		}
+	}
+
 	CoreEntry* core = NULL;
 	int32 bestScore = -1;
 
@@ -281,11 +337,16 @@ choose_core(const ThreadData* threadData)
 	CPUSet mask = threadData->GetCPUMask();
 	bool useMask = !mask.IsEmpty();
 
-	// Thread Coloring: High-priority threads prefer Performance cores
+	// Thread Coloring: only meaningful on heterogeneous systems.
+	// Skip on homogeneous systems where gMinCoreType == gMaxCoreType to avoid
+	// a redundant type-filtered search that returns the same result as the
+	// general packing logic below.
 	bool isForeground = threadData->IsForeground();
 	int32 priority = threadData->GetPriority();
-	bool preferMax = priority > B_DISPLAY_PRIORITY || isForeground;
-	bool preferMin = priority < B_NORMAL_PRIORITY && !isForeground;
+	bool preferMax = (priority > B_DISPLAY_PRIORITY || isForeground)
+		&& (gMinCoreType != gMaxCoreType);
+	bool preferMin = (priority < B_NORMAL_PRIORITY && !isForeground)
+		&& (gMinCoreType != gMaxCoreType);
 
 	// Optimization: If the mask is effectively "all enabled CPUs", treat it as no mask
 	if (useMask && Scheduler::IsAllEnabledMask(mask))
@@ -323,9 +384,47 @@ choose_core(const ThreadData* threadData)
 			}
 		}
 
-		// For Performance cores, respect load threshold (80%).
+		// Prevent overloading E-cores: if the best E-core is already heavily
+		// utilized, fall through rather than pile more background threads on.
+		if (preferMin && core != NULL && core->GetScore() > kHighLoad)
+			core = NULL;
+
+		// For P-cores, respect the 80% raw-load ceiling.
 		if (preferMax && core != NULL && core->GetLoad() > 800)
 			core = NULL;
+
+		// 3-type intermediate fallback: P overloaded → try STANDARD before
+		// giving up type preference and falling to the general packing search.
+		if (preferMax && core == NULL && gHasStandardCores) {
+			int32 stdBestScore = -1;
+			bool foundNonOverloadedStd = false;
+			bool tryRandomStd = gPackageCount > kRandomSearchThreshold;
+
+			if (tryRandomStd && !useMask) {
+				search_global_random([&](PackageEntry* entry) {
+					check_package_packing(entry, NULL, core, stdBestScore,
+						foundNonOverloadedStd, CORE_TYPE_STANDARD);
+					return false;
+				});
+			} else if (useMask) {
+				check_masked_packages_packing(mask, core, stdBestScore,
+					foundNonOverloadedStd, CORE_TYPE_STANDARD);
+			}
+
+			if (core == NULL) {
+				int32 startIndex = tryRandomStd
+					? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom()
+						% gPackageCount
+					: 0;
+				int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
+				for (int32 i = 0; i < attempts; i++) {
+					int32 index = startIndex + i;
+					if (index >= gPackageCount) index -= gPackageCount;
+					check_package_packing(&gPackageEntries[index], NULL, core,
+						stdBestScore, foundNonOverloadedStd, CORE_TYPE_STANDARD);
+				}
+			}
+		}
 
 		if (core != NULL)
 			return core;
@@ -521,6 +620,35 @@ rebalance(const ThreadData* threadData)
 			return core; // Fallback
 		}
 		ASSERT(other != NULL);
+
+		// Type-affinity guard: resist cross-type migration on heterogeneous
+		// systems to preserve the placement made by choose_core. Without this,
+		// a high-priority thread on a P-core is immediately rebalanced to a
+		// lightly loaded E-core (which has a lower normalized score), defeating
+		// thread coloring on every scheduling quantum.
+		if (gMinCoreType != gMaxCoreType) {
+			bool isFgRebal = threadData->IsForeground();
+			int32 prioRebal = threadData->GetPriority();
+			CoreType wantedType
+				= (prioRebal > B_DISPLAY_PRIORITY || isFgRebal)
+					? gMaxCoreType
+					: (prioRebal < B_NORMAL_PRIORITY && !isFgRebal)
+						? gMinCoreType
+						: CORE_TYPE_UNKNOWN;
+
+			if (wantedType != CORE_TYPE_UNKNOWN
+					&& core->Type() == wantedType
+					&& other->Type() != wantedType) {
+				// Require double the normal load difference before accepting a
+				// cross-type migration. A severely overloaded P-core can still
+				// shed threads; a mildly overloaded one cannot.
+				int32 adjustment = kLoadDifference;
+				int32 coreNewScore = coreScore - threadLoad;
+				int32 otherNewScore = other->GetScore() + threadLoad;
+				if (coreNewScore - otherNewScore < (kLoadDifference >> 1) + adjustment)
+					return core;
+			}
+		}
 
 		int32 coreNewScore = coreScore - threadLoad;
 		int32 otherNewScore = other->GetScore() + threadLoad;

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -62,6 +62,8 @@ int64 gDeadlineBucketSize = 5000;
 CoreType gMinCoreType = CORE_TYPE_UNKNOWN;
 CoreType gMaxCoreType = CORE_TYPE_UNKNOWN;
 
+bool gHasStandardCores = false;
+
 static timer sInteractionTimer;
 static int64 sLastInteractionTime;
 static int32 sDPCPending = 0;
@@ -1236,6 +1238,12 @@ init()
 
 	// Determine CPU Capacities (Heterogeneous Support)
 	// We use the CPU frequency as a proxy for performance capacity.
+	// detectedHeterogeneous is set to true only when cpu_frequency() returns
+	// at least two distinct non-zero values, confirming that the hardware
+	// exposes different core performance tiers. It gates the Alder Lake
+	// fallback heuristic below: without this flag the heuristic would
+	// misclassify any homogeneous system with >8 cores.
+	bool detectedHeterogeneous = false;
 	uint64 maxFreq = 0;
 	uint64* cpuFreqs = new(std::nothrow) uint64[cpuCount];
 	if (cpuFreqs != NULL) {
@@ -1256,6 +1264,7 @@ init()
 			}
 
 			if (heterogeneous) {
+				detectedHeterogeneous = true;
 				dprintf("scheduler: heterogeneous CPUs detected (max frequency: %"
 					B_PRIu64 ")\n", maxFreq);
 
@@ -1329,12 +1338,20 @@ init()
 		}
 	}
 
-	if (coreCount > 8) {
-		// Heuristic workaround for hybrid systems that don't report capacity
-		// through frequencies (e.g., some Intel Alder Lake+ configurations).
-		// We assume that if no heterogeneous capacity was detected but the core
-		// count is high, it's likely a hybrid system where a subset of cores
-		// are Efficiency cores.
+	// Alder Lake fallback heuristic: some hybrid CPUs do not report distinct
+	// frequencies for P-cores and E-cores (the firmware reports the P-core
+	// boost frequency for all entries). The heuristic assumes the last 8 or
+	// 50% of cores (whichever is smaller) are Efficiency cores.
+	//
+	// IMPORTANT: Only apply this when the frequency API actually confirmed
+	// heterogeneity (detectedHeterogeneous == true) but left some cores
+	// unclassified (cpu_frequency() returned 0 for them). If the API
+	// reported identical frequencies for every core, this is a genuinely
+	// homogeneous system and the heuristic must not fire — it would
+	// incorrectly split a 16-core Xeon or 64-core EPYC into fake P/E
+	// clusters, causing artificial load imbalance and misguided thread
+	// coloring with no performance benefit.
+	if (detectedHeterogeneous && coreCount > 8) {
 		bool allUnknown = true;
 		for (int32 i = 0; i < coreCount; i++) {
 			if (gCoreEntries[i].Type() != CORE_TYPE_UNKNOWN) {
@@ -1344,8 +1361,6 @@ init()
 		}
 
 		if (allUnknown) {
-			// Typical configuration: last 8 or 50% are Efficiency cores.
-			// Let's assume a reasonable default for high core count systems.
 			int32 eCoreCount = coreCount > 16 ? 8 : coreCount / 2;
 			for (int32 i = 0; i < coreCount; i++) {
 				if (i >= coreCount - eCoreCount)
@@ -1354,11 +1369,24 @@ init()
 					gCoreEntries[i].SetType(CORE_TYPE_PERFORMANCE);
 			}
 		}
-	} else {
-		// Small systems: assume all are standard cores if not otherwise detected
-		for (int32 i = 0; i < coreCount; i++) {
-			if (gCoreEntries[i].Type() == CORE_TYPE_UNKNOWN)
-				gCoreEntries[i].SetType(CORE_TYPE_STANDARD);
+	}
+
+	// All remaining unclassified cores are STANDARD (covers homogeneous
+	// systems of any size and heterogeneous systems where the heuristic
+	// left some cores unassigned).
+	for (int32 i = 0; i < coreCount; i++) {
+		if (gCoreEntries[i].Type() == CORE_TYPE_UNKNOWN)
+			gCoreEntries[i].SetType(CORE_TYPE_STANDARD);
+	}
+
+	// Detect whether STANDARD cores are present — used in choose_core to
+	// decide if a 3-type intermediate fallback (P → STANDARD → general) is
+	// available, as opposed to a 2-type E+P system where STANDARD is absent.
+	gHasStandardCores = false;
+	for (int32 i = 0; i < coreCount; i++) {
+		if (gCoreEntries[i].Type() == CORE_TYPE_STANDARD) {
+			gHasStandardCores = true;
+			break;
 		}
 	}
 

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -1286,7 +1286,7 @@ init()
 							break;
 						}
 					}
-					if (!found)
+					if (!found && uniqueCapacityCount < SMP_MAX_CPUS)
 						uniqueCapacities[uniqueCapacityCount++] = capacity;
 				}
 
@@ -1343,26 +1343,29 @@ init()
 	// boost frequency for all entries). The heuristic assumes the last 8 or
 	// 50% of cores (whichever is smaller) are Efficiency cores.
 	//
-	// IMPORTANT: Only apply this when the frequency API actually confirmed
-	// heterogeneity (detectedHeterogeneous == true) but left some cores
-	// unclassified (cpu_frequency() returned 0 for them). If the API
-	// reported identical frequencies for every core, this is a genuinely
-	// homogeneous system and the heuristic must not fire — it would
-	// incorrectly split a 16-core Xeon or 64-core EPYC into fake P/E
+	// IMPORTANT: Only apply this when the frequency API either returned no
+	// data at all (maxFreq == 0) OR confirmed heterogeneity
+	// (detectedHeterogeneous == true) but left some cores unclassified.
+	// If the API reported identical frequencies for every core, this is a
+	// genuinely homogeneous system and the heuristic must not fire — it
+	// would incorrectly split a 16-core Xeon or 64-core EPYC into fake P/E
 	// clusters, causing artificial load imbalance and misguided thread
 	// coloring with no performance benefit.
-	if (detectedHeterogeneous && coreCount > 8) {
-		bool allUnknown = true;
+	if ((maxFreq == 0 || detectedHeterogeneous) && coreCount > 8) {
+		bool anyUnknown = false;
 		for (int32 i = 0; i < coreCount; i++) {
-			if (gCoreEntries[i].Type() != CORE_TYPE_UNKNOWN) {
-				allUnknown = false;
+			if (gCoreEntries[i].Type() == CORE_TYPE_UNKNOWN) {
+				anyUnknown = true;
 				break;
 			}
 		}
 
-		if (allUnknown) {
+		if (anyUnknown) {
 			int32 eCoreCount = coreCount > 16 ? 8 : coreCount / 2;
 			for (int32 i = 0; i < coreCount; i++) {
+				if (gCoreEntries[i].Type() != CORE_TYPE_UNKNOWN)
+					continue;
+
 				if (i >= coreCount - eCoreCount)
 					gCoreEntries[i].SetType(CORE_TYPE_EFFICIENCY);
 				else

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -1343,15 +1343,15 @@ init()
 	// boost frequency for all entries). The heuristic assumes the last 8 or
 	// 50% of cores (whichever is smaller) are Efficiency cores.
 	//
-	// IMPORTANT: Only apply this when the frequency API either returned no
-	// data at all (maxFreq == 0) OR confirmed heterogeneity
-	// (detectedHeterogeneous == true) but left some cores unclassified.
-	// If the API reported identical frequencies for every core, this is a
-	// genuinely homogeneous system and the heuristic must not fire — it
-	// would incorrectly split a 16-core Xeon or 64-core EPYC into fake P/E
+	// IMPORTANT: Only apply this when the frequency API actually confirmed
+	// heterogeneity (detectedHeterogeneous == true) but left some cores
+	// unclassified (cpu_frequency() returned 0 for them). If the API
+	// reported identical frequencies for every core, this is a genuinely
+	// homogeneous system and the heuristic must not fire — it would
+	// incorrectly split a 16-core Xeon or 64-core EPYC into fake P/E
 	// clusters, causing artificial load imbalance and misguided thread
 	// coloring with no performance benefit.
-	if ((maxFreq == 0 || detectedHeterogeneous) && coreCount > 8) {
+	if (detectedHeterogeneous && coreCount > 8) {
 		bool anyUnknown = false;
 		for (int32 i = 0; i < coreCount; i++) {
 			if (gCoreEntries[i].Type() == CORE_TYPE_UNKNOWN) {
@@ -1376,28 +1376,18 @@ init()
 
 	// All remaining unclassified cores are STANDARD (covers homogeneous
 	// systems of any size and heterogeneous systems where the heuristic
-	// left some cores unassigned).
+	// left some cores unassigned). We also update the global core type
+	// range and detect whether STANDARD cores exist (enabling 3-type
+	// intermediate fallbacks in choose_core).
+	gHasStandardCores = false;
 	for (int32 i = 0; i < coreCount; i++) {
 		if (gCoreEntries[i].Type() == CORE_TYPE_UNKNOWN)
 			gCoreEntries[i].SetType(CORE_TYPE_STANDARD);
-	}
 
-	// Detect whether STANDARD cores are present — used in choose_core to
-	// decide if a 3-type intermediate fallback (P → STANDARD → general) is
-	// available, as opposed to a 2-type E+P system where STANDARD is absent.
-	gHasStandardCores = false;
-	for (int32 i = 0; i < coreCount; i++) {
-		if (gCoreEntries[i].Type() == CORE_TYPE_STANDARD) {
-			gHasStandardCores = true;
-			break;
-		}
-	}
-
-	// Update gMinCoreType and gMaxCoreType based on assigned types
-	for (int32 i = 0; i < coreCount; i++) {
 		CoreType type = gCoreEntries[i].Type();
-		if (type == CORE_TYPE_UNKNOWN)
-			continue;
+		if (type == CORE_TYPE_STANDARD)
+			gHasStandardCores = true;
+
 		if (gMinCoreType == CORE_TYPE_UNKNOWN || type < gMinCoreType)
 			gMinCoreType = type;
 		if (gMaxCoreType == CORE_TYPE_UNKNOWN || type > gMaxCoreType)

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -153,6 +153,12 @@ extern CoreType gMinCoreType;
 extern CoreType gMaxCoreType;
 
 
+// True when at least one CORE_TYPE_STANDARD core exists. Used by choose_core
+// to decide whether a STANDARD-core intermediate fallback is available for
+// 3-type systems (EFFICIENCY + STANDARD + PERFORMANCE).
+extern bool gHasStandardCores;
+
+
 void init_debug_commands();
 void scheduler_update_interaction_state();
 


### PR DESCRIPTION
Implemented a series of fixes and improvements to the Haiku scheduler to correctly handle various CPU topologies. Key changes include fixing false-positive hybrid detection on large server systems, adding rebalance guards to preserve thread coloring, implementing 3-type intermediate fallbacks, and optimizing small task packing on heterogeneous systems. Verified the changes through manual code review and logical analysis.

---
*PR created automatically by Jules for task [8813093000526429499](https://jules.google.com/task/8813093000526429499) started by @tonestone57*