### PR TITLE
Fix scheduler state, DPC, thread count and profiler locking

### DIFF
--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -632,6 +632,7 @@ reschedule(int32 nextState)
 		if (!oldThreadData->IsIdle()) {
 			putOldThreadAtBack = true;
 			oldThreadData->UnassignCore(true);
+			core->DecrementTotalThreadCount();
 
 			CPURunQueueLocker cpuLocker(cpu);
 			nextThreadData = cpu->PeekIdleThread();

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -114,8 +114,10 @@ interaction_timer_hook(struct timer* timer)
 	// in an interrupt context is unsafe if any CPU already holds a scheduler
 	// read lock.
 	if (atomic_get_and_set(&sDPCPending, 1) == 0) {
-		DPCQueue::DefaultQueue(B_URGENT_DISPLAY_PRIORITY)->Add(
-			&update_quantum_lengths_dpc, (void*)(addr_t)5000);
+		if (DPCQueue::DefaultQueue(B_URGENT_DISPLAY_PRIORITY)->Add(
+				&update_quantum_lengths_dpc, (void*)(addr_t)5000) != B_OK) {
+			atomic_set(&sDPCPending, 0);
+		}
 	}
 
 	return B_HANDLED_INTERRUPT;
@@ -160,8 +162,10 @@ scheduler_update_interaction_state()
 	// scheduler_update_interaction_state is called from Enqueue, which HOLDS
 	// scheduler locks.
 	if (atomic_get_and_set(&sDPCPending, 1) == 0) {
-		DPCQueue::DefaultQueue(B_URGENT_DISPLAY_PRIORITY)->Add(
-			&update_quantum_lengths_dpc, (void*)(addr_t)1000);
+		if (DPCQueue::DefaultQueue(B_URGENT_DISPLAY_PRIORITY)->Add(
+				&update_quantum_lengths_dpc, (void*)(addr_t)1000) != B_OK) {
+			atomic_set(&sDPCPending, 0);
+		}
 	}
 
 	if (atomic_get_and_set(&sTimerArmed, 1) == 0) {
@@ -1159,6 +1163,10 @@ static status_t
 init()
 {
 	gIdleNodeMask = 0;
+
+	gMinCoreType = CORE_TYPE_UNKNOWN;
+	gMaxCoreType = CORE_TYPE_UNKNOWN;
+	gHasStandardCores = false;
 
 	// create logical processor to core and package mappings
 	int32 cpuCount, coreCount, packageCount, nodeCount;

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -180,6 +180,9 @@ CPUEntry::PushFront(ThreadData* thread, int32 priority)
 	SCHEDULER_ENTER_FUNCTION();
 	fRunQueue.PushFront(thread, priority);
 	atomic_add(&fThreadCount, 1);
+
+	if (!thread->IsIdle())
+		Core()->IncrementTotalThreadCount();
 }
 
 
@@ -189,6 +192,9 @@ CPUEntry::PushBack(ThreadData* thread, int32 priority)
 	SCHEDULER_ENTER_FUNCTION();
 	fRunQueue.PushBack(thread, priority);
 	atomic_add(&fThreadCount, 1);
+
+	if (!thread->IsIdle())
+		Core()->IncrementTotalThreadCount();
 }
 
 
@@ -200,6 +206,9 @@ CPUEntry::Remove(ThreadData* thread)
 	thread->SetDequeued();
 	fRunQueue.Remove(thread);
 	atomic_add(&fThreadCount, -1);
+
+	if (!thread->IsIdle())
+		Core()->DecrementTotalThreadCount();
 }
 
 
@@ -686,7 +695,7 @@ CoreEntry::PushFront(ThreadData* thread, int32 priority)
 
 	fRunQueue.PushFront(thread, priority);
 	atomic_add(&fThreadCount, 1);
-	atomic_add(&fTotalThreadCount, 1);
+	IncrementTotalThreadCount();
 }
 
 
@@ -697,7 +706,7 @@ CoreEntry::PushBack(ThreadData* thread, int32 priority)
 
 	fRunQueue.PushBack(thread, priority);
 	atomic_add(&fThreadCount, 1);
-	atomic_add(&fTotalThreadCount, 1);
+	IncrementTotalThreadCount();
 }
 
 
@@ -712,7 +721,7 @@ CoreEntry::Remove(ThreadData* thread)
 	thread->SetDequeued();
 
 	atomic_add(&fThreadCount, -1);
-	atomic_add(&fTotalThreadCount, -1);
+	DecrementTotalThreadCount();
 	fRunQueue.Remove(thread);
 }
 

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -226,6 +226,10 @@ public:
 
 	inline				int32			ThreadCount() const
 											{ return atomic_get(const_cast<int32*>(&fTotalThreadCount)); }
+	inline				void			IncrementTotalThreadCount()
+											{ atomic_add(&fTotalThreadCount, 1); }
+	inline				void			DecrementTotalThreadCount()
+											{ atomic_add(&fTotalThreadCount, -1); }
 	inline				int32			CoreRunQueueThreadCount() const
 											{ return atomic_get(const_cast<int32*>(&fThreadCount)); }
 
@@ -776,7 +780,7 @@ CoreEntry::CPUGoesIdle(CPUEntry* /* cpu */)
 		return;
 
 	ASSERT(atomic_get(&fIdleCPUCount) < atomic_get(&fCPUCount));
-	atomic_add(&fTotalThreadCount, -1);
+	DecrementTotalThreadCount();
 	if (atomic_add(&fIdleCPUCount, 1) == atomic_get(&fCPUCount) - 1)
 		fPackage->CoreGoesIdle(this);
 }
@@ -790,7 +794,7 @@ CoreEntry::CPUWakesUp(CPUEntry* /* cpu */)
 
 	ASSERT(atomic_get(&fIdleCPUCount) > 0);
 
-	atomic_add(&fTotalThreadCount, 1);
+	IncrementTotalThreadCount();
 	// Fix #1 (documentation): == cpuCount is intentionally correct here.
 	// atomic_add() returns the OLD value of fIdleCPUCount.  CoreWakesUp must
 	// fire exactly on the transition "fully idle -> first CPU active", which

--- a/src/system/kernel/scheduler/scheduler_profiler.cpp
+++ b/src/system/kernel/scheduler/scheduler_profiler.cpp
@@ -6,6 +6,7 @@
 #include "scheduler_profiler.h"
 
 #include <debug.h>
+#include <KernelExport.h>
 #include <util/atomic.h>
 #include <util/AutoLock.h>
 

--- a/src/system/kernel/scheduler/scheduler_profiler.cpp
+++ b/src/system/kernel/scheduler/scheduler_profiler.cpp
@@ -299,6 +299,7 @@ Profiler::_FindFunction(const char* function)
 		if (entry == NULL)
 			break;
 
+		memory_read_barrier();
 		if (strcmp(entry->fFunction, function) == 0)
 			return entry;
 
@@ -315,6 +316,7 @@ Profiler::_FindFunction(const char* function)
 		if (entry == NULL)
 			break;
 
+		memory_read_barrier();
 		if (strcmp(entry->fFunction, function) == 0)
 			return entry;
 
@@ -330,6 +332,8 @@ Profiler::_FindFunction(const char* function)
 		index = hash % kHashTableSize;
 		while (atomic_pointer_get(&fHashTable[index]) != NULL)
 			index = (index + 1) % kHashTableSize;
+
+		memory_write_barrier();
 		atomic_pointer_set(&fHashTable[index], entry);
 
 		return entry;

--- a/src/system/kernel/scheduler/scheduler_profiler.cpp
+++ b/src/system/kernel/scheduler/scheduler_profiler.cpp
@@ -6,6 +6,7 @@
 #include "scheduler_profiler.h"
 
 #include <debug.h>
+#include <util/atomic.h>
 #include <util/AutoLock.h>
 
 #include <algorithm>
@@ -294,7 +295,7 @@ Profiler::_FindFunction(const char* function)
 	uint32 index = hash % kHashTableSize;
 	uint32 startIndex = index;
 	do {
-		FunctionData* entry = fHashTable[index];
+		FunctionData* entry = atomic_pointer_get(&fHashTable[index]);
 		if (entry == NULL)
 			break;
 
@@ -310,7 +311,7 @@ Profiler::_FindFunction(const char* function)
 	index = hash % kHashTableSize;
 	startIndex = index;
 	do {
-		FunctionData* entry = fHashTable[index];
+		FunctionData* entry = atomic_pointer_get(&fHashTable[index]);
 		if (entry == NULL)
 			break;
 
@@ -327,9 +328,9 @@ Profiler::_FindFunction(const char* function)
 
 		// Insert into hash table.
 		index = hash % kHashTableSize;
-		while (fHashTable[index] != NULL)
+		while (atomic_pointer_get(&fHashTable[index]) != NULL)
 			index = (index + 1) % kHashTableSize;
-		fHashTable[index] = entry;
+		atomic_pointer_set(&fHashTable[index], entry);
 
 		return entry;
 	}

--- a/src/system/kernel/scheduler/scheduler_profiler.cpp
+++ b/src/system/kernel/scheduler/scheduler_profiler.cpp
@@ -127,8 +127,6 @@ Profiler::ExitFunction(int32 cpu, const char* functionName)
 		return;
 
 	stackDepth = --fFunctionStackPointers[cpu];
-	if (stackDepth >= (int32)kMaxFunctionStackEntries)
-		return;
 
 	FunctionEntry* stackEntry = &fFunctionStacks[cpu][stackDepth];
 
@@ -292,11 +290,25 @@ Profiler::_FindFunction(const char* function)
 	for (const char* p = function; *p; p++)
 		hash = (hash * 31 + *p);
 
-	InterruptsSpinLocker _(fFunctionLock);
-
-	// Linear Probing: handle collisions without evictions.
+	// Lockless Search: fast path for existing entries.
 	uint32 index = hash % kHashTableSize;
 	uint32 startIndex = index;
+	do {
+		FunctionData* entry = fHashTable[index];
+		if (entry == NULL)
+			break;
+
+		if (strcmp(entry->fFunction, function) == 0)
+			return entry;
+
+		index = (index + 1) % kHashTableSize;
+	} while (index != startIndex);
+
+	InterruptsSpinLocker _(fFunctionLock);
+
+	// Double-checked Search: handle races and insertions.
+	index = hash % kHashTableSize;
+	startIndex = index;
 	do {
 		FunctionData* entry = fHashTable[index];
 		if (entry == NULL)


### PR DESCRIPTION
This patch addresses five issues in the Haiku scheduler and profiler:
1. Fixed a bug where global core type state was not reset during scheduler initialization, leading to stale values persisting across topology changes (e.g. hot-plug).
2. Removed an unreachable bounds check in the profiler's ExitFunction that provided false safety assurance.
3. Added error checking for DPC enqueues in the interaction timer hooks; if the DPC queue is full, the pending flag is now correctly cleared to allow future scaling updates.
4. Fixed a semantic mismatch in fTotalThreadCount, which was previously only tracking running threads. It now correctly includes all ready threads (including pinned threads in per-CPU queues), ensuring accurate dynamic quantum scaling.
5. Optimized the profiler's function lookup by implementing double-checked locking, significantly reducing spinlock contention by performing a lockless search first.

---
*PR created automatically by Jules for task [3238239641535948242](https://jules.google.com/task/3238239641535948242) started by @tonestone57*