### PR TITLE
Fix scheduler analysis and improve atomic mask operations

### DIFF
--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -733,7 +733,8 @@ CoreEntry::AddCPU(CPUEntry* cpu)
 		atomic_set64(&fCombinedLoad, 0);
 
 		atomic_set(&fPackage->fCoreLoads[fPackageIndex], 0);
-		atomic_or((int32*)&fPackage->fEnabledCoreMask, 1U << fPackageIndex);
+		scheduler_atomic_or(&fPackage->fEnabledCoreMask,
+			(native_cpu_mask_t)1 << fPackageIndex);
 
 		fPackage->AddIdleCore(this);
 	}
@@ -745,7 +746,8 @@ CoreEntry::AddCPU(CPUEntry* cpu)
 		fCPUSet.ClearBitAtomic(cpu->ID());
 		if (firstCPU) {
 			fPackage->RemoveIdleCore(this);
-			atomic_and((int32*)&fPackage->fEnabledCoreMask, ~(1U << fPackageIndex));
+			scheduler_atomic_and(&fPackage->fEnabledCoreMask,
+				~((native_cpu_mask_t)1 << fPackageIndex));
 			// Restore fCPUCount and fIdleCPUCount symmetrically.
 			atomic_add(&fCPUCount, -1);
 		} else {
@@ -771,7 +773,8 @@ CoreEntry::RemoveCPU(CPUEntry* cpu, ThreadProcessing& threadPostProcessing)
 	fCPUSet.ClearBitAtomic(cpu->ID());
 	if (atomic_add(&fCPUCount, -1) == 1) {
 		// core has been disabled
-		atomic_and((int32*)&fPackage->fEnabledCoreMask, ~(1U << fPackageIndex));
+		scheduler_atomic_and(&fPackage->fEnabledCoreMask,
+			~((native_cpu_mask_t)1 << fPackageIndex));
 		fPackage->RemoveIdleCore(this);
 
 		// get rid of threads

--- a/src/system/kernel/scheduler/scheduling_analysis.cpp
+++ b/src/system/kernel/scheduler/scheduling_analysis.cpp
@@ -81,7 +81,7 @@ struct Thread : HashObject, scheduling_analysis_thread {
 
 		runs = 0;
 		total_run_time = 0;
-		min_run_time = 1;
+		min_run_time = -1;
 		max_run_time = -1;
 
 		latencies = 0;


### PR DESCRIPTION
This change applies a patch to the Haiku scheduler to improve the correctness of scheduling analysis and the safety of atomic operations on CPU masks. Specifically, it ensures that `min_run_time` is initialized to -1 in `scheduling_analysis.cpp` and utilizes the `scheduler_atomic_*` helper functions for manipulating `fEnabledCoreMask` in `scheduler_cpu.cpp`, avoiding unsafe pointer casts and ensuring compatibility with 64-bit CPU masks.

---
*PR created automatically by Jules for task [6548445641524726389](https://jules.google.com/task/6548445641524726389) started by @tonestone57*