### PR TITLE
Scheduler Robustness and Race Condition Fixes (19-26)

### DIFF
--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -763,7 +763,9 @@ rebalance_irqs(bool idle)
 
 	CoreEntry* other = NULL;
 	if (pack) {
-		if (sSmallTaskCore != NULL && currentCore != NULL) {
+		if (sSmallTaskCore != NULL && currentCore != NULL
+				&& currentCore->Package() != NULL
+				&& currentCore->Package()->Node() != NULL) {
 			int32 nodeID = currentCore->Package()->Node()->ID();
 			other = (CoreEntry*)atomic_pointer_get(&sSmallTaskCore[nodeID]);
 		}

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -144,7 +144,7 @@ CPUEntry::Stop()
 
 	// get rid of irqs
 	SpinLocker locker(entry->irqs_lock);
-	while (true) {
+	for (int32 i = 0; i < 1000; i++) {
 		irq_assignment* irq
 			= (irq_assignment*)list_get_first_item(&entry->irqs);
 		if (irq == NULL)
@@ -163,6 +163,11 @@ CPUEntry::Stop()
 			dprintf("CPUEntry::Stop: interrupt %" B_PRId32 " still assigned "
 				"after successful reassignment\n", irqVector);
 			break;
+		}
+
+		if (i == 999) {
+			dprintf("CPUEntry::Stop: safety limit reached while removing "
+				"interrupts from CPU %" B_PRId32 "\n", fCPUNumber);
 		}
 	}
 	locker.Unlock();
@@ -920,6 +925,7 @@ CoreEntry::_UpdateLoad(bool forceUpdate)
 	// AddLoad calls either contribute to the old epoch (and are manually
 	// added to fLoad) or the new epoch (and are captured in the next snapshot),
 	// with no double-counting or loss.
+	int32 prevLoad = atomic_get(&fLoad);
 	int32 currentLoad = 0;
 	int64 oldCombined = atomic_get64(&fCombinedLoad);
 	while (true) {
@@ -930,11 +936,12 @@ CoreEntry::_UpdateLoad(bool forceUpdate)
 		int64 actual = atomic_test_and_set64(&fCombinedLoad, newCombined,
 			oldCombined);
 		if (actual == oldCombined) {
-			// Read fLoad AFTER the CAS. Concurrent AddLoad() calls that detect the
-			// epoch change AFTER the CAS will do atomic_add(&fLoad, load) directly.
-			// By reading it here, we ensure that any load added to fLoad before
-			// we reset fCombinedLoad is accounted for in our delta calculation.
-			int32 prevLoad = atomic_get(&fLoad);
+			// Read fLoad BEFORE the CAS (or re-read on retry). Concurrent
+			// AddLoad() calls that detect the epoch change AFTER the CAS will
+			// do atomic_add(&fLoad, load) directly. By reading it before we
+			// commit the reset, we ensure that the delta is computed against
+			// a baseline that does not yet include those new-epoch additions,
+			// preventing us from "double-subtracting" them.
 
 			// Use atomic_add rather than atomic_set.  Between the CAS above
 			// (which resets the upper 32 bits of fCombinedLoad to 0 and bumps
@@ -951,6 +958,7 @@ CoreEntry::_UpdateLoad(bool forceUpdate)
 			break;
 		}
 		oldCombined = actual;
+		prevLoad = atomic_get(&fLoad);
 	}
 
 	if (cpuCount > 0) {
@@ -1043,15 +1051,16 @@ void
 PackageEntry::RemoveIdleCore(CoreEntry* core)
 {
 	WriteSpinLocker coreLocker(fCoreLock);
-	// Decrement the count BEFORE clearing the mask bit.  A concurrent reader
-	// (e.g. GetLeastIdlePackage) checks fIdleCoreCount as a fast pre-filter
-	// before inspecting fIdleCoreMask.  If the mask is cleared first, the
-	// reader can observe fIdleCoreCount > 0 with an empty mask and then
-	// dereference a NULL core from GetIdleCore().
-	atomic_add(&fIdleCoreCount, -1);
-
+	// Clear the mask bit BEFORE decrementing the count.  A concurrent reader
+	// of the mask (e.g. GetIdleCore) must not see a core that is in the
+	// process of being removed from the idle set, as that could lead to a
+	// "dangling-ish" core reference if the core is being disabled.  The
+	// reader of the count (e.g. GetLeastIdlePackage) will gracefully handle
+	// a count > 0 with an empty mask by receiving NULL from GetIdleCore().
 	native_cpu_mask_t clearBit = (native_cpu_mask_t)1 << core->PackageIndex();
 	native_cpu_mask_t oldMask = scheduler_atomic_and(&fIdleCoreMask, ~clearBit);
+
+	atomic_add(&fIdleCoreCount, -1);
 
 	if ((oldMask & ~clearBit) == 0) {
 		// Package wakes up (last idle core became active).  Delegate to

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -698,11 +698,13 @@ PackageEntry::CoreWakesUp(CoreEntry* core)
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	// Decrement the count BEFORE clearing the mask bit.
-	atomic_add(&fIdleCoreCount, -1);
-
+	// Clear the mask bit BEFORE decrementing the count, matching the logic
+	// in RemoveIdleCore to prevent GetIdleCore from returning a
+	// "dangling-ish" core reference.
 	native_cpu_mask_t clearBit = (native_cpu_mask_t)1 << core->PackageIndex();
 	native_cpu_mask_t oldMask = scheduler_atomic_and(&fIdleCoreMask, ~clearBit);
+
+	atomic_add(&fIdleCoreCount, -1);
 
 	// Detect the transition from fully-idle to partially-active:
 	// the package wakes up when the *last* idle core becomes active, i.e.
@@ -743,7 +745,11 @@ SchedulerNode::PackageWakesUp(PackageEntry* package)
 	uint64 clearBit = 1ULL << package->NodeIndex();
 	uint64 oldMask = (uint64)atomic_and64((int64*)&fIdlePackageMask, ~clearBit);
 
-	if ((oldMask & ~clearBit) == 0)
+	// Detect the transition from fully-idle to partially-active for the node.
+	// Only clear the bit in gIdleNodeMask if this package was actually idle
+	// (bit was set in oldMask) AND it was the last idle package in this node
+	// (mask is now zero).
+	if ((oldMask & clearBit) != 0 && (oldMask & ~clearBit) == 0)
 		atomic_and64((int64*)&gIdleNodeMask, ~(1ULL << fNodeID));
 }
 

--- a/src/system/kernel/scheduler/scheduler_profiler.cpp
+++ b/src/system/kernel/scheduler/scheduler_profiler.cpp
@@ -87,11 +87,12 @@ Profiler::EnterFunction(int32 cpu, const char* functionName)
 	FunctionData* function = _FindFunction(functionName);
 	if (function == NULL)
 		return false;
-	atomic_add(&function->fCalled, 1);
 
 	int32 stackDepth = fFunctionStackPointers[cpu];
 	if (stackDepth >= (int32)kMaxFunctionStackEntries)
 		return false;
+
+	atomic_add(&function->fCalled, 1);
 
 	fFunctionStackPointers[cpu]++;
 	FunctionEntry* stackEntry = &fFunctionStacks[cpu][stackDepth];

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -226,7 +226,7 @@ ThreadData::ChooseCoreAndCPU(CoreEntry*& targetCore, CPUEntry*& targetCPU)
 		bool rescheduleNeeded = false;
 
 		if (targetCore != NULL && (useMask
-				&& GetCPUMask().And(targetCore->CPUMask()).IsEmpty())) {
+				&& mask.And(targetCore->CPUMask()).IsEmpty())) {
 			targetCore = NULL;
 		}
 		if (targetCPU != NULL && (useMask && !mask.GetBit(targetCPU->ID())))

--- a/src/system/kernel/scheduler/scheduling_analysis.cpp
+++ b/src/system/kernel/scheduler/scheduling_analysis.cpp
@@ -863,7 +863,9 @@ _user_analyze_scheduling(bigtime_t from, bigtime_t until, void* buffer,
 
 	if ((addr_t)buffer & 0x7) {
 		addr_t diff = (addr_t)buffer & 0x7;
-		if (size < 8 - diff)
+		// Use explicit size check to prevent underflow or wrap-around on
+		// zero/small size when computing the 8-byte alignment fixup.
+		if (size <= (size_t)(8 - diff))
 			return B_BAD_VALUE;
 		buffer = (void*)((addr_t)buffer + 8 - diff);
 		size -= 8 - diff;


### PR DESCRIPTION
Implemented fixes for eight specific issues (19-26) in the Haiku kernel scheduler:
1. Added iteration limit to IRQ removal in `CPUEntry::Stop`.
2. Fixed load delta calculation in `CoreEntry::_UpdateLoad`.
3. Reordered mask/count updates in idle core tracking for consistency.
4. Strengthened `SchedulerNode::PackageWakesUp` to prevent spurious mask clears.
5. Ensured `ThreadData::ChooseCoreAndCPU` uses a consistent CPUMask.
6. Corrected call counter timing in `Profiler::EnterFunction`.
7. Added defensive NULL checks in `power_saving.cpp::rebalance_irqs`.
8. Improved buffer alignment logic in `_user_analyze_scheduling`.

---
*PR created automatically by Jules for task [4594661985371983430](https://jules.google.com/task/4594661985371983430) started by @tonestone57*