### PR TITLE
Fix multiple kernel scheduler race conditions and logic bugs

### DIFF
--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -356,16 +356,9 @@ RUN_QUEUE_CLASS_NAME::PushFront(Element* element,
 	if (fBest != NULL) {
 		unsigned int bestPriority = sGetLink(fBest)->fPriority;
 		if (priority > bestPriority)
-			// New element is at a strictly higher priority level so it always
-			// wins regardless of virtual runtime.  However, set fBest only if
-			// there is no existing element already at this priority (if there
-			// is, a same-priority compare is needed and we must rescan).
-			// Actually: PushFront inserts at HEAD of the priority list.  If
-			// something was already at 'priority', fBest would have had
-			// bestPriority == priority which is handled by the else-if below.
-			// So priority > bestPriority means this is the only element at a
-			// new peak level — it wins unconditionally.
-			fBest = element;  // correct: strictly highest level, no peers yet
+			fBest = element;
+		else if (priority == bestPriority && sCompare(element, fBest))
+			fBest = element;
 		else
 			fBest = NULL;	// Invalidate: fVirtualRuntime is mutable so the
 							// cached winner may be stale. PeekBest will rescan.

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -1151,13 +1151,9 @@ init()
 
 	// These arrays are only used for initialization and can be freed now.
 	ArrayDeleter<int32> cpuToCoreDeleter(sCPUToCore);
-	sCPUToCore = NULL;
 	ArrayDeleter<int32> cpuToPackageDeleter(sCPUToPackage);
-	sCPUToPackage = NULL;
 	ArrayDeleter<int32> cpuToClusterDeleter(sCPUToCluster);
-	sCPUToCluster = NULL;
 	ArrayDeleter<int32> packageToNodeDeleter(sPackageToNode);
-	sPackageToNode = NULL;
 
 	if (packageCount > 4096) {
 		dprintf("scheduler: system has too many packages (%" B_PRId32 " > 4096). "
@@ -1485,6 +1481,11 @@ init()
 	cpuEntriesDeleter.Detach();
 	coreEntriesDeleter.Detach();
 	packageEntriesDeleter.Detach();
+
+	sCPUToCore = NULL;
+	sCPUToPackage = NULL;
+	sCPUToCluster = NULL;
+	sPackageToNode = NULL;
 
 	return B_OK;
 }

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -899,6 +899,11 @@ traverse_topology_tree(const cpu_topology_node* node, int packageID, int coreID,
 					B_PRId32 ")\n", node->id, cpuCount);
 				return;
 			}
+			if (coreID >= cpuCount) {
+				dprintf("scheduler: core index %d out of bounds (max %"
+					B_PRId32 ")\n", coreID, cpuCount);
+				return;
+			}
 			sCPUToCore[node->id] = coreID;
 			sCPUToPackage[node->id] = packageID;
 			if (sCPUToCluster != NULL)
@@ -1146,9 +1151,13 @@ init()
 
 	// These arrays are only used for initialization and can be freed now.
 	ArrayDeleter<int32> cpuToCoreDeleter(sCPUToCore);
+	sCPUToCore = NULL;
 	ArrayDeleter<int32> cpuToPackageDeleter(sCPUToPackage);
+	sCPUToPackage = NULL;
 	ArrayDeleter<int32> cpuToClusterDeleter(sCPUToCluster);
+	sCPUToCluster = NULL;
 	ArrayDeleter<int32> packageToNodeDeleter(sPackageToNode);
+	sPackageToNode = NULL;
 
 	if (packageCount > 4096) {
 		dprintf("scheduler: system has too many packages (%" B_PRId32 " > 4096). "

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -1006,9 +1006,9 @@ void
 PackageEntry::AddIdleCore(CoreEntry* core)
 {
 	WriteSpinLocker coreLocker(fCoreLock);
-	atomic_add(&fIdleCoreCount, 1);
 	native_cpu_mask_t oldMask = scheduler_atomic_or(&fIdleCoreMask,
 		(native_cpu_mask_t)1 << core->PackageIndex());
+	atomic_add(&fIdleCoreCount, 1);
 
 	if (oldMask == 0) {
 		// Package goes idle (first idle core).  Delegate entirely to

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -127,11 +127,6 @@ CPUEntry::Init(int32 id, CoreEntry* core)
 
 
 void
-
-
-
-
-void
 CPUEntry::Start()
 {
 	fThreadCount = 0;
@@ -915,6 +910,12 @@ CoreEntry::_UpdateLoad(bool forceUpdate)
 		uint32 nextEpoch = (uint32)oldCombined + 1;
 		int64 newCombined = (int64)nextEpoch; // Load reset to 0
 
+		// Read fLoad BEFORE the CAS. Concurrent AddLoad() calls that detect the
+		// epoch change AFTER the CAS will do atomic_add(&fLoad, load) directly.
+		// By reading it here, we ensure that any load added to fLoad before
+		// we reset fCombinedLoad is accounted for in our delta calculation.
+		int32 prevLoad = atomic_get(&fLoad);
+
 		int64 actual = atomic_test_and_set64(&fCombinedLoad, newCombined,
 			oldCombined);
 		if (actual == oldCombined) {
@@ -926,10 +927,7 @@ CoreEntry::_UpdateLoad(bool forceUpdate)
 			// contributions for threads that woke up in this window.
 			//
 			// Instead, compute the delta from the last snapshotted value and
-			// add it atomically.  We read fLoad before the CAS; the delta
-			// is (currentLoad - prevLoad).  Any concurrent atomic_add between
-			// the read and here adds on top, which is the desired behaviour.
-			int32 prevLoad = atomic_get(&fLoad);
+			// add it atomically.
 			int32 delta = currentLoad - prevLoad;
 			if (delta != 0)
 				atomic_add(&fLoad, delta);

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -679,13 +679,14 @@ PackageEntry::CoreGoesIdle(CoreEntry* core)
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	atomic_add(&fIdleCoreCount, 1);
 	native_cpu_mask_t oldMask = scheduler_atomic_or(&fIdleCoreMask,
 		(native_cpu_mask_t)1 << core->PackageIndex());
+	atomic_add(&fIdleCoreCount, 1);
 
 	if (oldMask == 0) {
 		// package goes idle (first core)
-		fNode->PackageGoesIdle(this);
+		if (fNode != NULL)
+			fNode->PackageGoesIdle(this);
 	}
 }
 
@@ -695,7 +696,9 @@ PackageEntry::CoreWakesUp(CoreEntry* core)
 {
 	SCHEDULER_ENTER_FUNCTION();
 
+	// Decrement the count BEFORE clearing the mask bit.
 	atomic_add(&fIdleCoreCount, -1);
+
 	native_cpu_mask_t clearBit = (native_cpu_mask_t)1 << core->PackageIndex();
 	native_cpu_mask_t oldMask = scheduler_atomic_and(&fIdleCoreMask, ~clearBit);
 
@@ -704,7 +707,8 @@ PackageEntry::CoreWakesUp(CoreEntry* core)
 	// after clearing this core's bit the mask becomes zero.
 	if ((oldMask & ~clearBit) == 0) {
 		// package wakes up (last idle core becomes active)
-		fNode->PackageWakesUp(this);
+		if (fNode != NULL)
+			fNode->PackageWakesUp(this);
 	}
 }
 
@@ -773,16 +777,13 @@ CoreEntry::CPUWakesUp(CPUEntry* /* cpu */)
 
 	ASSERT(atomic_get(&fIdleCPUCount) > 0);
 
-	// Capture the old idle count atomically, then read fCPUCount afterwards.
-	// Reading fCPUCount before the atomic_add creates a window where a
-	// concurrent RemoveCPU can decrement fCPUCount between our read and our
-	// add, producing a stale comparison.  Reading it after narrows the window:
-	// if RemoveCPU has already decremented fCPUCount it will call
-	// RemoveIdleCore directly, so missing the CoreWakesUp transition here is
-	// safe.
+	// Snapshot fCPUCount before the atomic_add. Reading it after creates a
+	// window where a concurrent RemoveCPU can decrement fCPUCount, leading
+	// to a spurious CoreWakesUp call if oldIdleCount matches the new,
+	// smaller fCPUCount.
+	int32 cpuCount = atomic_get(&fCPUCount);
 	atomic_add(&fTotalThreadCount, 1);
-	int32 oldIdleCount = atomic_add(&fIdleCPUCount, -1);
-	if (oldIdleCount == atomic_get(&fCPUCount))
+	if (atomic_add(&fIdleCPUCount, -1) == cpuCount)
 		fPackage->CoreWakesUp(this);
 }
 


### PR DESCRIPTION
Multiple fixes for the Haiku kernel scheduler addressing race conditions in idle transitions and load tracking, memory safety during initialization, and logic errors in the run queue and topology mapping.

---
*PR created automatically by Jules for task [8279208827756736841](https://jules.google.com/task/8279208827756736841) started by @tonestone57*