### PR TITLE
Fix Scheduler Races, Stability, and Performance Bottlenecks

### DIFF
--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -584,7 +584,8 @@ RUN_QUEUE_CLASS_NAME::PeekOption(const Predicate& predicate) const
 
 	// Scale search depth based on system size.
 	// More cores = more budget to find better affinity.
-	const int kMaxSearchPerLevel = 16 + (smp_get_num_cpus() >> 3);
+	static const int kNumCPUs = smp_get_num_cpus();
+	const int kMaxSearchPerLevel = 16 + (kNumCPUs >> 3);
 
 	int totalBudget = kMaxSearchPerLevel * 2;
 

--- a/src/system/kernel/scheduler/low_latency.cpp
+++ b/src/system/kernel/scheduler/low_latency.cpp
@@ -51,13 +51,14 @@ choose_core(const ThreadData* threadData)
 {
 	SCHEDULER_ENTER_FUNCTION();
 
+	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
 	CoreEntry* previousCore = threadData->PreviousCore();
 
 	// Stage 0: Hot-Idle Fast Path
 	// If the core we previously ran on is idle and in the same package,
 	// use it immediately to preserve cache warmth and skip expensive search.
 	if (previousCore != NULL && previousCore->GetScore() == 0) {
-		if (previousCore->Package() == CoreEntry::GetCore(smp_get_current_cpu())->Package())
+		if (previousCore->Package() == cpu->Core()->Package())
 			return previousCore;
 	}
 
@@ -157,7 +158,7 @@ choose_core(const ThreadData* threadData)
 					continue;
 
 				PackageEntry* package = &gPackageEntries[globalPackageIndex];
-				core = package->PeekMinimumLoadCore(&mask, preferredType);
+				core = package->PeekMinimumLoadCore(cpu, &mask, preferredType);
 				if (core != NULL && core->GetLoad() == 0)
 					break;
 				core = NULL;
@@ -172,25 +173,25 @@ choose_core(const ThreadData* threadData)
 			bool tryRandom = gPackageCount > kRandomSearchThreshold;
 			if (tryRandom && !useMask) {
 				search_global_random([&](PackageEntry* entry) {
-					CheckPackageMinimumLoad(entry, NULL, core, bestScore,
+					CheckPackageMinimumLoad(cpu, entry, NULL, core, bestScore,
 						preferredType);
 					return false;
 				});
 			} else if (useMask) {
-				CheckMaskedPackagesMinimumLoad(mask, core, bestScore,
+				CheckMaskedPackagesMinimumLoad(cpu, mask, core, bestScore,
 					preferredType);
 			}
 
 			if (core == NULL && !useMask) {
-				int32 startIndex = tryRandom ? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom() % gPackageCount : 0;
+				int32 startIndex = tryRandom ? cpu->GetRandom() % gPackageCount : 0;
 				int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
 
 				for (int32 i = 0; i < attempts; i++) {
 					int32 index = startIndex + i;
 					if (index >= gPackageCount)
 						index -= gPackageCount;
-					CheckPackageMinimumLoad(&gPackageEntries[index], NULL, core,
-						bestScore, preferredType);
+					CheckPackageMinimumLoad(cpu, &gPackageEntries[index], NULL,
+						core, bestScore, preferredType);
 				}
 			}
 
@@ -222,27 +223,26 @@ choose_core(const ThreadData* threadData)
 
 			if (tryRandomStd && !useMask) {
 				search_global_random([&](PackageEntry* entry) {
-					CheckPackageMinimumLoad(entry, NULL, core, stdBestScore,
+					CheckPackageMinimumLoad(cpu, entry, NULL, core, stdBestScore,
 						CORE_TYPE_STANDARD);
 					return false;
 				});
 			} else if (useMask) {
-				CheckMaskedPackagesMinimumLoad(mask, core, stdBestScore,
+				CheckMaskedPackagesMinimumLoad(cpu, mask, core, stdBestScore,
 					CORE_TYPE_STANDARD);
 			}
 
 			if (core == NULL && !useMask) {
 				int32 startIndex2 = tryRandomStd
-					? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom()
-						% gPackageCount
+					? cpu->GetRandom() % gPackageCount
 					: 0;
 				int32 attempts2 = min_c(gPackageCount, kMaxFallbackAttempts);
 				for (int32 i = 0; i < attempts2; i++) {
 					int32 index = startIndex2 + i;
 					if (index >= gPackageCount)
 						index -= gPackageCount;
-					CheckPackageMinimumLoad(&gPackageEntries[index], NULL, core,
-						stdBestScore, CORE_TYPE_STANDARD);
+					CheckPackageMinimumLoad(cpu, &gPackageEntries[index], NULL,
+						core, stdBestScore, CORE_TYPE_STANDARD);
 				}
 			}
 
@@ -261,7 +261,7 @@ choose_core(const ThreadData* threadData)
 		CoreType preferredType = preferMax ? gMaxCoreType :
 			(preferMin ? gMinCoreType : CORE_TYPE_UNKNOWN);
 
-		CoreEntry* candidate = homePackage->PeekMinimumLoadCore(
+		CoreEntry* candidate = homePackage->PeekMinimumLoadCore(cpu,
 			useMask ? &mask : NULL, preferredType);
 
 		if (candidate != NULL && candidate->GetLoad() == 0) {
@@ -273,7 +273,7 @@ choose_core(const ThreadData* threadData)
 			// NUMA home-package optimization for unconstrained threads.
 			CoreEntry* bestHomeCore = NULL;
 			int32 bestHomeLoad = -1;
-			CheckPackageMinimumLoad(homePackage, useMask ? &mask : NULL,
+			CheckPackageMinimumLoad(cpu, homePackage, useMask ? &mask : NULL,
 				bestHomeCore, bestHomeLoad, preferredType);
 
 			if (bestHomeCore != NULL && bestHomeLoad < kLoadDifference)
@@ -337,18 +337,18 @@ choose_core(const ThreadData* threadData)
 				node = gPackageEntries[homePackageID].Node();
 
 			search_local_node(node, [&](PackageEntry* entry) {
-				CheckPackageMinimumLoad(entry, NULL, bestCore, bestLoad);
+				CheckPackageMinimumLoad(cpu, entry, NULL, bestCore, bestLoad);
 				return false;
 			});
 
 			// Phase 3: Global Random
 			search_global_random([&](PackageEntry* entry) {
-				CheckPackageMinimumLoad(entry, NULL, bestCore, bestLoad);
+				CheckPackageMinimumLoad(cpu, entry, NULL, bestCore, bestLoad);
 				return false;
 			});
 
 		} else if (useMask) {
-			CheckMaskedPackagesMinimumLoad(mask, bestCore, bestLoad);
+			CheckMaskedPackagesMinimumLoad(cpu, mask, bestCore, bestLoad);
 		}
 
 		// Fallback to full scan ONLY if we are not using random sampling (small system)
@@ -359,15 +359,15 @@ choose_core(const ThreadData* threadData)
 			// Start from a random index to ensure fairness over time.
 			// 64 attempts cover small systems entirely and provide a reasonable
 			// search depth for large ones.
-			int32 startIndex = tryRandom ? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom() % gPackageCount : 0;
+			int32 startIndex = tryRandom ? cpu->GetRandom() % gPackageCount : 0;
 			int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
 
 			for (int32 i = 0; i < attempts; i++) {
 				int32 index = startIndex + i;
 				if (index >= gPackageCount)
 					index -= gPackageCount;
-				CheckPackageMinimumLoad(&gPackageEntries[index], NULL, bestCore,
-					bestLoad);
+				CheckPackageMinimumLoad(cpu, &gPackageEntries[index], NULL,
+					bestCore, bestLoad);
 			}
 		}
 
@@ -426,6 +426,7 @@ rebalance(const ThreadData* threadData)
 	if (threadData->IsRealTime())
 		return threadData->Core();
 
+	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
 	CoreEntry* core = threadData->Core();
 	ASSERT(core != NULL);
 
@@ -443,29 +444,30 @@ rebalance(const ThreadData* threadData)
 		// Phase 2: Local Node
 		SchedulerNode* node = core->Package()->Node();
 		search_local_node(node, [&](PackageEntry* entry) {
-			CheckPackageMinimumLoad(entry, NULL, other, bestLoad);
+			CheckPackageMinimumLoad(cpu, entry, NULL, other, bestLoad);
 			return false;
 		});
 
 		// Phase 3: Global Random
 		search_global_random([&](PackageEntry* entry) {
-			CheckPackageMinimumLoad(entry, NULL, other, bestLoad);
+			CheckPackageMinimumLoad(cpu, entry, NULL, other, bestLoad);
 			return false;
 		});
 
 	} else if (useMask) {
-		CheckMaskedPackagesMinimumLoad(mask, other, bestLoad);
+		CheckMaskedPackagesMinimumLoad(cpu, mask, other, bestLoad);
 	}
 
 	if (other == NULL && !useMask) {
-		int32 startIndex = tryRandom ? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom() % gPackageCount : 0;
+		int32 startIndex = tryRandom ? cpu->GetRandom() % gPackageCount : 0;
 		int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
 
 		for (int32 i = 0; i < attempts; i++) {
 			int32 index = startIndex + i;
 			if (index >= gPackageCount)
 				index -= gPackageCount;
-			CheckPackageMinimumLoad(&gPackageEntries[index], NULL, other, bestLoad);
+			CheckPackageMinimumLoad(cpu, &gPackageEntries[index], NULL, other,
+				bestLoad);
 		}
 	}
 
@@ -597,35 +599,39 @@ rebalance_irqs(bool idle)
 	// Use random sampling if possible
 	bool tryRandom = gPackageCount > kRandomSearchThreshold;
 
+	CPUEntry* cpuEntryForIRQ = CPUEntry::GetCPU(cpu->cpu_num);
+
 	if (tryRandom) {
 		// Phase 2: Local Node
 		CoreEntry* currentCore = CoreEntry::GetCore(cpu->cpu_num);
 		if (currentCore != NULL) {
 			SchedulerNode* node = currentCore->Package()->Node();
 			search_local_node(node, [&](PackageEntry* entry) {
-				CheckPackageMinimumLoad(entry, NULL, other, bestLoad);
+				CheckPackageMinimumLoad(cpuEntryForIRQ, entry, NULL, other,
+					bestLoad);
 				return false;
 			});
 		}
 
 		// Phase 3: Global Random
 		search_global_random([&](PackageEntry* entry) {
-			CheckPackageMinimumLoad(entry, NULL, other, bestLoad);
+			CheckPackageMinimumLoad(cpuEntryForIRQ, entry, NULL, other,
+				bestLoad);
 			return false;
 		});
 	}
 
 	// Use empty mask (NULL), as we don't care about affinity here
 	if (other == NULL) {
-		int32 startIndex = tryRandom ? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom() % gPackageCount : 0;
+		int32 startIndex = tryRandom ? cpuEntryForIRQ->GetRandom() % gPackageCount : 0;
 		int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
 
 		for (int32 i = 0; i < attempts; i++) {
 			int32 index = startIndex + i;
 			if (index >= gPackageCount)
 				index -= gPackageCount;
-			CheckPackageMinimumLoad(&gPackageEntries[index], NULL, other,
-				bestLoad);
+			CheckPackageMinimumLoad(cpuEntryForIRQ, &gPackageEntries[index],
+				NULL, other, bestLoad);
 		}
 	}
 

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -57,17 +57,18 @@ has_cache_expired(const ThreadData* threadData)
 
 
 static void
-check_package_small_task(PackageEntry* entry, CoreEntry*& core, int32& bestScore)
+check_package_small_task(CPUEntry* cpu, PackageEntry* entry, CoreEntry*& core,
+	int32& bestScore)
 {
 	// Find the core with highest score that isn't overloaded.
 	// If all are overloaded, we might pick the least loaded later.
 	// For choosing a small task core, we want packing.
-	CoreEntry* candidate = entry->PeekMaximumLoadCore();
+	CoreEntry* candidate = entry->PeekMaximumLoadCore(cpu);
 
 	if (candidate != NULL) {
 		if (candidate->GetScore() >= kHighLoad) {
 			// The busiest is overloaded. Check if there is a less loaded one.
-			candidate = entry->PeekMinimumLoadCore();
+			candidate = entry->PeekMinimumLoadCore(cpu);
 		}
 	}
 
@@ -103,7 +104,7 @@ check_package_small_task(PackageEntry* entry, CoreEntry*& core, int32& bestScore
 
 
 static CoreEntry*
-choose_small_task_core()
+choose_small_task_core(CPUEntry* cpu)
 {
 	SCHEDULER_ENTER_FUNCTION();
 
@@ -119,7 +120,7 @@ choose_small_task_core()
 		if (tryRandom) {
 			search_global_random([&](PackageEntry* entry) {
 				CoreEntry* candidate
-					= entry->PeekMaximumLoadCore(NULL, gMinCoreType);
+					= entry->PeekMaximumLoadCore(cpu, NULL, gMinCoreType);
 				if (candidate != NULL && candidate->GetScore() < kHighLoad) {
 					int32 score = candidate->GetScore();
 					if (eCore == NULL || score > eBestScore) {
@@ -133,14 +134,14 @@ choose_small_task_core()
 
 		if (eCore == NULL) {
 			int32 start = tryRandom
-				? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom()
-					% gPackageCount
+				? cpu->GetRandom() % gPackageCount
 				: 0;
 			for (int32 i = 0; i < min_c(gPackageCount, kMaxFallbackAttempts); i++) {
 				int32 idx = start + i;
 				if (idx >= gPackageCount) idx -= gPackageCount;
 				CoreEntry* candidate
-					= gPackageEntries[idx].PeekMaximumLoadCore(NULL, gMinCoreType);
+					= gPackageEntries[idx].PeekMaximumLoadCore(cpu, NULL,
+						gMinCoreType);
 				if (candidate != NULL && candidate->GetScore() < kHighLoad) {
 					int32 score = candidate->GetScore();
 					if (eCore == NULL || score > eBestScore) {
@@ -168,7 +169,7 @@ choose_small_task_core()
 	bool tryRandom = gPackageCount > kRandomSearchThreshold;
 	if (tryRandom) {
 		search_global_random([&](PackageEntry* entry) {
-			check_package_small_task(entry, core, bestScore);
+			check_package_small_task(cpu, entry, core, bestScore);
 			return false;
 		});
 	}
@@ -178,13 +179,14 @@ choose_small_task_core()
 	if (core == NULL) {
 		// Use the global kMaxFallbackAttempts constant from scheduler_common.h.
 		int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
-		int32 startIndex = tryRandom ? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom() % gPackageCount : 0;
+		int32 startIndex = tryRandom ? cpu->GetRandom() % gPackageCount : 0;
 
 		for (int32 i = 0; i < attempts; i++) {
 			int32 index = startIndex + i;
 			if (index >= gPackageCount)
 				index -= gPackageCount;
-			check_package_small_task(&gPackageEntries[index], core, bestScore);
+			check_package_small_task(cpu, &gPackageEntries[index], core,
+				bestScore);
 		}
 	}
 
@@ -240,18 +242,18 @@ choose_idle_core()
 
 
 static void
-check_package_packing(PackageEntry* entry, const CPUSet* mask,
+check_package_packing(CPUEntry* cpu, PackageEntry* entry, const CPUSet* mask,
 	CoreEntry*& other, int32& bestScore, bool& foundNonOverloaded,
 	CoreType type = CORE_TYPE_UNKNOWN)
 {
 	// We want to pack: find the busiest core that is NOT overloaded (score < kHighLoad).
 	// If all active cores are overloaded, pick the least loaded one (to minimize overload).
-	CoreEntry* candidate = entry->PeekMaximumLoadCore(mask, type);
+	CoreEntry* candidate = entry->PeekMaximumLoadCore(cpu, mask, type);
 
 	if (candidate != NULL) {
 		if (candidate->GetScore() >= kHighLoad) {
 			// The busiest is overloaded. Check if there is a less loaded one.
-			candidate = entry->PeekMinimumLoadCore(mask, type);
+			candidate = entry->PeekMinimumLoadCore(cpu, mask, type);
 		}
 	}
 
@@ -291,8 +293,9 @@ check_package_packing(PackageEntry* entry, const CPUSet* mask,
 
 
 static void
-check_masked_packages_packing(const CPUSet& mask, CoreEntry*& other,
-	int32& bestScore, bool& foundNonOverloaded, CoreType type = CORE_TYPE_UNKNOWN)
+check_masked_packages_packing(CPUEntry* cpu, const CPUSet& mask,
+	CoreEntry*& other, int32& bestScore, bool& foundNonOverloaded,
+	CoreType type = CORE_TYPE_UNKNOWN)
 {
 	const int32 kCPUSetArraySize = (SMP_MAX_CPUS + 31) / 32;
 	const int32 cpuCount = smp_get_num_cpus();
@@ -315,8 +318,8 @@ check_masked_packages_packing(const CPUSet& mask, CoreEntry*& other,
 			if (cpuCore != NULL) {
 				PackageEntry* package = cpuCore->Package();
 				if (package != NULL && package != lastPackage) {
-					check_package_packing(package, &mask, other, bestScore,
-						foundNonOverloaded, type);
+					check_package_packing(cpu, package, &mask, other,
+						bestScore, foundNonOverloaded, type);
 					lastPackage = package;
 				}
 			}
@@ -332,6 +335,7 @@ choose_core(const ThreadData* threadData)
 {
 	SCHEDULER_ENTER_FUNCTION();
 
+	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
 	CoreEntry* core = NULL;
 
 	CPUSet mask = threadData->GetCPUMask();
@@ -361,24 +365,24 @@ choose_core(const ThreadData* threadData)
 
 		if (tryRandom && !useMask) {
 			search_global_random([&](PackageEntry* entry) {
-				check_package_packing(entry, NULL, core, bestScore,
+				check_package_packing(cpu, entry, NULL, core, bestScore,
 					foundNonOverloaded, preferredType);
 				return false;
 			});
 		} else if (useMask) {
-			check_masked_packages_packing(mask, core, bestScore,
+			check_masked_packages_packing(cpu, mask, core, bestScore,
 				foundNonOverloaded, preferredType);
 		}
 
 		if (core == NULL && !useMask) {
-			int32 startIndex = tryRandom ? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom() % gPackageCount : 0;
+			int32 startIndex = tryRandom ? cpu->GetRandom() % gPackageCount : 0;
 			int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
 
 			for (int32 i = 0; i < attempts; i++) {
 				int32 index = startIndex + i;
 				if (index >= gPackageCount)
 					index -= gPackageCount;
-				check_package_packing(&gPackageEntries[index], NULL, core,
+				check_package_packing(cpu, &gPackageEntries[index], NULL, core,
 					bestScore, foundNonOverloaded, preferredType);
 			}
 		}
@@ -401,26 +405,26 @@ choose_core(const ThreadData* threadData)
 
 			if (tryRandomStd && !useMask) {
 				search_global_random([&](PackageEntry* entry) {
-				check_package_packing(entry, useMask ? &mask : NULL,
+				check_package_packing(cpu, entry, useMask ? &mask : NULL,
 					core, stdBestScore, foundNonOverloadedStd, CORE_TYPE_STANDARD);
 					return false;
 				});
 			} else if (useMask) {
-				check_masked_packages_packing(mask, core, stdBestScore,
+				check_masked_packages_packing(cpu, mask, core, stdBestScore,
 					foundNonOverloadedStd, CORE_TYPE_STANDARD);
 			}
 
 			if (core == NULL && !useMask) {
 				int32 startIndex = tryRandomStd
-					? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom()
-						% gPackageCount
+					? cpu->GetRandom() % gPackageCount
 					: 0;
 				int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
 				for (int32 i = 0; i < attempts; i++) {
 					int32 index = startIndex + i;
 					if (index >= gPackageCount) index -= gPackageCount;
-					check_package_packing(&gPackageEntries[index], useMask ? &mask : NULL, core,
-						stdBestScore, foundNonOverloadedStd, CORE_TYPE_STANDARD);
+					check_package_packing(cpu, &gPackageEntries[index],
+						useMask ? &mask : NULL, core, stdBestScore,
+						foundNonOverloadedStd, CORE_TYPE_STANDARD);
 				}
 			}
 		}
@@ -430,7 +434,7 @@ choose_core(const ThreadData* threadData)
 	}
 
 	// try to pack all threads on one core
-	core = choose_small_task_core();
+	core = choose_small_task_core(cpu);
 	if (core != NULL && (useMask && !core->CPUMask().Matches(mask)))
 		core = NULL;
 
@@ -448,7 +452,8 @@ choose_core(const ThreadData* threadData)
 			if (previousCore != NULL && !has_cache_expired(threadData)) {
 				PackageEntry* package = previousCore->Package();
 				if (package != NULL) {
-					CheckPackageMinimumLoad(package, NULL, bestCore, bestScore);
+					CheckPackageMinimumLoad(cpu, package, NULL, bestCore,
+						bestScore);
 				}
 			}
 
@@ -462,31 +467,31 @@ choose_core(const ThreadData* threadData)
 			}
 
 			search_local_node(node, [&](PackageEntry* entry) {
-				CheckPackageMinimumLoad(entry, NULL, bestCore, bestScore);
+				CheckPackageMinimumLoad(cpu, entry, NULL, bestCore, bestScore);
 				return false;
 			});
 
 			// Phase 3: Global Random
 			search_global_random([&](PackageEntry* entry) {
-				CheckPackageMinimumLoad(entry, NULL, bestCore, bestScore);
+				CheckPackageMinimumLoad(cpu, entry, NULL, bestCore, bestScore);
 				return false;
 			});
 
 		} else if (useMask) {
-			CheckMaskedPackagesMinimumLoad(mask, bestCore, bestScore);
+			CheckMaskedPackagesMinimumLoad(cpu, mask, bestCore, bestScore);
 		}
 
 		// Fallback to full scan
 		if (bestCore == NULL && !useMask) {
-			int32 startIndex = tryRandom ? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom() % gPackageCount : 0;
+			int32 startIndex = tryRandom ? cpu->GetRandom() % gPackageCount : 0;
 			int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
 
 			for (int32 i = 0; i < attempts; i++) {
 				int32 index = startIndex + i;
 				if (index >= gPackageCount)
 					index -= gPackageCount;
-				CheckPackageMinimumLoad(&gPackageEntries[index], NULL, bestCore,
-					bestScore);
+				CheckPackageMinimumLoad(cpu, &gPackageEntries[index], NULL,
+					bestCore, bestScore);
 			}
 		}
 
@@ -545,6 +550,7 @@ rebalance(const ThreadData* threadData)
 	if (threadData->IsRealTime())
 		return threadData->Core();
 
+	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
 	CPUSet mask = threadData->GetCPUMask();
 	const bool useMask = !mask.IsEmpty();
 
@@ -557,7 +563,7 @@ rebalance(const ThreadData* threadData)
 		int32 nodeID = core->Package()->Node()->ID();
 		if (sSmallTaskCore != NULL && atomic_pointer_get(&sSmallTaskCore[nodeID]) == core) {
 			atomic_pointer_set(&sSmallTaskCore[nodeID], (CoreEntry*)NULL);
-			CoreEntry* smallTaskCore = choose_small_task_core();
+			CoreEntry* smallTaskCore = choose_small_task_core(cpu);
 
 			if (threadLoad > coreScore / 3 || smallTaskCore == NULL
 					|| (useMask && !smallTaskCore->CPUMask().Matches(mask))) {
@@ -580,33 +586,34 @@ rebalance(const ThreadData* threadData)
 			// Phase 2: Local Node
 			SchedulerNode* node = core->Package()->Node();
 			search_local_node(node, [&](PackageEntry* entry) {
-				check_package_packing(entry, NULL, other, bestScore,
+				check_package_packing(cpu, entry, NULL, other, bestScore,
 					foundNonOverloaded);
 				return false;
 			});
 
 			// Phase 3: Global Random
 			search_global_random([&](PackageEntry* entry) {
-				check_package_packing(entry, NULL, other, bestScore,
+				check_package_packing(cpu, entry, NULL, other, bestScore,
 					foundNonOverloaded);
 				return false;
 			});
 
 		} else if (useMask) {
-			check_masked_packages_packing(mask, other, bestScore, foundNonOverloaded);
+			check_masked_packages_packing(cpu, mask, other, bestScore,
+				foundNonOverloaded);
 		}
 
 		if (other == NULL && !useMask) {
 			// Phase 4: Limited Global Scan (Fallback)
-			int32 startIndex = tryRandom ? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom() % gPackageCount : 0;
+			int32 startIndex = tryRandom ? cpu->GetRandom() % gPackageCount : 0;
 			int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
 
 			for (int32 i = 0; i < attempts; i++) {
 				int32 index = startIndex + i;
 				if (index >= gPackageCount)
 					index -= gPackageCount;
-				check_package_packing(&gPackageEntries[index], NULL, other,
-					bestScore, foundNonOverloaded);
+				check_package_packing(cpu, &gPackageEntries[index], NULL,
+					other, bestScore, foundNonOverloaded);
 			}
 		}
 
@@ -654,7 +661,7 @@ rebalance(const ThreadData* threadData)
 		return core;
 
 	int32 nodeID = core->Package()->Node()->ID();
-	CoreEntry* smallTaskCore = choose_small_task_core();
+	CoreEntry* smallTaskCore = choose_small_task_core(cpu);
 	if (smallTaskCore == NULL || (useMask && !smallTaskCore->CPUMask().Matches(mask)))
 		return core;
 	return smallTaskCore->GetScore() + threadLoad < kHighLoad
@@ -735,6 +742,8 @@ rebalance_irqs(bool idle)
 		// Use random sampling if possible
 		bool tryRandom = gPackageCount > kRandomSearchThreshold;
 
+		CPUEntry* cpuEntryForIRQ = CPUEntry::GetCPU(cpu->cpu_num);
+
 		if (tryRandom) {
 			// Phase 2: Local Node
 			// Fix #5: Do NOT re-read CoreEntry::GetCore() here.  currentCore
@@ -747,7 +756,8 @@ rebalance_irqs(bool idle)
 				SchedulerNode* node = currentCore->Package()->Node();
 				if (node != NULL) {
 					search_local_node(node, [&](PackageEntry* entry) {
-						CheckPackageMinimumLoad(entry, NULL, other, bestScore);
+						CheckPackageMinimumLoad(cpuEntryForIRQ, entry,
+							NULL, other, bestScore);
 						return false;
 					});
 				}
@@ -755,22 +765,23 @@ rebalance_irqs(bool idle)
 
 			// Phase 3: Global Random
 			search_global_random([&](PackageEntry* entry) {
-				CheckPackageMinimumLoad(entry, NULL, other, bestScore);
+				CheckPackageMinimumLoad(cpuEntryForIRQ, entry, NULL, other,
+					bestScore);
 				return false;
 			});
 		}
 
 		if (other == NULL) {
 			// Limit fallback attempts
-			int32 startIndex = tryRandom ? CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom() % gPackageCount : 0;
+			int32 startIndex = tryRandom ? cpuEntryForIRQ->GetRandom() % gPackageCount : 0;
 			int32 attempts = min_c(gPackageCount, kMaxFallbackAttempts);
 
 			for (int32 i = 0; i < attempts; i++) {
 				int32 index = startIndex + i;
 				if (index >= gPackageCount)
 					index -= gPackageCount;
-				CheckPackageMinimumLoad(&gPackageEntries[index], NULL, other,
-					bestScore);
+				CheckPackageMinimumLoad(cpuEntryForIRQ, &gPackageEntries[index],
+					NULL, other, bestScore);
 			}
 		}
 	}

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -378,7 +378,12 @@ enqueue(Thread* thread, bool newOne, Thread* waker)
 		TRACE("enqueueing thread %" B_PRId32 " with priority %" B_PRId32 " on CPU %" B_PRId32 " (core %" B_PRId32 ")\n",
 			thread->id, threadPriority, targetCPU->ID(), targetCore->ID());
 
-	} while (!threadData->Enqueue(wasRunQueueEmpty, requestPreemption));
+		if (!threadData->Enqueue(wasRunQueueEmpty, requestPreemption)) {
+			targetCore = NULL;
+			targetCPU = NULL;
+		} else
+			break;
+	} while (true);
 
 	// notify listeners
 	NotifySchedulerListeners(&SchedulerListener::ThreadEnqueuedInRunQueue,

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -710,10 +710,10 @@ CoreEntry::StealThread(int32& stolenPriority, int32 thiefCPU)
 	SCHEDULER_ENTER_FUNCTION();
 
 	ThreadData* thread = fRunQueue.PeekOption([&](ThreadData* thread) {
-		const CPUSet& rawMask = thread->GetThread()->cpumask;
-		if (rawMask.GetBit(thiefCPU))
+		const CPUSet& mask = thread->GetCPUMask();
+		if (mask.GetBit(thiefCPU))
 			return true;
-		if (rawMask.IsEmpty())
+		if (mask.IsEmpty())
 			return true;
 
 		return false;
@@ -924,15 +924,15 @@ CoreEntry::_UpdateLoad(bool forceUpdate)
 		uint32 nextEpoch = (uint32)oldCombined + 1;
 		int64 newCombined = (int64)nextEpoch; // Load reset to 0
 
-		// Read fLoad BEFORE the CAS. Concurrent AddLoad() calls that detect the
-		// epoch change AFTER the CAS will do atomic_add(&fLoad, load) directly.
-		// By reading it here, we ensure that any load added to fLoad before
-		// we reset fCombinedLoad is accounted for in our delta calculation.
-		int32 prevLoad = atomic_get(&fLoad);
-
 		int64 actual = atomic_test_and_set64(&fCombinedLoad, newCombined,
 			oldCombined);
 		if (actual == oldCombined) {
+			// Read fLoad AFTER the CAS. Concurrent AddLoad() calls that detect the
+			// epoch change AFTER the CAS will do atomic_add(&fLoad, load) directly.
+			// By reading it here, we ensure that any load added to fLoad before
+			// we reset fCombinedLoad is accounted for in our delta calculation.
+			int32 prevLoad = atomic_get(&fLoad);
+
 			// Use atomic_add rather than atomic_set.  Between the CAS above
 			// (which resets the upper 32 bits of fCombinedLoad to 0 and bumps
 			// the epoch) and here, concurrent AddLoad() calls that detect the
@@ -1098,7 +1098,8 @@ PackageEntry::RegisterCore(int32 index, CoreEntry* core)
 
 
 CoreEntry*
-PackageEntry::PeekMinimumLoadCore(const CPUSet* mask, CoreType type) const
+PackageEntry::PeekMinimumLoadCore(CPUEntry* cpu, const CPUSet* mask,
+	CoreType type) const
 {
 	CoreEntry* minEntry = NULL;
 	int32 minLoad = -1;
@@ -1110,7 +1111,6 @@ PackageEntry::PeekMinimumLoadCore(const CPUSet* mask, CoreType type) const
 	// Use "Power of Two Choices" random sampling if the core count is large.
 	// This avoids cache pollution and interconnect saturation from scanning all cores.
 	if (fRegisteredCoreCount > kRandomCoreSearchThreshold) {	// Fix #15
-		CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
 		int32 firstIndex = -1;
 		int32 attempts = 0;
 		int32 registeredCores = fRegisteredCoreCount;
@@ -1184,7 +1184,8 @@ PackageEntry::PeekMinimumLoadCore(const CPUSet* mask, CoreType type) const
 
 
 CoreEntry*
-PackageEntry::PeekMaximumLoadCore(const CPUSet* mask, CoreType type) const
+PackageEntry::PeekMaximumLoadCore(CPUEntry* cpu, const CPUSet* mask,
+	CoreType type) const
 {
 	CoreEntry* maxEntry = NULL;
 	int32 maxLoad = -1;
@@ -1196,7 +1197,6 @@ PackageEntry::PeekMaximumLoadCore(const CPUSet* mask, CoreType type) const
 	// Use "Power of Two Choices" random sampling if the core count is large.
 	// This avoids cache pollution and interconnect saturation from scanning all cores.
 	if (fRegisteredCoreCount > kRandomCoreSearchThreshold) {	// Fix #15
-		CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
 		int32 firstIndex = -1;
 		int32 attempts = 0;
 		int32 registeredCores = fRegisteredCoreCount;
@@ -1249,8 +1249,7 @@ PackageEntry::PeekMaximumLoadCore(const CPUSet* mask, CoreType type) const
 	int32 startBit = 0;
 
 	if (count > 1) {
-		startBit = (int32)(((uint64)CPUEntry::GetCPU(smp_get_current_cpu())->GetRandom()
-			* kMaxCoresPerPackage) >> 32);
+		startBit = (int32)(((uint64)cpu->GetRandom() * kMaxCoresPerPackage) >> 32);
 	}
 
 	// Split mask into two parts to randomize start position

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -394,9 +394,11 @@ public:
 	inline				void				ReadUnlockCore();
 
 						CoreEntry*			PeekMinimumLoadCore(
+												CPUEntry* cpu,
 												const CPUSet* mask = NULL,
 												CoreType type = CORE_TYPE_UNKNOWN) const;
 						CoreEntry*			PeekMaximumLoadCore(
+												CPUEntry* cpu,
 												const CPUSet* mask = NULL,
 												CoreType type = CORE_TYPE_UNKNOWN) const;
 
@@ -738,11 +740,10 @@ SchedulerNode::PackageWakesUp(PackageEntry* package)
 	if (package->NodeIndex() < 0 || package->NodeIndex() >= 64)
 		return;
 
-	atomic_and64((int64*)&fIdlePackageMask, ~(1ULL << package->NodeIndex()));
+	uint64 clearBit = 1ULL << package->NodeIndex();
+	uint64 oldMask = (uint64)atomic_and64((int64*)&fIdlePackageMask, ~clearBit);
 
-	// Read-after-confirmation pattern: clear the bit first, then confirm the node
-	// is still not idle before clearing its bit in gIdleNodeMask.
-	if (atomic_get64((int64*)&fIdlePackageMask) == 0)
+	if ((oldMask & ~clearBit) == 0)
 		atomic_and64((int64*)&gIdleNodeMask, ~(1ULL << fNodeID));
 }
 
@@ -791,7 +792,7 @@ CoreEntry::CPUWakesUp(CPUEntry* /* cpu */)
 	// starts running — the opposite edge, and the wrong one for CoreWakesUp.
 	// The symmetric CPUGoesIdle check (== cpuCount - 1) confirms the pattern:
 	// both conditions detect the all-idle boundary from their respective sides.
-	if (atomic_add(&fIdleCPUCount, -1) == cpuCount)
+	if (atomic_add(&fIdleCPUCount, -1) >= cpuCount)
 		fPackage->CoreWakesUp(this);
 }
 

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -28,6 +28,8 @@ static const int32 kRangeReciprocal = (int32)(((int64)kLoadScale * kLoadScale
 	+ (kMaxLoad - kLowLoad) / 2) / (kMaxLoad - kLowLoad));
 static bigtime_t sVirtualDeadlineSlices[THREAD_MAX_SET_PRIORITY + 1];
 
+bigtime_t ThreadData::sMaxLatency;
+
 
 void
 ThreadData::_InitBase()
@@ -402,6 +404,8 @@ ThreadData::UnassignCore(bool running)
 ThreadData::ComputeQuantumLengths()
 {
 	SCHEDULER_ENTER_FUNCTION();
+
+	atomic_set64(&sMaxLatency, Scheduler::MaximumLatency());
 
 	const bigtime_t kBaseSlice = atomic_get64(&Scheduler::gDeadlineBucketSize);
 	const bigtime_t kQuantum0 = Scheduler::BaseQuantum();

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -85,6 +85,8 @@ public:
 	SCHEDULER_INLINE	void		UpdateActivity(bigtime_t active,
 								bigtime_t now = 0);
 
+	static	bigtime_t	sMaxLatency;
+
 	SCHEDULER_INLINE	bigtime_t	GetVirtualRuntime() const { return fVirtualRuntime; }
 
 	SCHEDULER_INLINE	void		SetQuantum(bigtime_t quantum)
@@ -600,7 +602,8 @@ ThreadData::UpdateActivity(bigtime_t active, bigtime_t now)
 		// thread is at most MaximumLatency()*1000 in virtual-time units,
 		// after which they are scheduled fairly again as real time advances.
 		// Use a monotonic base to prevent clock skew from causing starvation.
-		const bigtime_t kLookahead = Scheduler::MaximumLatency() * 1000LL;
+		const bigtime_t maxLatency = atomic_get64(&sMaxLatency);
+		const bigtime_t kLookahead = maxLatency * 1000LL;
 		if (now == 0)
 			now = system_time();
 		bigtime_t ceiling = now + kLookahead;

--- a/src/system/kernel/scheduler/scheduler_topology.h
+++ b/src/system/kernel/scheduler/scheduler_topology.h
@@ -154,10 +154,10 @@ search_global_random(Action action)
 
 
 static inline void
-CheckPackageMinimumLoad(PackageEntry* entry, const CPUSet* mask,
+CheckPackageMinimumLoad(CPUEntry* cpu, PackageEntry* entry, const CPUSet* mask,
 	CoreEntry*& bestCore, int32& bestLoad, CoreType type = CORE_TYPE_UNKNOWN)
 {
-	CoreEntry* candidate = entry->PeekMinimumLoadCore(mask, type);
+	CoreEntry* candidate = entry->PeekMinimumLoadCore(cpu, mask, type);
 
 	if (candidate != NULL) {
 		int32 score = candidate->GetScore();
@@ -180,8 +180,8 @@ CheckPackageMinimumLoad(PackageEntry* entry, const CPUSet* mask,
 
 
 static inline void
-CheckMaskedPackagesMinimumLoad(const CPUSet& mask, CoreEntry*& bestCore,
-	int32& bestLoad, CoreType type = CORE_TYPE_UNKNOWN)
+CheckMaskedPackagesMinimumLoad(CPUEntry* cpu, const CPUSet& mask,
+	CoreEntry*& bestCore, int32& bestLoad, CoreType type = CORE_TYPE_UNKNOWN)
 {
 	const int32 kCPUSetArraySize = (SMP_MAX_CPUS + 31) / 32;
 	const int32 cpuCount = smp_get_num_cpus();
@@ -204,8 +204,8 @@ CheckMaskedPackagesMinimumLoad(const CPUSet& mask, CoreEntry*& bestCore,
 			if (cpuCore != NULL) {
 				PackageEntry* package = cpuCore->Package();
 				if (package != NULL && package != lastPackage) {
-					CheckPackageMinimumLoad(package, &mask, bestCore, bestLoad,
-						type);
+					CheckPackageMinimumLoad(cpu, package, &mask, bestCore,
+						bestLoad, type);
 					lastPackage = package;
 				}
 			}


### PR DESCRIPTION
This patch addresses eight identified issues in the Haiku kernel scheduler, ranging from critical race conditions to performance bottlenecks on the hot scheduling path.

Key changes:
1. **Concurrency Safety:** Fixed TOCTOU races in `PackageWakesUp` and `CPUWakesUp`, and a subtle load-tracking race in `_UpdateLoad`.
2. **Stability:** Resolved an infinite retry loop in `enqueue()` triggered during CPU hot-unplug events.
3. **Correctness:** Fixed `StealThread` to respect the `gCPUEnabled` mask, preventing threads from being stolen to cores where they cannot run.
4. **Performance Optimization:** 
   - Cached `MaximumLatency()` and `smp_get_num_cpus()` to avoid repeated pointer dereferences and syscalls.
   - Extensive refactoring to hoist `smp_get_current_cpu()` out of the per-package core search logic, passing the `CPUEntry` reference through the call stack instead.

These improvements enhance the overall robustness and efficiency of the scheduler, particularly on heterogeneous and high-core-count systems.

---
*PR created automatically by Jules for task [18316913640360890470](https://jules.google.com/task/18316913640360890470) started by @tonestone57*