### PR TITLE
Comprehensive Scheduler Improvements and Race Condition Fixes

### DIFF
--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -450,15 +450,13 @@ RUN_QUEUE_CLASS_NAME::Remove(Element* element)
 	elementLink->fPrevious = NULL;
 	elementLink->fNext = NULL;
 
-	if ((Element*)atomic_pointer_get((void**)&fBest) == element) {
-		// Issue #11 (clarification): The cache is cleared ONLY when the
-		// removed element IS fBest (conditional check above).  If the removed
-		// element is not fBest, the cache is untouched and remains valid.
-		// The original audit finding that "fBest is unconditionally set to NULL
-		// on any Remove" does not match the current code — this is already
-		// correct.  No code change required.
-		atomic_pointer_set((void**)&fBest, (Element*)NULL);
-	}
+	// Issue #18: Unconditionally clear the fBest cache on every removal.
+	// While clearing only when (fBest == element) is a valid optimization
+	// in a strictly locked single-queue context, it is vulnerable to ABA
+	// issues if the same pointer is reallocated and re-added before a
+	// concurrent PeekBest reader completes.  Clearing it unconditionally
+	// ensures the cache never points to an element no longer in the queue.
+	atomic_pointer_set((void**)&fBest, (Element*)NULL);
 }
 
 

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -114,6 +114,9 @@ choose_small_task_core(CPUEntry* cpu)
 	// the general packing logic.
 	if (sSmallTaskCore != NULL && gMinCoreType != gMaxCoreType) {
 		int32 currentNodeID = cpu->Core()->Package()->Node()->ID();
+		if (currentNodeID < 0 || currentNodeID >= gNodeCount)
+			return NULL;
+
 		CoreEntry* current = (CoreEntry*)atomic_pointer_get(
 			&sSmallTaskCore[currentNodeID]);
 		if (current != NULL && current->Type() == gMinCoreType
@@ -165,6 +168,9 @@ choose_small_task_core(CPUEntry* cpu)
 		// capacity (all E-cores are already heavily loaded).
 		if (eCore != NULL) {
 			int32 nodeID = eCore->Package()->Node()->ID();
+			if (nodeID < 0 || nodeID >= gNodeCount)
+				return eCore;
+
 			while (true) {
 				CoreEntry* currentE = (CoreEntry*)atomic_pointer_get(
 					&sSmallTaskCore[nodeID]);
@@ -186,6 +192,9 @@ choose_small_task_core(CPUEntry* cpu)
 
 	if (sSmallTaskCore != NULL) {
 		int32 currentNodeID = cpu->Core()->Package()->Node()->ID();
+		if (currentNodeID < 0 || currentNodeID >= gNodeCount)
+			return NULL;
+
 		CoreEntry* current = (CoreEntry*)atomic_pointer_get(
 			&sSmallTaskCore[currentNodeID]);
 		if (current != NULL && current->GetScore() < kHighLoad)
@@ -223,6 +232,9 @@ choose_small_task_core(CPUEntry* cpu)
 
 	if (sSmallTaskCore != NULL) {
 		int32 nodeID = core->Package()->Node()->ID();
+		if (nodeID < 0 || nodeID >= gNodeCount)
+			return core;
+
 		while (true) {
 			CoreEntry* current = (CoreEntry*)atomic_pointer_get(
 				&sSmallTaskCore[nodeID]);
@@ -601,7 +613,8 @@ rebalance(const ThreadData* threadData)
 		if (core->Package() != NULL && core->Package()->Node() != NULL)
 			nodeID = core->Package()->Node()->ID();
 
-		if (nodeID != -1 && sSmallTaskCore != NULL && atomic_pointer_get(&sSmallTaskCore[nodeID]) == core) {
+		if (nodeID >= 0 && nodeID < gNodeCount && sSmallTaskCore != NULL
+				&& atomic_pointer_get(&sSmallTaskCore[nodeID]) == core) {
 			atomic_pointer_set(&sSmallTaskCore[nodeID], (CoreEntry*)NULL);
 			CoreEntry* smallTaskCore = choose_small_task_core(cpu);
 
@@ -732,6 +745,9 @@ rebalance(const ThreadData* threadData)
 		return core;
 
 	int32 nodeID = core->Package()->Node()->ID();
+	if (nodeID < 0 || nodeID >= gNodeCount)
+		return core;
+
 	CoreEntry* smallTaskCore = choose_small_task_core(cpu);
 	if (smallTaskCore == NULL || (useMask && !smallTaskCore->CPUMask().Matches(mask)))
 		return core;
@@ -775,8 +791,10 @@ rebalance_irqs(bool idle)
 			&& currentCore->Package() != NULL
 			&& currentCore->Package()->Node() != NULL) {
 		int32 nodeID = currentCore->Package()->Node()->ID();
-		if (atomic_pointer_get(&sSmallTaskCore[nodeID]) == currentCore)
+		if (nodeID >= 0 && nodeID < gNodeCount
+				&& atomic_pointer_get(&sSmallTaskCore[nodeID]) == currentCore) {
 			return;
+		}
 	}
 
 	SpinLocker locker(cpu->irqs_lock);
@@ -807,7 +825,8 @@ rebalance_irqs(bool idle)
 				&& currentCore->Package() != NULL
 				&& currentCore->Package()->Node() != NULL) {
 			int32 nodeID = currentCore->Package()->Node()->ID();
-			other = (CoreEntry*)atomic_pointer_get(&sSmallTaskCore[nodeID]);
+			if (nodeID >= 0 && nodeID < gNodeCount)
+				other = (CoreEntry*)atomic_pointer_get(&sSmallTaskCore[nodeID]);
 		}
 	} else {
 		int32 bestScore = -2;

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -16,6 +16,8 @@
 
 #include <OS.h>
 
+#include <algorithm>
+
 #include <AutoDeleter.h>
 #include <cpu.h>
 #include <debug.h>
@@ -1077,25 +1079,26 @@ build_topology_mappings(int32& cpuCount, int32& coreCount, int32& packageCount,
 	}
 
 	// Sort by L3 Topology ID
-	for (int32 i = 1; i < cpuCount; i++) {
-		int32 key = cpuList[i];
-		int32 topoKey = distinctTopology ? get_topology_id(key) : (key / 16); // Fake topology if missing
-		int32 j = i - 1;
+	struct TopologyComparator {
+		bool distinctTopology;
+		TopologyComparator(bool distinct) : distinctTopology(distinct) {}
 
-		while (j >= 0) {
-			int32 compare = cpuList[j];
-			int32 compareTopo = distinctTopology ? get_topology_id(compare) : (compare / 16);
-
-			if (compareTopo > topoKey
-				|| (compareTopo == topoKey && compare > key)) {
-				cpuList[j + 1] = cpuList[j];
-				j--;
-			} else {
-				break;
-			}
+		int32 GetTopoKey(int32 cpu) const
+		{
+			return distinctTopology ? get_topology_id(cpu) : (cpu / 16);
 		}
-		cpuList[j + 1] = key;
-	}
+
+		bool operator()(int32 a, int32 b) const
+		{
+			int32 topoA = GetTopoKey(a);
+			int32 topoB = GetTopoKey(b);
+			if (topoA != topoB)
+				return topoA < topoB;
+			return a < b;
+		}
+	} comparator(distinctTopology);
+
+	std::sort(cpuList, cpuList + cpuCount, comparator);
 
 	packageCount = 0;
 	nodeCount = 0;

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -829,12 +829,20 @@ CoreEntry::RemoveCPU(CPUEntry* cpu, ThreadProcessing& threadPostProcessing)
 	ASSERT(fCPUCount > 0);
 	ASSERT(atomic_get(&fIdleCPUCount) >= 0);
 
-	// Only decrement fIdleCPUCount if the CPU being removed was actually idle.
+	// Issue #30: Strictly reorder updates to fIdleCPUCount and fCPUCount.
+	// By decrementing fIdleCPUCount BEFORE fCPUCount, we ensure that during the
+	// transient window where only one has been updated, the idle ratio
+	// (fIdleCPUCount / fCPUCount) always remains <= 1.0. If we did the reverse,
+	// removing an idle CPU would briefly leave fIdleCPUCount > fCPUCount,
+	// potentially making a non-fully-idle core appear fully idle to concurrent
+	// searches in CPUGoesIdle/CPUWakesUp.
 	if (CPUPriorityHeap::GetKey(cpu) == B_IDLE_PRIORITY)
 		atomic_add(&fIdleCPUCount, -1);
 
 	fCPUSet.ClearBitAtomic(cpu->ID());
-	if (atomic_add(&fCPUCount, -1) == 1) {
+	int32 oldCPUCount = atomic_add(&fCPUCount, -1);
+
+	if (oldCPUCount == 1) {
 		// core has been disabled
 		scheduler_atomic_and(&fPackage->fEnabledCoreMask,
 			~((native_cpu_mask_t)1 << fPackageIndex));
@@ -1139,20 +1147,23 @@ CoreEntry*
 PackageEntry::GetIdleCore(int32 index) const
 {
 	native_cpu_mask_t mask = scheduler_atomic_get(&fIdleCoreMask);
-
-	// Find the N-th set bit (index-th)
-	for (int32 i = 0; i < index; i++) {
-		if (mask == 0)
-			return NULL;
-
-		int32 bit = scheduler_ctz(mask);
-		mask &= ~((native_cpu_mask_t)1 << bit);
-	}
-
 	if (mask == 0)
 		return NULL;
 
-	return fCores[scheduler_ctz(mask)];
+	native_cpu_mask_t currentMask = mask;
+
+	// Find the N-th set bit (index-th)
+	for (int32 i = 0; i < index; i++) {
+		int32 bit = scheduler_ctz(currentMask);
+		currentMask &= ~((native_cpu_mask_t)1 << bit);
+
+		if (currentMask == 0) {
+			// index out of bounds (race), fallback to the first idle core
+			return fCores[scheduler_ctz(mask)];
+		}
+	}
+
+	return fCores[scheduler_ctz(currentMask)];
 }
 
 

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -455,10 +455,8 @@ CPUEntry::_TryStealWork()
 			int32 stolenPriority = -1;
 			ThreadData* stolen = victim->StealThread(stolenPriority, fCPUNumber);
 
-			if (stolen != NULL) {
+			if (stolen != NULL)
 				stolen->MigrateTo(fCore);
-				fCore->IncrementTotalThreadCount();
-			}
 
 			victim->UnlockRunQueue();
 
@@ -502,7 +500,6 @@ CPUEntry::_TryStealWork()
 
 			if (stolen != NULL) {
 				stolen->MigrateTo(fCore);
-				fCore->IncrementTotalThreadCount();
 				victim->UnlockRunQueue();
 				return true;
 			}
@@ -551,7 +548,6 @@ CPUEntry::_TryStealWork()
 
 			if (stolen != NULL) {
 				stolen->MigrateTo(fCore);
-				fCore->IncrementTotalThreadCount();
 				victim->UnlockRunQueue();
 				return true;
 			}
@@ -835,11 +831,11 @@ CoreEntry::RemoveCPU(CPUEntry* cpu, ThreadProcessing& threadPostProcessing)
 
 	// Issue #30: Strictly reorder updates to fIdleCPUCount and fCPUCount.
 	// By decrementing fIdleCPUCount BEFORE fCPUCount, we ensure that during the
-	// transient window where only one has been updated, the idle ratio
-	// (fIdleCPUCount / fCPUCount) always remains <= 1.0. If we did the reverse,
-	// removing an idle CPU would briefly leave fIdleCPUCount > fCPUCount,
-	// potentially making a non-fully-idle core appear fully idle to concurrent
-	// searches in CPUGoesIdle/CPUWakesUp.
+	// transient window where only one has been updated, fIdleCPUCount / fCPUCount
+	// always produces a ratio <= 1.0. If we did the reverse, removing an idle
+	// CPU would briefly leave fIdleCPUCount > fCPUCount (e.g. 1 idle / 0 total),
+	// making a core appear fully idle while a thread might still be running or
+	// waking up on the remaining CPU.
 	if (CPUPriorityHeap::GetKey(cpu) == B_IDLE_PRIORITY)
 		atomic_add(&fIdleCPUCount, -1);
 

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -330,6 +330,10 @@ CPUEntry::ChooseNextThread(ThreadData* oldThread, bool putAtBack)
 	}
 
 	if (sharedPriority > pinnedPriority) {
+		if (sharedThread->fStolen) {
+			fCore->DecrementTotalThreadCount();
+			sharedThread->fStolen = false;
+		}
 		if (sharedThread->Core() == fCore && !sharedThreadIsFloating)
 			fCore->Remove(sharedThread);
 		return sharedThread;
@@ -455,8 +459,11 @@ CPUEntry::_TryStealWork()
 			int32 stolenPriority = -1;
 			ThreadData* stolen = victim->StealThread(stolenPriority, fCPUNumber);
 
-			if (stolen != NULL)
+			if (stolen != NULL) {
 				stolen->MigrateTo(fCore);
+				stolen->fStolen = true;
+				fCore->IncrementTotalThreadCount();
+			}
 
 			victim->UnlockRunQueue();
 
@@ -500,6 +507,8 @@ CPUEntry::_TryStealWork()
 
 			if (stolen != NULL) {
 				stolen->MigrateTo(fCore);
+				stolen->fStolen = true;
+				fCore->IncrementTotalThreadCount();
 				victim->UnlockRunQueue();
 				return true;
 			}
@@ -548,6 +557,8 @@ CPUEntry::_TryStealWork()
 
 			if (stolen != NULL) {
 				stolen->MigrateTo(fCore);
+				stolen->fStolen = true;
+				fCore->IncrementTotalThreadCount();
 				victim->UnlockRunQueue();
 				return true;
 			}

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -455,8 +455,10 @@ CPUEntry::_TryStealWork()
 			int32 stolenPriority = -1;
 			ThreadData* stolen = victim->StealThread(stolenPriority, fCPUNumber);
 
-			if (stolen != NULL)
+			if (stolen != NULL) {
 				stolen->MigrateTo(fCore);
+				fCore->IncrementTotalThreadCount();
+			}
 
 			victim->UnlockRunQueue();
 
@@ -500,6 +502,7 @@ CPUEntry::_TryStealWork()
 
 			if (stolen != NULL) {
 				stolen->MigrateTo(fCore);
+				fCore->IncrementTotalThreadCount();
 				victim->UnlockRunQueue();
 				return true;
 			}
@@ -548,6 +551,7 @@ CPUEntry::_TryStealWork()
 
 			if (stolen != NULL) {
 				stolen->MigrateTo(fCore);
+				fCore->IncrementTotalThreadCount();
 				victim->UnlockRunQueue();
 				return true;
 			}

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -705,7 +705,7 @@ PackageEntry::CoreGoesIdle(CoreEntry* core)
 	atomic_add(&fIdleCoreCount, 1);
 
 	if (oldMask == 0) {
-		// Issue #34 (clarification): The race between AddIdleCore (which holds
+		// Issue #4 (clarification): The race between AddIdleCore (which holds
 		// fCoreLock) and CoreGoesIdle (which does not hold fCoreLock) on the
 		// oldMask==0 → PackageGoesIdle path is benign in practice: both paths
 		// are guarded by the InterruptsBigSchedulerLocker at their call sites

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -774,17 +774,15 @@ SchedulerNode::PackageWakesUp(PackageEntry* package)
 	// Only clear the bit in gIdleNodeMask if this package was actually idle
 	// (bit was set in oldMask) AND it was the last idle package in this node
 	// (mask is now zero).
-	if ((oldMask & clearBit) != 0 && (oldMask & ~clearBit) == 0)
-		// Issue #39 (clarification): Between the atomic_and on fIdlePackageMask
-		// and the atomic_and on gIdleNodeMask, another CPU can call
-		// PackageGoesIdle on a different package in the same node, setting a
-		// new bit in fIdlePackageMask.  If that happens, we clear the node bit
-		// in gIdleNodeMask even though the node still has idle packages.  The
-		// inconsistency is self-healing: the next PackageGoesIdle will restore
-		// the node bit.  The window is small and the consequence is at most one
-		// scheduling quantum of missed idle-core wakeups — acceptable for a
-		// lock-free fast path.  A full fix requires a CAS retry loop here.
+	if ((oldMask & clearBit) != 0 && (oldMask & ~clearBit) == 0) {
 		atomic_and64((int64*)&gIdleNodeMask, ~(1ULL << fNodeID));
+
+		// Double-check to resolve the race with PackageGoesIdle. If another
+		// package in this node went idle between the atomic_and64 calls
+		// above, we must restore the bit in gIdleNodeMask.
+		if (atomic_get64((int64*)&fIdlePackageMask) != 0)
+			atomic_or64((int64*)&gIdleNodeMask, 1ULL << fNodeID);
+	}
 }
 
 

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -583,6 +583,9 @@ ThreadData::_ComputeEffectivePriority(bigtime_t now) const
 		}
 
 		const int32 kMaxDynamicPriority = B_FIRST_REAL_TIME_PRIORITY - 1;
+		static_assert(kMaxDynamicPriority <= THREAD_MAX_SET_PRIORITY,
+			"kMaxDynamicPriority exceeds THREAD_MAX_SET_PRIORITY");
+
 		bigtime_t urgency = kMaxDynamicPriority - diff / bucketSize;
 		if (urgency < 0) urgency = 0;
 		if (urgency > kMaxDynamicPriority) urgency = kMaxDynamicPriority;
@@ -596,11 +599,7 @@ ThreadData::_ComputeEffectivePriority(bigtime_t now) const
 		fEffectivePriority = (int32)urgency;
 	}
 
-	int32 effectivePriority = GetEffectivePriority();
-	if (effectivePriority > THREAD_MAX_SET_PRIORITY)
-		effectivePriority = THREAD_MAX_SET_PRIORITY;
-
-	fBaseQuantum = atomic_get64(&sQuantumLengths[effectivePriority]);
+	fBaseQuantum = atomic_get64(&sQuantumLengths[GetEffectivePriority()]);
 }
 
 

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -64,6 +64,7 @@ ThreadData::_InitBase()
 	fInteractivityScore = 500;
 
 	fIsForeground = fThread->team->fIsForeground;
+	fStolen = false;
 }
 
 

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -139,6 +139,7 @@ private:
 			bool		fReady;
 			bool		fQuickStartCredit;
 			bool		fIsForeground;
+			bool		fStolen;
 
 			Thread*		fThread;
 
@@ -567,6 +568,11 @@ ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption)
 	if (!pinned) {
 		CoreCPULocker cpuLocker(fCore);
 		CoreRunQueueLocker locker(fCore);
+
+		if (fStolen) {
+			fCore->DecrementTotalThreadCount();
+			fStolen = false;
+		}
 
 		// Check if the Core is still active under the lock.
 		if (fCore->CPUCount() == 0) {

--- a/src/system/kernel/scheduler/scheduling_analysis.cpp
+++ b/src/system/kernel/scheduler/scheduling_analysis.cpp
@@ -278,13 +278,27 @@ public:
 		ASSERT(fHashTable == NULL
 			|| (uint8*)fHashTable - fNextAllocation == (ptrdiff_t)fRemainingBytes);
 #endif
-		if (size > fRemainingBytes)
-			return NULL;
+		while (true) {
+#if B_HAIKU_64_BIT
+			int64 remaining = atomic_get64((int64*)&fRemainingBytes);
+			if ((int64)size > remaining)
+				return NULL;
 
-		void* address = fNextAllocation;
-		fNextAllocation += size;
-		fRemainingBytes -= size;
-		return address;
+			if (atomic_test_and_set64((int64*)&fRemainingBytes,
+					remaining - (int64)size, remaining) == remaining) {
+				return (void*)atomic_add64((int64*)&fNextAllocation, (int64)size);
+			}
+#else
+			int32 remaining = atomic_get((int32*)&fRemainingBytes);
+			if ((int32)size > remaining)
+				return NULL;
+
+			if (atomic_test_and_set((int32*)&fRemainingBytes,
+					remaining - (int32)size, remaining) == remaining) {
+				return (void*)atomic_add((int32*)&fNextAllocation, (int32)size);
+			}
+#endif
+		}
 	}
 
 	void Insert(HashObject* object)

--- a/src/system/kernel/scheduler/scheduling_analysis.cpp
+++ b/src/system/kernel/scheduler/scheduling_analysis.cpp
@@ -633,8 +633,8 @@ private:
 	size_t				fSize;
 	HashObject**		fHashTable;
 	uint32				fHashTableSize;
-	uint8*				fNextAllocation;
-	size_t				fRemainingBytes;
+	alignas(8) uint8*	fNextAllocation;
+	alignas(8) size_t	fRemainingBytes;
 };
 
 


### PR DESCRIPTION
I have completed the task of applying several improvements to the Haiku kernel scheduler. 

The fixes address:
- **Race conditions** in idle state tracking (gIdleNodeMask) and CPU removal logic.
- **Safety issues**, including out-of-bounds array accesses (nodeID) and NULL pointer returns from GetIdleCore.
- **Concurrency bugs**, specifically a race in the lock-free allocator for scheduling analysis and an ABA problem in the RunQueue cache.
- **Performance bottlenecks**, replacing an O(N^2) sort during boot with an O(N log N) implementation.
- **Technical debt**, such as redundant priority clamping and inconsistent thread load tracking during work-stealing.

All changes have been refined based on code review feedback to ensure kernel-grade correctness, particularly in high-concurrency paths.

---
*PR created automatically by Jules for task [9498053689188554832](https://jules.google.com/task/9498053689188554832) started by @tonestone57*