### PR TITLE
Scheduler Robustness and RunQueue Access Improvements

### DIFF
--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -689,7 +689,12 @@ rebalance_irqs(bool idle)
 	cpu_ent* cpu = get_cpu_struct();
 	CoreEntry* currentCore = CoreEntry::GetCore(cpu->cpu_num);
 
-	if (pack && sSmallTaskCore != NULL && currentCore != NULL) {
+	// Package() and Node() can be NULL during topology teardown or if a core
+	// was never fully initialised (e.g. it exceeded kMaxCoresPerPackage and
+	// its Init() was skipped).  Defend all three pointer dereferences.
+	if (pack && sSmallTaskCore != NULL && currentCore != NULL
+			&& currentCore->Package() != NULL
+			&& currentCore->Package()->Node() != NULL) {
 		int32 nodeID = currentCore->Package()->Node()->ID();
 		if (atomic_pointer_get(&sSmallTaskCore[nodeID]) == currentCore)
 			return;

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -1065,7 +1065,12 @@ PackageEntry::PeekMinimumLoadCore(const CPUSet* mask, CoreType type) const
 			if (!(((native_cpu_mask_t)1 << i) & enabledMask))
 				continue;
 
+			// fCores[i] is set by RegisterCore; an enabled bit implies the
+			// core was registered, but guard defensively against a transient
+			// window where the bit is set before the pointer is written.
 			CoreEntry* candidate = fCores[i];
+			if (candidate == NULL)
+				continue;
 			if (mask != NULL && !mask->GetBit(candidate->ID()))
 				continue;
 			if (type != CORE_TYPE_UNKNOWN && candidate->Type() != type)

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -110,6 +110,9 @@ public:
 						void			Remove(ThreadData* thread);
 						ThreadData*		PeekThread() const;
 						ThreadData*		PeekIdleThread() const;
+						// Required by UpdatePriorityBoostScalable in scheduler.cpp,
+						// which inspects the run queue bitmap directly for priority boosting.
+	inline				const ThreadRunQueue*	RunQueue() const { return &fRunQueue; }
 
 	inline				ThreadRunQueue::ConstIterator
 										GetConstIterator() const
@@ -227,6 +230,7 @@ public:
 						ThreadData*		PeekThread() const;
 	inline				ThreadData*		PeekHead() const
 											{ return fRunQueue.PeekMaximum(); }
+	inline				const ThreadRunQueue*	RunQueue() const { return &fRunQueue; }
 
 	inline				ThreadRunQueue::ConstIterator
 										GetConstIterator() const

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -190,8 +190,11 @@ ThreadData::PreviousCore() const
 	if (fThread->previous_cpu == NULL)
 		return NULL;
 
+	// Core() can transiently return NULL during hot-unplug: the CPUEntry's
+	// fCore pointer is cleared before the CPU is fully removed from its
+	// package.  Guard against this before dereferencing.
 	CoreEntry* core = CPUEntry::GetCPU(fThread->previous_cpu->cpu_num)->Core();
-	if (core->CPUCount() <= 0)
+	if (core == NULL || core->CPUCount() <= 0)
 		return NULL;
 
 	return core;


### PR DESCRIPTION
Applied defensive programming improvements to the Haiku scheduler to prevent NULL pointer dereferences during CPU hot-unplugging and topology changes. Also exposed the RunQueue accessor needed for priority boosting. Verified changes via code review and manual inspection.

---
*PR created automatically by Jules for task [16016759474086932411](https://jules.google.com/task/16016759474086932411) started by @tonestone57*