### PR TITLE
Apply correctness and scalability fixes to the scheduler

### DIFF
--- a/src/system/kernel/scheduler/low_latency.cpp
+++ b/src/system/kernel/scheduler/low_latency.cpp
@@ -668,12 +668,12 @@ rebalance_irqs(bool idle)
 	int32 newCPU = other->CPUHeap()->PeekRoot()->ID();
 	_.Unlock();
 
-	CoreEntry* core = CoreEntry::GetCore(cpu->cpu_num);
-	if (other == core)
+	// Issue 6: use pre-lock snapshot; do NOT re-read via GetCore() here.
+	if (other == currentCore)
 		return;
 
 	int32 otherLoad = other->GetScore();
-	int32 coreLoad = core->GetScore();
+	int32 coreLoad = currentCore->GetScore();
 
 	if (otherLoad + kLoadDifference >= coreLoad)
 		return;

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -866,10 +866,10 @@ rebalance_irqs(bool idle)
 	int32 newCPU = other->CPUHeap()->PeekRoot()->ID();
 	_.Unlock();
 
-	CoreEntry* core = CoreEntry::GetCore(smp_get_current_cpu());
-	if (other == core)
+	// Issue 6: use pre-lock snapshot; do NOT re-read via GetCore() here.
+	if (other == currentCore)
 		return;
-	if (!pack && other->GetScore() + kLoadDifference >= core->GetScore())
+	if (!pack && other->GetScore() + kLoadDifference >= currentCore->GetScore())
 		return;
 
 	CPUEntry* cpuEntry = CPUEntry::GetCPU(cpu->cpu_num);

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -780,6 +780,13 @@ CoreEntry::AddCPU(CPUEntry* cpu)
 
 	atomic_add(&fIdleCPUCount, 1);
 	bool firstCPU = (atomic_add(&fCPUCount, 1) == 0);
+
+	// Issue 33: Publish the CPU in fCPUSet BEFORE advertising the core as idle
+	// via AddIdleCore.  A concurrent choose_core that sees the idle-mask update
+	// will call _ChooseCPU(), which iterates fCPUSet.  If fCPUSet is still
+	// empty at that point it returns NULL and forces an unnecessary retry.
+	fCPUSet.SetBitAtomic(cpu->ID());
+
 	if (firstCPU) {
 		// core has been reenabled
 		fLoad = 0;
@@ -791,7 +798,6 @@ CoreEntry::AddCPU(CPUEntry* cpu)
 
 		fPackage->AddIdleCore(this);
 	}
-	fCPUSet.SetBitAtomic(cpu->ID());
 
 	if (fCPUHeap.Insert(cpu, B_IDLE_PRIORITY) != B_OK) {
 		// Issue #32: Complete the rollback — zero the load fields that were
@@ -1248,7 +1254,9 @@ PackageEntry::PeekMinimumLoadCore(CPUEntry* cpu, const CPUSet* mask,
 			if (!(((native_cpu_mask_t)1 << i) & enabledMask))
 				continue;
 
-			if (mask != NULL && !mask->GetBit(candidate->ID()))
+			// Issue 3: candidate->ID() is a core ID; the mask is indexed by
+			// CPU ID.  Check whether the core has any CPU in the affinity set.
+			if (mask != NULL && !candidate->CPUMask().Matches(*mask))
 				continue;
 			if (type != CORE_TYPE_UNKNOWN && candidate->Type() != type)
 				continue;
@@ -1276,7 +1284,8 @@ PackageEntry::PeekMinimumLoadCore(CPUEntry* cpu, const CPUSet* mask,
 		CoreEntry* candidate = fCores[i];
 		if (candidate == NULL)
 			continue;
-		if (mask != NULL && !mask->GetBit(candidate->ID()))
+		// Issue 3: same fix as the random sampling path above.
+		if (mask != NULL && !candidate->CPUMask().Matches(*mask))
 			continue;
 		if (type != CORE_TYPE_UNKNOWN && candidate->Type() != type)
 			continue;
@@ -1327,7 +1336,8 @@ PackageEntry::PeekMaximumLoadCore(CPUEntry* cpu, const CPUSet* mask,
 			if (!(((native_cpu_mask_t)1 << i) & enabledMask))
 				continue;
 
-			if (mask != NULL && !mask->GetBit(candidate->ID()))
+			// Issue 3: candidate->ID() is a core ID; mask is indexed by CPU ID.
+			if (mask != NULL && !candidate->CPUMask().Matches(*mask))
 				continue;
 			if (type != CORE_TYPE_UNKNOWN && candidate->Type() != type)
 				continue;
@@ -1382,7 +1392,8 @@ PackageEntry::PeekMaximumLoadCore(CPUEntry* cpu, const CPUSet* mask,
 			CoreEntry* candidate = fCores[i];
 			if (candidate == NULL)
 				continue;
-			if (mask != NULL && !mask->GetBit(candidate->ID()))
+			// Issue 3: same fix as PeekMinimumLoadCore.
+			if (mask != NULL && !candidate->CPUMask().Matches(*mask))
 				continue;
 			if (type != CORE_TYPE_UNKNOWN && candidate->Type() != type)
 				continue;

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -482,12 +482,14 @@ ThreadData::DonateTimesliceTo(Thread* beneficiary)
 	bigtime_t timeLeft = quantum - fTimeUsed;
 	if (timeLeft > 0) {
 		// Donate remaining slice to the beneficiary.
-		// Issue #37: This acquires beneficiary->scheduler_lock.  Callers
-		// MUST NOT hold any run-queue spinlock when invoking this function;
-		// doing so inverts the documented lock ordering (Core/CPU queue lock →
-		// thread scheduler_lock) and risks deadlock.  Assert here in debug
-		// builds to catch future callers that violate the constraint.
-		ASSERT(!are_interrupts_enabled() || /* irqs already off */ true);
+		// Callers MUST NOT hold any run-queue spinlock when invoking this
+		// function; doing so inverts the lock ordering (Core/CPU queue lock
+		// → thread scheduler_lock) and risks deadlock.
+		// Issue 21: the original assertion was a tautology
+		// (!x || true == true always).  Assert what was actually intended:
+		// interrupts must be disabled on entry so the spinlock acquire below
+		// cannot be preempted.
+		ASSERT(!are_interrupts_enabled());
 		InterruptsSpinLocker locker(beneficiary->scheduler_lock);
 		beneficiaryData->fStolenTime += timeLeft;
 	}

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -398,12 +398,25 @@ ThreadData::GoesAway()
 
 	ASSERT(fReady);
 
-	if (!IsIdle())
-		// Issue #45: Saturate at zero to prevent the load-average EMA from
-		// receiving a negative thread count due to a double-call or other
-		// reference-count mismatch.
-		if (atomic_add(&gTotalRunnableThreads, -1) <= 0)
-			atomic_set(&gTotalRunnableThreads, 0);
+	if (!IsIdle()) {
+		// Issue 28: the original atomic_set(0) could overwrite a concurrent
+		// increment from another CPU that legitimately enqueued a thread in
+		// the window between our atomic_add and the atomic_set, permanently
+		// undercounting gTotalRunnableThreads.  Use a CAS retry loop that
+		// only resets the counter while it is still negative, so valid
+		// increments from concurrent CPUs are never lost.
+		int32 prev = atomic_add(&gTotalRunnableThreads, -1);
+		if (prev <= 0) {
+			int32 cur = atomic_get(&gTotalRunnableThreads);
+			while (cur < 0) {
+				int32 was = atomic_test_and_set(&gTotalRunnableThreads, 0,
+					cur);
+				if (was == cur)
+					break;
+				cur = was;
+			}
+		}
+	}
 
 	if (!HasQuantumEnded(false, false)) {
 		fQuickStartCredit = true;
@@ -433,10 +446,21 @@ ThreadData::Dies()
 
 	ASSERT(fReady);
 
-	if (!IsIdle())
-		// Issue #45: Same saturation guard as GoesAway.
-		if (atomic_add(&gTotalRunnableThreads, -1) <= 0)
-			atomic_set(&gTotalRunnableThreads, 0);
+	if (!IsIdle()) {
+		// Issue 28: same CAS-based saturation as GoesAway to avoid
+		// overwriting concurrent increments.
+		int32 prev = atomic_add(&gTotalRunnableThreads, -1);
+		if (prev <= 0) {
+			int32 cur = atomic_get(&gTotalRunnableThreads);
+			while (cur < 0) {
+				int32 was = atomic_test_and_set(&gTotalRunnableThreads, 0,
+					cur);
+				if (was == cur)
+					break;
+				cur = was;
+			}
+		}
+	}
 
 	if (gTrackCoreLoad)
 		fCore->RemoveLoad(fNeededLoad, true);

--- a/src/system/kernel/scheduler/scheduler_topology.h
+++ b/src/system/kernel/scheduler/scheduler_topology.h
@@ -127,58 +127,37 @@ search_global_random(Action action)
 		return;
 	}
 
-	// Use a smaller fixed buffer on the stack (128 bytes = 1024 packages)
-	// which covers >99% of systems. For massive systems, we skip collision
-	// detection for indices beyond 1024 to save stack space.
-	const int32 kStackBitmaskSize = 1024;
+	// Issue 8: the original kStackBitmaskSize of 1024 meant that packages
+	// in the range [1024, 4096) fell into a coarse stripe-based fallback
+	// that visited at most 1 package per 64-package band, severely
+	// under-sampling large systems.  gPackageCount is capped at 4096, so a
+	// 512-byte (4096-bit) bitmask covers the entire valid range without any
+	// stripe approximation.  512 bytes is acceptable on a kernel stack that
+	// is at least 8 KB.
+	const int32 kStackBitmaskSize = 4096;
 	uint64 visitedBits[kStackBitmaskSize / 64];
-	uint64 stripeVisited = 0;
 
-	// Always zero the entire array. The conditional initialization above
-	// only cleared as many words as needed for gPackageCount, leaving words
-	// beyond that range uninitialized. Any subsequent access with an index
-	// in [cleared_range, kStackBitmaskSize) read garbage, causing spurious
-	// "already visited" skips. Zeroing all 128 bytes unconditionally is
-	// negligible on the scheduler hot path.
+	// Zero all 512 bytes unconditionally; partial clears risk leaving stale
+	// bits that produce spurious "already visited" skips.
 	memset(visitedBits, 0, sizeof(visitedBits));
 
 	while (samplesTaken < samplesToTake && attempts++ < kMaxAttempts) {
-		// Multiplicative random mapping to avoid expensive modulo
 		int32 i = (int32)(((uint64)cpu->GetRandom() * gPackageCount) >> 32);
 
-		// Issue #6: For indices >= kStackBitmaskSize we previously always
-		// incremented samplesTaken even for repeated probes, inflating the
-		// count and reducing effective coverage on systems with >1024 packages.
-		// Use a secondary per-call counter for the out-of-range region and
-		// only count the first visit to any given 64-entry stripe.
-		// Avoid checking the same package twice using the bitmask
+		// With kStackBitmaskSize == 4096 and gPackageCount <= 4096 every
+		// valid index i fits inside the bitmask.  The out-of-range branch
+		// is retained as a safety net in case the cap ever changes.
 		int32 word = i / 64;
-		int32 bit = i % 64;
+		int32 bit  = i % 64;
 
-		// Deduplication: skip packages already probed this call (within the
-		// stack bitmask range).
 		if (i < kStackBitmaskSize) {
 			if ((visitedBits[word] & (1ULL << bit)) != 0)
-				continue;	// Duplicate within bitmask range: do NOT count.
+				continue;
 			visitedBits[word] |= (1ULL << bit);
-
-			// Only count unique probes towards the statistical coverage goal.
-			samplesTaken++;
-		} else {
-			// Out-of-range: deduplicate per 64-package stripe via a compact
-			// uint64 stripe-visited bitmask (covers up to 4096 packages in
-			// 64 stripes of 64).
-			int32 stripe = (i - kStackBitmaskSize) / 64;
-			static const int32 kMaxStripes = 64;
-
-			if (stripe >= 0 && stripe < kMaxStripes) {
-				if ((stripeVisited & (1ULL << stripe)) != 0)
-					continue;
-				stripeVisited |= (1ULL << stripe);
-			}
-
-			samplesTaken++;
 		}
+		// For indices >= kStackBitmaskSize (unreachable today) allow the
+		// probe without deduplication; at worst we visit a package twice.
+		samplesTaken++;
 
 		if (action(&gPackageEntries[i]))
 			break;


### PR DESCRIPTION
This batch of changes improves the Haiku kernel scheduler by addressing several race conditions, logic errors, and scalability limitations. Key improvements include robust affinity handling for core selection, safe IRQ rebalancing during topology changes, full coverage for random sampling on large systems, and atomic counter saturation for thread tracking.

---
*PR created automatically by Jules for task [13431053292189218289](https://jules.google.com/task/13431053292189218289) started by @tonestone57*