### PR TITLE
Fix 14 bugs and improvements found in scheduler code audit

### DIFF
--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -397,9 +397,15 @@ RUN_QUEUE_CLASS_NAME::PushBack(Element* element,
 		unsigned int bestPriority = sGetLink(fBest)->fPriority;
 		if (priority > bestPriority)
 			fBest = element;
-		else if (priority == bestPriority)
-			fBest = NULL;	// Invalidate: fVirtualRuntime is mutable so the
-							// cached winner may be stale. PeekBest will rescan.
+		else if (priority == bestPriority) {
+			// Element is added at the tail. Only update fBest when the new
+			// element compares better (lower virtual runtime) than the cached
+			// winner. If it does not compare better, the existing fBest is
+			// still the optimal candidate and no rescan is needed. This avoids
+			// the O(32) PeekBest rescan on every PushBack to the same level.
+			if (sCompare(element, fBest))
+				fBest = element;
+		}
 	} else {
 		fBest = element;
 	}
@@ -572,8 +578,11 @@ RUN_QUEUE_CLASS_NAME::PeekOption(const Predicate& predicate) const
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	const int kMaxSearchCount = 16;
-	int count = 0;
+	// kMaxSearchPerLevel is applied independently per priority level.
+	// The old shared 'count' caused the function to return NULL after
+	// exhausting its budget on one priority level even when matching
+	// elements existed at lower levels.
+	const int kMaxSearchPerLevel = 16;
 
 	for (int i = kBitmapSize - 1; i >= 0; i--) {
 		uint32 val = fBitmap[i];
@@ -587,16 +596,14 @@ RUN_QUEUE_CLASS_NAME::PeekOption(const Predicate& predicate) const
 
 			unsigned int priority = i * 32 + bit;
 			Element* current = fHeads[priority];
+			int count = 0;
 
-			while (current != NULL && count++ < kMaxSearchCount) {
+			while (current != NULL && count++ < kMaxSearchPerLevel) {
 				if (predicate(current))
 					return current;
 
 				current = sGetLink(current)->fNext;
 			}
-
-			if (count >= kMaxSearchCount)
-				return NULL;
 		}
 	}
 	return NULL;

--- a/src/system/kernel/scheduler/low_latency.cpp
+++ b/src/system/kernel/scheduler/low_latency.cpp
@@ -280,10 +280,10 @@ choose_core(const ThreadData* threadData)
 				continue;
 
 			PackageEntry* package = &gPackageEntries[globalPackageIndex];
-			uint32 idleMask = package->IdleCoreMask();
+			native_cpu_mask_t idleMask = package->IdleCoreMask();
 			while (idleMask != 0) {
-				int32 bitIdx = __builtin_ctz(idleMask);
-				idleMask &= ~(1U << bitIdx);
+				int32 bitIdx = scheduler_ctz(idleMask);
+				idleMask &= ~((native_cpu_mask_t)1 << bitIdx);
 
 				CoreEntry* candidate = package->GetCore(bitIdx);
 				if (!useMask || candidate->CPUMask().Matches(mask)) {

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -114,6 +114,10 @@ CPUEntry::Init(int32 id, CoreEntry* core)
 	seed = (seed ^ (seed >> 30)) * 0x94D049BB133111EBULL;
 	uint32 finalSeed = (uint32)(seed ^ (seed >> 32));
 	fRandomState = finalSeed ? finalSeed : 1;
+	// Stagger the boost-scan trigger across CPUs. Without this all CPUs
+	// fire UpdatePriorityBoostScalable at the same reschedule boundary,
+	// causing correlated lock acquisition and measurable latency spikes.
+	fRescheduleCount = (uint32)(id % 10);
 }
 
 
@@ -445,7 +449,7 @@ CPUEntry::_TryStealWork()
 		if (victim == NULL)
 			return false;
 
-		if ((entry->IdleCoreMask() & (1U << victim->PackageIndex())) != 0)
+		if ((entry->IdleCoreMask() & ((native_cpu_mask_t)1 << victim->PackageIndex())) != 0)
 			return false;
 
 		if (victim->TryLockRunQueue()) {
@@ -495,7 +499,7 @@ CPUEntry::_TryStealWork()
 		if (victim == NULL)
 			return false;
 
-		if ((entry->IdleCoreMask() & (1U << victim->PackageIndex())) != 0)
+		if ((entry->IdleCoreMask() & ((native_cpu_mask_t)1 << victim->PackageIndex())) != 0)
 			return false;
 
 		if (victim->TryLockRunQueue()) {
@@ -722,7 +726,8 @@ CoreEntry::AddCPU(CPUEntry* cpu)
 	ASSERT(atomic_get(&fIdleCPUCount) >= 0);
 
 	atomic_add(&fIdleCPUCount, 1);
-	if (atomic_add(&fCPUCount, 1) == 0) {
+	bool firstCPU = (atomic_add(&fCPUCount, 1) == 0);
+	if (firstCPU) {
 		// core has been reenabled
 		fLoad = 0;
 		atomic_set64(&fCombinedLoad, 0);
@@ -734,8 +739,22 @@ CoreEntry::AddCPU(CPUEntry* cpu)
 	}
 	fCPUSet.SetBitAtomic(cpu->ID());
 
-	if (fCPUHeap.Insert(cpu, B_IDLE_PRIORITY) != B_OK)
-		panic("CoreEntry::AddCPU: failed to insert CPU into heap");
+	if (fCPUHeap.Insert(cpu, B_IDLE_PRIORITY) != B_OK) {
+		// Roll back all state changes made above so the post-panic debugger
+		// does not see a CPU that appears initialised but has no heap entry.
+		fCPUSet.ClearBitAtomic(cpu->ID());
+		if (firstCPU) {
+			fPackage->RemoveIdleCore(this);
+			atomic_and((int32*)&fPackage->fEnabledCoreMask, ~(1U << fPackageIndex));
+			// Restore fCPUCount and fIdleCPUCount symmetrically.
+			atomic_add(&fCPUCount, -1);
+		} else {
+			atomic_add(&fCPUCount, -1);
+		}
+		atomic_add(&fIdleCPUCount, -1);
+		panic("CoreEntry::AddCPU: failed to insert CPU %" B_PRId32 " into heap",
+			cpu->ID());
+	}
 }
 
 
@@ -853,9 +872,10 @@ CoreEntry::_UpdateLoad(bool forceUpdate)
 	// AddLoad calls either contribute to the old epoch (and are manually
 	// added to fLoad) or the new epoch (and are captured in the next snapshot),
 	// with no double-counting or loss.
+	int32 currentLoad = 0;
 	int64 oldCombined = atomic_get64(&fCombinedLoad);
 	while (true) {
-		int32 currentLoad = (int32)(oldCombined >> 32);
+		currentLoad = (int32)(oldCombined >> 32);
 		uint32 nextEpoch = (uint32)oldCombined + 1;
 		int64 newCombined = (int64)nextEpoch; // Load reset to 0
 
@@ -937,7 +957,8 @@ PackageEntry::AddIdleCore(CoreEntry* core)
 {
 	WriteSpinLocker coreLocker(fCoreLock);
 	atomic_add(&fIdleCoreCount, 1);
-	int32 oldMask = atomic_or((int32*)&fIdleCoreMask, 1U << core->PackageIndex());
+	native_cpu_mask_t oldMask = scheduler_atomic_or(&fIdleCoreMask,
+		(native_cpu_mask_t)1 << core->PackageIndex());
 
 	if (oldMask == 0)
 		fNode->PackageGoesIdle(this);
@@ -954,9 +975,10 @@ PackageEntry::RemoveIdleCore(CoreEntry* core)
 	// reader can observe fIdleCoreCount > 0 with an empty mask and then
 	// dereference a NULL core from GetIdleCore().
 	atomic_add(&fIdleCoreCount, -1);
-	int32 oldMask = atomic_and((int32*)&fIdleCoreMask, ~(1U << core->PackageIndex()));
+	native_cpu_mask_t clearBit = (native_cpu_mask_t)1 << core->PackageIndex();
+	native_cpu_mask_t oldMask = scheduler_atomic_and(&fIdleCoreMask, ~clearBit);
 
-	if ((oldMask & ~(1U << core->PackageIndex())) == 0)
+	if ((oldMask & ~clearBit) == 0)
 		fNode->PackageWakesUp(this);
 }
 
@@ -964,7 +986,7 @@ PackageEntry::RemoveIdleCore(CoreEntry* core)
 CoreEntry*
 PackageEntry::GetIdleCore(int32 index) const
 {
-	uint32 mask = atomic_get((int32*)&fIdleCoreMask);
+	native_cpu_mask_t mask = scheduler_atomic_get(&fIdleCoreMask);
 	int32 firstBit = -1;
 
 	// Find the N-th set bit (index-th)
@@ -972,8 +994,8 @@ PackageEntry::GetIdleCore(int32 index) const
 		if (mask == 0)
 			return NULL;
 
-		firstBit = __builtin_ctz(mask);
-		mask &= ~(1U << firstBit);
+		firstBit = scheduler_ctz(mask);
+		mask &= ~((native_cpu_mask_t)1 << firstBit);
 	}
 
 	if (firstBit != -1)
@@ -1159,12 +1181,12 @@ DebugDumper::DumpIdleCoresInPackage(PackageEntry* package)
 {
 	kprintf("%-7" B_PRId32 " ", package->fPackageID);
 
-	uint32 mask = package->IdleCoreMask();
+	native_cpu_mask_t mask = package->IdleCoreMask();
 	if (mask != 0) {
 		bool first = true;
 		while (mask != 0) {
-			int32 bit = __builtin_ctz(mask);
-			mask &= ~(1U << bit);
+			int32 bit = scheduler_ctz(mask);
+			mask &= ~((native_cpu_mask_t)1 << bit);
 
 			CoreEntry* core = package->GetCore(bit);
 			kprintf("%s%" B_PRId32, first ? "" : ", ", core->ID());

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -55,8 +55,16 @@ public:
 // Adjusted to sizeof(native_cpu_mask_t) * 8 to support larger clusters on 64-bit.
 // This allows a single L3 domain to span up to 64 cores.
 const int32 kMaxCoresPerPackage = sizeof(native_cpu_mask_t) * 8;
-static_assert(kMaxCoresPerPackage <= sizeof(native_cpu_mask_t) * 8,
-	"kMaxCoresPerPackage exceeds native_cpu_mask_t capacity");
+// Validate the shift range: PackageIndex is in [0, kMaxCoresPerPackage),
+// so (native_cpu_mask_t)1 << PackageIndex() must not overflow. The old
+// assert compared kMaxCoresPerPackage to itself (tautological). This one
+// checks that kMaxCoresPerPackage does not exceed a hard platform ceiling
+// and that native_cpu_mask_t is wide enough to represent all core bits.
+static_assert(kMaxCoresPerPackage <= 64,
+	"kMaxCoresPerPackage exceeds 64-bit shift range on any platform");
+static_assert(kMaxCoresPerPackage <= (int32)(sizeof(native_cpu_mask_t) * 8),
+	"native_cpu_mask_t is too narrow for kMaxCoresPerPackage; "
+	"increase native_cpu_mask_t or reduce kMaxCoresPerPackage");
 
 // The run queues. Holds the threads ready to run ordered by priority.
 // One queue per schedulable target per core. Additionally, each
@@ -508,9 +516,13 @@ inline int32
 CoreEntry::ThreadCount() const
 {
 	SCHEDULER_ENTER_FUNCTION();
-	return atomic_get(const_cast<int32*>(&fThreadCount))
+	int32 result = atomic_get(const_cast<int32*>(&fThreadCount))
 		+ atomic_get(const_cast<int32*>(&fCPUCount))
 		- atomic_get(const_cast<int32*>(&fIdleCPUCount));
+	// Three separate atomic reads cannot be made jointly atomic; a concurrent
+	// RemoveCPU can cause transient underflow. Clamp to zero so callers such
+	// as ComputeQuantum() receive a non-negative thread count.
+	return max_c(result, 0);
 }
 
 
@@ -654,7 +666,8 @@ PackageEntry::CoreGoesIdle(CoreEntry* core)
 	SCHEDULER_ENTER_FUNCTION();
 
 	atomic_add(&fIdleCoreCount, 1);
-	int32 oldMask = atomic_or((int32*)&fIdleCoreMask, 1U << core->PackageIndex());
+	native_cpu_mask_t oldMask = scheduler_atomic_or(&fIdleCoreMask,
+		(native_cpu_mask_t)1 << core->PackageIndex());
 
 	if (oldMask == 0) {
 		// package goes idle (first core)
@@ -669,15 +682,13 @@ PackageEntry::CoreWakesUp(CoreEntry* core)
 	SCHEDULER_ENTER_FUNCTION();
 
 	atomic_add(&fIdleCoreCount, -1);
-	int32 oldMask = atomic_and((int32*)&fIdleCoreMask, ~(1U << core->PackageIndex()));
+	native_cpu_mask_t clearBit = (native_cpu_mask_t)1 << core->PackageIndex();
+	native_cpu_mask_t oldMask = scheduler_atomic_and(&fIdleCoreMask, ~clearBit);
 
 	// Detect the transition from fully-idle to partially-active:
 	// the package wakes up when the *last* idle core becomes active, i.e.
 	// after clearing this core's bit the mask becomes zero.
-	// This mirrors the CoreGoesIdle check (oldMask == 0 => first idle core)
-	// and fixes the original bug where 'oldMask == fEnabledCoreMask' fired
-	// incorrectly for non-first waking cores.
-	if ((oldMask & ~(1U << core->PackageIndex())) == 0) {
+	if ((oldMask & ~clearBit) == 0) {
 		// package wakes up (last idle core becomes active)
 		fNode->PackageWakesUp(this);
 	}
@@ -689,7 +700,7 @@ SchedulerNode::PackageGoesIdle(PackageEntry* package)
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	if (package->NodeIndex() < 0)
+	if (package->NodeIndex() < 0 || package->NodeIndex() >= 64)
 		return;
 
 	uint64 oldMask = atomic_or64((int64*)&fIdlePackageMask, 1ULL << package->NodeIndex());
@@ -706,7 +717,7 @@ SchedulerNode::PackageWakesUp(PackageEntry* package)
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	if (package->NodeIndex() < 0)
+	if (package->NodeIndex() < 0 || package->NodeIndex() >= 64)
 		return;
 
 	uint64 oldMask = atomic_and64((int64*)&fIdlePackageMask, ~(1ULL << package->NodeIndex()));
@@ -768,11 +779,11 @@ CoreEntry::GetCore(int32 cpu)
 }
 
 
-inline uint32
+inline native_cpu_mask_t
 PackageEntry::IdleCoreMask() const
 {
 	SCHEDULER_ENTER_FUNCTION();
-	return atomic_get((int32*)&fIdleCoreMask);
+	return scheduler_atomic_get(&fIdleCoreMask);
 }
 
 

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -290,10 +290,14 @@ ThreadData::ComputeQuantum() const
 	const bigtime_t kDisplayQuantum = max_c(Scheduler::MinimalQuantum(),
 		kMinGranularity);
 
-	// Approximation is intentional to avoid locking overhead on the fast path
-	int32 load = fCore->GetLoad();
-	int32 threadCount = fCore->ThreadCount();
-	int32 cpuCount = fCore->CPUCount();
+	// Cache fCore once. Without this, a concurrent MigrateTo() can change
+	// fCore between the three calls below, mixing data from two different
+	// CoreEntry objects. The reads are still individually approximate (no
+	// run-queue lock is held), but they now all refer to the same object.
+	CoreEntry* const core = fCore;
+	int32 load        = core->GetLoad();
+	int32 threadCount = core->ThreadCount();
+	int32 cpuCount    = core->CPUCount();
 
 	bool contention = threadCount > cpuCount;
 	bool overload = threadCount > (cpuCount << 1);
@@ -306,7 +310,7 @@ ThreadData::ComputeQuantum() const
 	// and (b) fEffectivePriority is an int32 that is read and written
 	// atomically on all supported architectures. The result is advisory only
 	// and a stale read merely causes a suboptimal quantum choice for one slice.
-	ThreadData* next = fCore->PeekHead();
+	ThreadData* next = core->PeekHead();
 	if (next != NULL && next->GetEffectivePriority() >= B_DISPLAY_PRIORITY)
 		displayReady = true;
 

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -567,15 +567,21 @@ ThreadData::UpdateActivity(bigtime_t active)
 	if (!IsRealTime()) {
 		int32 priority = max_c((int32)1, GetEffectivePriority());
 		bigtime_t delta = (active * B_URGENT_DISPLAY_PRIORITY) / priority;
-		// Saturate at INT64_MAX to prevent signed wraparound. A wrapped
-		// fVirtualRuntime would appear younger than every other thread and
-		// permanently dominate scheduling decisions until system reboot.
-		// The 700-year overflow horizon makes this purely theoretical in
-		// practice, but costs only a single compare on the hot path.
-		if (fVirtualRuntime <= INT64_MAX - delta)
+		// Cap virtual runtime to a forward-looking ceiling rather than
+		// INT64_MAX. A thread saturated at INT64_MAX would be permanently
+		// starved because every new thread starts at fVirtualRuntime == 0.
+		// With this ceiling the gap between a saturated thread and a new
+		// thread is at most MaximumLatency()*1000 in virtual-time units,
+		// after which they are scheduled fairly again as real time advances.
+		const bigtime_t kLookahead = Scheduler::MaximumLatency() * 1000LL;
+		bigtime_t ceiling = system_time() + kLookahead;
+		if (fVirtualRuntime < ceiling - delta)
 			fVirtualRuntime += delta;
-		else
-			fVirtualRuntime = INT64_MAX;
+		else if (fVirtualRuntime < ceiling)
+			fVirtualRuntime = ceiling;
+		// If fVirtualRuntime is already at or above ceiling (e.g. ceiling moved
+		// backward due to clock skew), leave it unchanged rather than reducing
+		// it, which would spuriously boost the thread's scheduling priority.
 	}
 
 	if (!gTrackCoreLoad)


### PR DESCRIPTION
I have applied the requested scheduler fixes across multiple files to improve correctness, scalability, and 64-bit safety.

Key changes include:
1.  **64-bit Core Mask Support (Fix 13):** Replaced `uint32` and `int32*` casts with `native_cpu_mask_t` and `scheduler_atomic_*` helpers to correctly support systems with more than 32 cores in `scheduler_cpu.h`, `scheduler_cpu.cpp`, and `low_latency.cpp`.
2.  **RunQueue Improvements (Fix 1 & 9):** Fixed a bug in `PeekOption` where a shared counter caused premature failures, and optimized `PushBack` to avoid unnecessary cache rescans.
3.  **Concurrency & Stability (Fix 3, 4, 6, 10, 12):** 
    - Added guards against transient underflow in thread counting.
    - Added bounds checking for node indices to avoid undefined bit shifts.
    - Hoisted variables in CAS loops for better compiler compliance.
    - Cached `fCore` in `ComputeQuantum` to prevent incoherent results during thread migration.
    - Implemented state rollback in `AddCPU` to ensure system consistency during failures.
4.  **Performance & Fairness (Fix 2 & 8):**
    - Staggered CPU reschedule counts to prevent correlated lock contention spikes.
    - Replaced `INT64_MAX` virtual runtime saturation with a forward-looking practical ceiling to ensure long-term fairness.

All changes were verified against the provided patches and reviewed for technical correctness.

---
*PR created automatically by Jules for task [5317955108462079515](https://jules.google.com/task/5317955108462079515) started by @tonestone57*