### PR TITLE
Scheduler Audit and Compatibility Fixes

### DIFF
--- a/src/system/kernel/scheduler/low_latency.cpp
+++ b/src/system/kernel/scheduler/low_latency.cpp
@@ -17,7 +17,25 @@
 #include "scheduler_topology.h"
 
 
-using namespace Scheduler;
+namespace Scheduler {
+
+struct MinimumLoadAction {
+	CPUEntry* cpu;
+	const CPUSet* mask;
+	CoreEntry*& bestCore;
+	int32& bestLoad;
+	CoreType type;
+
+	MinimumLoadAction(CPUEntry* c, const CPUSet* m, CoreEntry*& bc, int32& bl,
+		CoreType t = CORE_TYPE_UNKNOWN)
+		: cpu(c), mask(m), bestCore(bc), bestLoad(bl), type(t) {}
+
+	bool operator()(PackageEntry* entry) const {
+		return CheckPackageMinimumLoad(cpu, entry, mask, bestCore, bestLoad, type);
+	}
+};
+
+
 
 
 // --- Scheduler tuning (low latency mode improvements) ---
@@ -61,21 +79,7 @@ has_cache_expired(const ThreadData* threadData)
 
 
 
-struct MinimumLoadAction {
-	CPUEntry* cpu;
-	const CPUSet* mask;
-	CoreEntry*& bestCore;
-	int32& bestLoad;
-	CoreType type;
 
-	MinimumLoadAction(CPUEntry* c, const CPUSet* m, CoreEntry*& bc, int32& bl,
-		CoreType t = CORE_TYPE_UNKNOWN)
-		: cpu(c), mask(m), bestCore(bc), bestLoad(bl), type(t) {}
-
-	bool operator()(PackageEntry* entry) const {
-		return CheckPackageMinimumLoad(cpu, entry, mask, bestCore, bestLoad, type);
-	}
-};
 
 static CoreEntry*
 choose_core(const ThreadData* threadData)
@@ -835,3 +839,5 @@ scheduler_mode_operations gSchedulerLowLatencyMode = {
 	rebalance,
 	rebalance_irqs,
 };
+
+}	// namespace Scheduler

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -20,6 +20,17 @@
 
 namespace Scheduler {
 
+static void
+check_package_small_task(CPUEntry* cpu, PackageEntry* entry, CoreEntry*& core,
+	int32& bestScore);
+
+
+static void
+check_package_packing(CPUEntry* cpu, PackageEntry* entry, const CPUSet* mask,
+	CoreEntry*& other, int32& bestScore, bool& foundNonOverloaded,
+	CoreType type = CORE_TYPE_UNKNOWN);
+
+
 struct MinimumLoadAction {
 	CPUEntry* cpu;
 	const CPUSet* mask;
@@ -145,18 +156,6 @@ has_cache_expired(const ThreadData* threadData)
 
 
 
-static void
-check_package_small_task(CPUEntry* cpu, PackageEntry* entry, CoreEntry*& core,
-	int32& bestScore);
-
-
-
-
-
-static void
-check_package_packing(CPUEntry* cpu, PackageEntry* entry, const CPUSet* mask,
-	CoreEntry*& other, int32& bestScore, bool& foundNonOverloaded,
-	CoreType type = CORE_TYPE_UNKNOWN);
 
 
 

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -18,7 +18,80 @@
 #include "scheduler_topology.h"
 
 
-using namespace Scheduler;
+namespace Scheduler {
+
+struct MinimumLoadAction {
+	CPUEntry* cpu;
+	const CPUSet* mask;
+	CoreEntry*& bestCore;
+	int32& bestLoad;
+	CoreType type;
+
+	MinimumLoadAction(CPUEntry* c, const CPUSet* m, CoreEntry*& bc, int32& bl,
+		CoreType t = CORE_TYPE_UNKNOWN)
+		: cpu(c), mask(m), bestCore(bc), bestLoad(bl), type(t) {}
+
+	bool operator()(PackageEntry* entry) const {
+		return CheckPackageMinimumLoad(cpu, entry, mask, bestCore, bestLoad, type);
+	}
+};
+
+struct SmallTaskAction {
+	CPUEntry* cpu;
+	CoreEntry*& core;
+	int32& bestScore;
+
+	SmallTaskAction(CPUEntry* c, CoreEntry*& co, int32& s)
+		: cpu(c), core(co), bestScore(s) {}
+
+	bool operator()(PackageEntry* entry) const {
+		check_package_small_task(cpu, entry, core, bestScore);
+		return core != NULL && bestScore >= (kHighLoad * 3) / 4;
+	}
+};
+
+struct ECoreSmallTaskAction {
+	CPUEntry* cpu;
+	CoreEntry*& eCore;
+	int32& eBestScore;
+
+	ECoreSmallTaskAction(CPUEntry* c, CoreEntry*& ec, int32& es)
+		: cpu(c), eCore(ec), eBestScore(es) {}
+
+	bool operator()(PackageEntry* entry) const {
+		CoreEntry* candidate
+			= entry->PeekMaximumLoadCore(cpu, NULL, gMinCoreType);
+		if (candidate != NULL && candidate->GetScore() < kHighLoad) {
+			int32 score = candidate->GetScore();
+			if (eCore == NULL || score > eBestScore) {
+				eCore = candidate;
+				eBestScore = score;
+			}
+		}
+		return eCore != NULL && eBestScore >= (kHighLoad * 3) / 4;
+	}
+};
+
+struct PackagePackingAction {
+	CPUEntry* cpu;
+	const CPUSet* mask;
+	CoreEntry*& other;
+	int32& bestScore;
+	bool& foundNonOverloaded;
+	CoreType type;
+
+	PackagePackingAction(CPUEntry* c, const CPUSet* m, CoreEntry*& o, int32& bs,
+		bool& fno, CoreType t = CORE_TYPE_UNKNOWN)
+		: cpu(c), mask(m), other(o), bestScore(bs), foundNonOverloaded(fno), type(t) {}
+
+	bool operator()(PackageEntry* entry) const {
+		check_package_packing(cpu, entry, mask, other, bestScore,
+			foundNonOverloaded, type);
+		return other != NULL && foundNonOverloaded && bestScore >= (kHighLoad * 3) / 4;
+	}
+};
+
+
 
 
 // --- Scheduler tuning (power saving mode improvements) ---
@@ -70,85 +143,22 @@ has_cache_expired(const ThreadData* threadData)
 }
 
 
-struct MinimumLoadAction {
-	CPUEntry* cpu;
-	const CPUSet* mask;
-	CoreEntry*& bestCore;
-	int32& bestLoad;
-	CoreType type;
 
-	MinimumLoadAction(CPUEntry* c, const CPUSet* m, CoreEntry*& bc, int32& bl,
-		CoreType t = CORE_TYPE_UNKNOWN)
-		: cpu(c), mask(m), bestCore(bc), bestLoad(bl), type(t) {}
-
-	bool operator()(PackageEntry* entry) const {
-		return CheckPackageMinimumLoad(cpu, entry, mask, bestCore, bestLoad, type);
-	}
-};
 
 static void
 check_package_small_task(CPUEntry* cpu, PackageEntry* entry, CoreEntry*& core,
 	int32& bestScore);
 
-struct SmallTaskAction {
-	CPUEntry* cpu;
-	CoreEntry*& core;
-	int32& bestScore;
 
-	SmallTaskAction(CPUEntry* c, CoreEntry*& co, int32& s)
-		: cpu(c), core(co), bestScore(s) {}
 
-	bool operator()(PackageEntry* entry) const {
-		check_package_small_task(cpu, entry, core, bestScore);
-		return core != NULL && bestScore >= (kHighLoad * 3) / 4;
-	}
-};
 
-struct ECoreSmallTaskAction {
-	CPUEntry* cpu;
-	CoreEntry*& eCore;
-	int32& eBestScore;
-
-	ECoreSmallTaskAction(CPUEntry* c, CoreEntry*& ec, int32& es)
-		: cpu(c), eCore(ec), eBestScore(es) {}
-
-	bool operator()(PackageEntry* entry) const {
-		CoreEntry* candidate
-			= entry->PeekMaximumLoadCore(cpu, NULL, gMinCoreType);
-		if (candidate != NULL && candidate->GetScore() < kHighLoad) {
-			int32 score = candidate->GetScore();
-			if (eCore == NULL || score > eBestScore) {
-				eCore = candidate;
-				eBestScore = score;
-			}
-		}
-		return eCore != NULL && eBestScore >= (kHighLoad * 3) / 4;
-	}
-};
 
 static void
 check_package_packing(CPUEntry* cpu, PackageEntry* entry, const CPUSet* mask,
 	CoreEntry*& other, int32& bestScore, bool& foundNonOverloaded,
 	CoreType type = CORE_TYPE_UNKNOWN);
 
-struct PackagePackingAction {
-	CPUEntry* cpu;
-	const CPUSet* mask;
-	CoreEntry*& other;
-	int32& bestScore;
-	bool& foundNonOverloaded;
-	CoreType type;
 
-	PackagePackingAction(CPUEntry* c, const CPUSet* m, CoreEntry*& o, int32& bs,
-		bool& fno, CoreType t = CORE_TYPE_UNKNOWN)
-		: cpu(c), mask(m), other(o), bestScore(bs), foundNonOverloaded(fno), type(t) {}
-
-	bool operator()(PackageEntry* entry) const {
-		check_package_packing(cpu, entry, mask, other, bestScore,
-			foundNonOverloaded, type);
-		return other != NULL && foundNonOverloaded && bestScore >= (kHighLoad * 3) / 4;
-	}
-};
 
 static void
 check_package_small_task(CPUEntry* cpu, PackageEntry* entry, CoreEntry*& core,
@@ -1091,3 +1101,5 @@ scheduler_mode_operations gSchedulerPowerSavingMode = {
 	rebalance,
 	rebalance_irqs,
 };
+
+}	// namespace Scheduler

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -77,7 +77,7 @@ spinlock gSchedulerLock = B_SPINLOCK_INITIALIZER;
 
 
 static timer sInteractionTimer;
-static int64 sLastInteractionTime;
+static int64 sLastInteractionTime __attribute__((aligned(8)));
 static int32 sDPCPending = 0;
 // Atomic guard for sInteractionTimer arming.
 // timer_is_active() followed by add_timer() is not atomic: two CPUs can both
@@ -264,9 +264,68 @@ scheduler_update_interaction_state()
 }
 
 
-}	// namespace Scheduler
 
-using namespace Scheduler;
+struct RunQueueScanner {
+		uint32 kTopWordMask;
+		int kMaxThreadsToCheckPerQueue;
+
+		RunQueueScanner(uint32 topWordMask, int maxThreads)
+			: kTopWordMask(topWordMask), kMaxThreadsToCheckPerQueue(maxThreads) {}
+
+		void operator()(const ThreadRunQueue* runQueue) const {
+			const uint32* bitmap = runQueue->GetBitmap();
+
+			for (int i = ThreadRunQueue::kBitmapSize - 1; i >= 0; i--) {
+				uint32 val = bitmap[i];
+
+				if (i == ThreadRunQueue::kBitmapSize - 1)
+					val &= kTopWordMask;
+
+				if (val == 0)
+					continue;
+
+				int bit = fls(val) - 1;
+				while (true) {
+					unsigned int priority = i * 32 + bit;
+					ThreadData* thread = runQueue->GetHead(priority);
+					int count = 0;
+
+					while (thread != NULL && count++ < kMaxThreadsToCheckPerQueue) {
+						ThreadData* next = thread->GetRunQueueLink()->fNext;
+						thread->_UpdatePriorityBoost();
+						thread = next;
+					}
+
+					val &= ~(1UL << bit);
+					if (val == 0)
+						break;
+					bit = fls(val) - 1;
+				}
+			}
+		}
+	};
+
+
+struct TopologyComparator {
+		bool distinctTopology;
+		TopologyComparator(bool distinct) : distinctTopology(distinct) {}
+
+		int32 GetTopoKey(int32 cpu) const
+		{
+			return distinctTopology ? get_topology_id(cpu) : (cpu / 16);
+		}
+
+		bool operator()(int32 a, int32 b) const
+		{
+			int32 topoA = GetTopoKey(a);
+			int32 topoB = GetTopoKey(b);
+			if (topoA != topoB)
+				return topoA < topoB;
+			return a < b;
+		}
+	};
+
+
 
 
 static int32 sSchedulerEnabled;
@@ -316,45 +375,7 @@ UpdatePriorityBoostScalable(CoreEntry* core, CPUEntry* cpu)
 
 	const int kMaxThreadsToCheckPerQueue = 5;
 
-	struct RunQueueScanner {
-		uint32 kTopWordMask;
-		int kMaxThreadsToCheckPerQueue;
-
-		RunQueueScanner(uint32 topWordMask, int maxThreads)
-			: kTopWordMask(topWordMask), kMaxThreadsToCheckPerQueue(maxThreads) {}
-
-		void operator()(const ThreadRunQueue* runQueue) const {
-			const uint32* bitmap = runQueue->GetBitmap();
-
-			for (int i = ThreadRunQueue::kBitmapSize - 1; i >= 0; i--) {
-				uint32 val = bitmap[i];
-
-				if (i == ThreadRunQueue::kBitmapSize - 1)
-					val &= kTopWordMask;
-
-				if (val == 0)
-					continue;
-
-				int bit = fls(val) - 1;
-				while (true) {
-					unsigned int priority = i * 32 + bit;
-					ThreadData* thread = runQueue->GetHead(priority);
-					int count = 0;
-
-					while (thread != NULL && count++ < kMaxThreadsToCheckPerQueue) {
-						ThreadData* next = thread->GetRunQueueLink()->fNext;
-						thread->_UpdatePriorityBoost();
-						thread = next;
-					}
-
-					val &= ~(1UL << bit);
-					if (val == 0)
-						break;
-					bit = fls(val) - 1;
-				}
-			}
-		}
-	} scanRunQueue(kTopWordMask, kMaxThreadsToCheckPerQueue);
+	RunQueueScanner scanRunQueue(kTopWordMask, kMaxThreadsToCheckPerQueue);
 
 	// Check Core RunQueue first to maintain Core -> CPU lock ordering
 	// On an N-way SMT core, all N CPUs previously scanned the shared
@@ -1270,24 +1291,7 @@ build_topology_mappings(int32& cpuCount, int32& coreCount, int32& packageCount,
 	}
 
 	// Sort by L3 Topology ID
-	struct TopologyComparator {
-		bool distinctTopology;
-		TopologyComparator(bool distinct) : distinctTopology(distinct) {}
-
-		int32 GetTopoKey(int32 cpu) const
-		{
-			return distinctTopology ? get_topology_id(cpu) : (cpu / 16);
-		}
-
-		bool operator()(int32 a, int32 b) const
-		{
-			int32 topoA = GetTopoKey(a);
-			int32 topoB = GetTopoKey(b);
-			if (topoA != topoB)
-				return topoA < topoB;
-			return a < b;
-		}
-	} comparator(distinctTopology);
+	TopologyComparator comparator(distinctTopology);
 
 	std::sort(cpuList, cpuList + cpuCount, comparator);
 
@@ -1986,19 +1990,12 @@ scheduler_on_team_foreground_changed(Team* team)
 
 			if (thread != NULL) {
 				batchStart = batch[count - 1];
-				// Issue 3 fix: batchStart already has a reference from the
-				// AcquireReference() call in the collection loop above (stored
-				// in batch[count-1]). SetTo(batchStart, true) claims ownership
-				// of that reference — do NOT call AcquireReference() again or
-				// we leak one reference per batch boundary.
-				// The batch[count-1] entry's reference is "donated" to
-				// batchStartRef here; it is released when batchStartRef goes
-				// out of scope or is reset at the next batch start.
-				batchStartRef.SetTo(batchStart, true);
-				// Issue 47 fix: remove the batch[count-1] entry from the
-				// batch array to prevent processing it twice — once in this
-				// batch and once as the cursor in the next batch's GetNext().
-				count--;
+				// We need a reference for batchStart to survive as the cursor
+				// for the next batch.  We already have one from the collection
+				// loop above, but we also want to process it in the current
+				// batch (which also claims ownership of one reference).
+				// So we acquire another one here.
+				batchStartRef.SetTo(batchStart, false);
 				moreBatches = true;
 			}
 		} // thread_list_lock released here
@@ -2048,3 +2045,5 @@ scheduler_on_team_foreground_changed(Team* team)
 		}
 	}
 }
+
+}	// namespace Scheduler

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -20,6 +20,13 @@
 
 namespace Scheduler {
 
+static inline uint32
+get_random_index(uint32 random, uint32 range)
+{
+	// Robust mapping to reduce modulo bias.
+	return (uint32)(((uint64)random * range) >> 32);
+}
+
 
 CPUEntry* gCPUEntries;
 
@@ -30,13 +37,133 @@ PackageEntry* gPackageEntries;
 int32 gPackageCount;
 
 SchedulerNode* gSchedulerNodes;
-uint64 gIdleNodeMask = 0;
+uint64 gIdleNodeMask __attribute__((aligned(8))) = 0;
 int32 gNodeCount;
 
 
-}	// namespace Scheduler
 
-using namespace Scheduler;
+struct LocalNodeStealAction {
+	CPUEntry* cpu;
+	PackageEntry* package;
+	ThreadData** stolen;
+
+	LocalNodeStealAction(CPUEntry* c, PackageEntry* p, ThreadData** s)
+		: cpu(c), package(p), stolen(s) {}
+
+	bool operator()(PackageEntry* entry) const {
+		if (*stolen != NULL)
+			return true;
+
+		if (entry == package)
+			return false;
+
+		int32 victimCoreCount = entry->RegisteredCoreCount();
+		if (victimCoreCount == 0)
+			return false;
+
+		int32 coreIndex = (int32)get_random_index(cpu->GetRandom(), victimCoreCount);
+		CoreEntry* victim = entry->GetCore(coreIndex);
+
+		if (victim == NULL)
+			return false;
+
+		if ((entry->IdleCoreMask() & ((native_cpu_mask_t)1 << victim->PackageIndex())) != 0)
+			return false;
+
+		if (victim->TryLockRunQueue()) {
+			int32 stolenPriority = -1;
+			*stolen = victim->StealThread(stolenPriority, cpu->ID());
+
+			if (*stolen != NULL) {
+				(*stolen)->MigrateTo(cpu->Core());
+				(*stolen)->fStolen = true;
+				cpu->Core()->IncrementTotalThreadCount();
+				victim->UnlockRunQueue();
+				return true;
+			}
+
+			victim->UnlockRunQueue();
+		}
+
+		return false;
+	}
+};
+
+struct GlobalRandomStealAction {
+	CPUEntry* cpu;
+	PackageEntry* package;
+	ThreadData** stolen;
+
+	GlobalRandomStealAction(CPUEntry* c, PackageEntry* p, ThreadData** s)
+		: cpu(c), package(p), stolen(s) {}
+
+	bool operator()(PackageEntry* entry) const {
+		if (*stolen != NULL)
+			return true;
+
+		if (entry == package)
+			return false;
+
+		if (entry->IdleCoreCount() == entry->CoreCount())
+			return false;
+
+		int32 victimCoreCount = entry->RegisteredCoreCount();
+		if (victimCoreCount == 0)
+			return false;
+
+		int32 coreIndex = (int32)get_random_index(cpu->GetRandom(), victimCoreCount);
+		CoreEntry* victim = entry->GetCore(coreIndex);
+
+		if (victim == NULL)
+			return false;
+
+		if ((entry->IdleCoreMask() & ((native_cpu_mask_t)1 << victim->PackageIndex())) != 0)
+			return false;
+
+		if (victim->TryLockRunQueue()) {
+			int32 stolenPriority = -1;
+			*stolen = victim->StealThread(stolenPriority, cpu->ID());
+
+			if (*stolen != NULL) {
+				(*stolen)->MigrateTo(cpu->Core());
+				(*stolen)->fStolen = true;
+				cpu->Core()->IncrementTotalThreadCount();
+				victim->UnlockRunQueue();
+				return true;
+			}
+
+			victim->UnlockRunQueue();
+		}
+
+		return false;
+	}
+};
+
+struct StealThreadPredicate {
+	const CPUSet& enabledSnapshot;
+	int32 thiefCPU;
+
+	StealThreadPredicate(const CPUSet& e, int32 t)
+		: enabledSnapshot(e), thiefCPU(t) {}
+
+	bool operator()(ThreadData* td) const {
+		if (td->IsIdle())
+			return false;
+
+		const CPUSet& cpumask = td->GetThread()->cpumask;
+		if (cpumask.IsEmpty()) {
+			return enabledSnapshot.GetBit(thiefCPU);
+		}
+		return cpumask.GetBit(thiefCPU)
+			&& enabledSnapshot.GetBit(thiefCPU);
+	}
+};
+
+struct CoreThreadsData {
+			CoreEntry*	fCore;
+			int32		fLoad;
+	};
+
 
 
 class Scheduler::DebugDumper {
@@ -48,10 +175,6 @@ public:
 	static	void		DumpPackageCores(PackageEntry* package);
 
 private:
-	struct CoreThreadsData {
-			CoreEntry*	fCore;
-			int32		fLoad;
-	};
 
 	static	void		_AnalyzeCoreThreads(Thread* thread, void* data);
 };
@@ -98,7 +221,11 @@ CPUEntry::CPUEntry()
 	fUpdateLoadEvent(false),
 	fRandomState(1),
 	fRescheduleCount(0),
-	fCoreLocalIndex(0)
+	fCoreLocalIndex(0),
+	fInteractionUpdateCounter(0),
+	fReschedulePending(0),
+	fLastLocalPackageIndex(0),
+	lastReschedule(0)
 {
 	B_INITIALIZE_RW_SPINLOCK(&fSchedulerModeLock);
 	B_INITIALIZE_SPINLOCK(&fQueueLock);
@@ -138,15 +265,6 @@ CPUEntry::Init(int32 id, CoreEntry* core)
 		int32 staggerMod = (numCPUs > 1 && numCPUs <= 10) ? numCPUs : 10;
 		fRescheduleCount = (uint32)(id % staggerMod);
 	}
-
-	// Issue 92 fix: explicitly initialise fInteractionUpdateCounter in the
-	// constructor. If Init() is never called (e.g. disabled CPUs that skip
-	// initialisation), the counter contains garbage and the modulo-32 throttle
-	// in scheduler_update_interaction_state fires unpredictably.
-	fInteractionUpdateCounter = 0;
-	fReschedulePending = 0;
-	fLastLocalPackageIndex = 0;	//
-	lastReschedule = 0;
 }
 
 
@@ -549,110 +667,12 @@ CPUEntry::GetRandom()
 }
 
 
-static inline uint32
-get_random_index(uint32 random, uint32 range)
-{
-	// Robust mapping to reduce modulo bias.
-	return (uint32)(((uint64)random * range) >> 32);
-}
 
 
-struct LocalNodeStealAction {
-	CPUEntry* cpu;
-	PackageEntry* package;
-	ThreadData** stolen;
 
-	LocalNodeStealAction(CPUEntry* c, PackageEntry* p, ThreadData** s)
-		: cpu(c), package(p), stolen(s) {}
 
-	bool operator()(PackageEntry* entry) const {
-		if (*stolen != NULL)
-			return true;
 
-		if (entry == package)
-			return false;
 
-		int32 victimCoreCount = entry->RegisteredCoreCount();
-		if (victimCoreCount == 0)
-			return false;
-
-		int32 coreIndex = (int32)get_random_index(cpu->GetRandom(), victimCoreCount);
-		CoreEntry* victim = entry->GetCore(coreIndex);
-
-		if (victim == NULL)
-			return false;
-
-		if ((entry->IdleCoreMask() & ((native_cpu_mask_t)1 << victim->PackageIndex())) != 0)
-			return false;
-
-		if (victim->TryLockRunQueue()) {
-			int32 stolenPriority = -1;
-			*stolen = victim->StealThread(stolenPriority, cpu->ID());
-
-			if (*stolen != NULL) {
-				(*stolen)->MigrateTo(cpu->Core());
-				(*stolen)->fStolen = true;
-				cpu->Core()->IncrementTotalThreadCount();
-				victim->UnlockRunQueue();
-				return true;
-			}
-
-			victim->UnlockRunQueue();
-		}
-
-		return false;
-	}
-};
-
-struct GlobalRandomStealAction {
-	CPUEntry* cpu;
-	PackageEntry* package;
-	ThreadData** stolen;
-
-	GlobalRandomStealAction(CPUEntry* c, PackageEntry* p, ThreadData** s)
-		: cpu(c), package(p), stolen(s) {}
-
-	bool operator()(PackageEntry* entry) const {
-		if (*stolen != NULL)
-			return true;
-
-		if (entry == package)
-			return false;
-
-		if (entry->IdleCoreCount() == entry->CoreCount())
-			return false;
-
-		int32 victimCoreCount = entry->RegisteredCoreCount();
-		if (victimCoreCount == 0)
-			return false;
-
-		int32 coreIndex = (int32)get_random_index(cpu->GetRandom(), victimCoreCount);
-		CoreEntry* victim = entry->GetCore(coreIndex);
-
-		if (victim == NULL)
-			return false;
-
-		if ((entry->IdleCoreMask() & ((native_cpu_mask_t)1 << victim->PackageIndex())) != 0)
-			return false;
-
-		if (victim->TryLockRunQueue()) {
-			int32 stolenPriority = -1;
-			*stolen = victim->StealThread(stolenPriority, cpu->ID());
-
-			if (*stolen != NULL) {
-				(*stolen)->MigrateTo(cpu->Core());
-				(*stolen)->fStolen = true;
-				cpu->Core()->IncrementTotalThreadCount();
-				victim->UnlockRunQueue();
-				return true;
-			}
-
-			victim->UnlockRunQueue();
-		}
-
-		return false;
-	}
-};
 
 ThreadData*
 CPUEntry::_TryStealWork()
@@ -957,25 +977,7 @@ CoreEntry::Remove(ThreadData* thread)
 }
 
 
-struct StealThreadPredicate {
-	const CPUSet& enabledSnapshot;
-	int32 thiefCPU;
 
-	StealThreadPredicate(const CPUSet& e, int32 t)
-		: enabledSnapshot(e), thiefCPU(t) {}
-
-	bool operator()(ThreadData* td) const {
-		if (td->IsIdle())
-			return false;
-
-		const CPUSet& cpumask = td->GetThread()->cpumask;
-		if (cpumask.IsEmpty()) {
-			return enabledSnapshot.GetBit(thiefCPU);
-		}
-		return cpumask.GetBit(thiefCPU)
-			&& enabledSnapshot.GetBit(thiefCPU);
-	}
-};
 
 ThreadData*
 CoreEntry::StealThread(int32& stolenPriority, int32 thiefCPU)
@@ -2074,3 +2076,5 @@ void Scheduler::init_debug_commands()
 			"List idle cores", "\nList idle cores", 0);
 	}
 }
+
+}	// namespace Scheduler

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -167,15 +167,15 @@ private:
 
 						int32				fThreadCount;
 						int32				fLoad;
-						bigtime_t		lastReschedule;
+						bigtime_t		lastReschedule __attribute__((aligned(8)));
 
 						int32			fPerformanceScale;
 
-						bigtime_t		fMeasureActiveTime;
-						bigtime_t		fMeasureTime;
+						bigtime_t		fMeasureActiveTime __attribute__((aligned(8)));
+						bigtime_t		fMeasureTime __attribute__((aligned(8)));
 
 						bool			fUpdateLoadEvent;
-						uint64			fRandomState;
+						uint64			fRandomState __attribute__((aligned(8)));
 
 						uint32			fRescheduleCount;
 						uint32			fInteractionUpdateCounter;
@@ -306,12 +306,12 @@ private:
 	static				void			_UnassignThread(Thread* thread,
 											void* core);
 
-						bigtime_t		fActiveTime;
+						bigtime_t		fActiveTime __attribute__((aligned(8)));
 
 						// bits 32-63: Current Load, bits 0-31: Epoch
-						int64			fCombinedLoad;
+						int64			fCombinedLoad __attribute__((aligned(8)));
 
-						bigtime_t		fLastLoadUpdate;
+						bigtime_t		fLastLoadUpdate __attribute__((aligned(8)));
 
 						int32			fCoreID;
 						PackageEntry*	fPackage __attribute__((aligned(64)));
@@ -463,7 +463,7 @@ extern PackageEntry* gPackageEntries;
 extern int32 gPackageCount;
 
 extern SchedulerNode* gSchedulerNodes;
-extern uint64 gIdleNodeMask;
+extern uint64 gIdleNodeMask __attribute__((aligned(8)));
 extern int32 gNodeCount;
 
 

--- a/src/system/kernel/scheduler/scheduler_load.cpp
+++ b/src/system/kernel/scheduler/scheduler_load.cpp
@@ -27,7 +27,7 @@ using namespace Scheduler;
 const static int kFShift = 11;
 const static long kFScale = 1 << kFShift;
 static struct loadavg sAverageRunnable = {{0, 0, 0}, kFScale};
-const static uint64 sCExp[3] = {(uint64)(0.9200444146293232 * kFScale),
+const static uint64 sCExp[3] __attribute__((aligned(8))) = {(uint64)(0.9200444146293232 * kFScale),
 	(uint64)(0.9834714538216174 * kFScale), (uint64)(0.9944598480048967 * kFScale)};
 
 static spinlock sLoadAvgLock = B_SPINLOCK_INITIALIZER;

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -15,7 +15,7 @@
 using namespace Scheduler;
 
 
-static bigtime_t sQuantumLengths[THREAD_MAX_SET_PRIORITY + 1];
+static bigtime_t sQuantumLengths __attribute__((aligned(8)))[THREAD_MAX_SET_PRIORITY + 1];
 
 
 // ComputeQuantum load-scaling constants.  Placed at file scope so the
@@ -28,9 +28,9 @@ static const int32 kLoadScaleShift = 10;
 // 1024 / 800 * 1024 = 1310.72 ~= 1311
 static const int32 kRangeReciprocal = (int32)(((int64)kLoadScale * kLoadScale
 	+ (kMaxLoad - kLowLoad) / 2) / (kMaxLoad - kLowLoad));
-static bigtime_t sVirtualDeadlineSlices[THREAD_MAX_SET_PRIORITY + 1];
+static bigtime_t sVirtualDeadlineSlices __attribute__((aligned(8)))[THREAD_MAX_SET_PRIORITY + 1];
 
-bigtime_t ThreadData::sMaxLatency;
+bigtime_t ThreadData::sMaxLatency __attribute__((aligned(8)));
 
 
 void

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -15,7 +15,8 @@
 using namespace Scheduler;
 
 
-static bigtime_t sQuantumLengths __attribute__((aligned(8)))[THREAD_MAX_SET_PRIORITY + 1];
+static bigtime_t sQuantumLengths[THREAD_MAX_SET_PRIORITY + 1]
+	__attribute__((aligned(8)));
 
 
 // ComputeQuantum load-scaling constants.  Placed at file scope so the
@@ -28,7 +29,8 @@ static const int32 kLoadScaleShift = 10;
 // 1024 / 800 * 1024 = 1310.72 ~= 1311
 static const int32 kRangeReciprocal = (int32)(((int64)kLoadScale * kLoadScale
 	+ (kMaxLoad - kLowLoad) / 2) / (kMaxLoad - kLowLoad));
-static bigtime_t sVirtualDeadlineSlices __attribute__((aligned(8)))[THREAD_MAX_SET_PRIORITY + 1];
+static bigtime_t sVirtualDeadlineSlices[THREAD_MAX_SET_PRIORITY + 1]
+	__attribute__((aligned(8)));
 
 bigtime_t ThreadData::sMaxLatency __attribute__((aligned(8)));
 

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -127,7 +127,7 @@ public:
 	SCHEDULER_INLINE	void		UpdateActivity(bigtime_t active,
 								bigtime_t now = 0);
 
-	static	bigtime_t	sMaxLatency;
+	static	bigtime_t	sMaxLatency __attribute__((aligned(8)));
 
 	SCHEDULER_INLINE	bigtime_t	GetVirtualRuntime() const { return fVirtualRuntime; }
 
@@ -169,12 +169,12 @@ private:
 							bigtime_t minQuantum, int32 maxPriority,
 							int32 minPriority, int32 priority);
 
-			bigtime_t	fStolenTime;
-			bigtime_t	fQuantumStart;
-			bigtime_t	fLastInterruptTime;
+			bigtime_t	fStolenTime __attribute__((aligned(8)));
+			bigtime_t	fQuantumStart __attribute__((aligned(8)));
+			bigtime_t	fLastInterruptTime __attribute__((aligned(8)));
 
-			bigtime_t	fWentSleep;
-			bigtime_t	fWentSleepActive;
+			bigtime_t	fWentSleep __attribute__((aligned(8)));
+			bigtime_t	fWentSleepActive __attribute__((aligned(8)));
 
 			bool		fEnqueued;
 			bool		fEnqueuedInCPURunQueue;
@@ -190,11 +190,11 @@ private:
 	mutable	int32		fEffectivePriority;
 	mutable	bigtime_t	fBaseQuantum __attribute__((aligned(8)));
 
-			bigtime_t	fTimeUsed;
+			bigtime_t	fTimeUsed __attribute__((aligned(8)));
 
-			bigtime_t	fMeasureAvailableActiveTime;
-			bigtime_t	fMeasureAvailableTime;
-			bigtime_t	fLastMeasureAvailableTime;
+			bigtime_t	fMeasureAvailableActiveTime __attribute__((aligned(8)));
+			bigtime_t	fMeasureAvailableTime __attribute__((aligned(8)));
+			bigtime_t	fLastMeasureAvailableTime __attribute__((aligned(8)));
 
 			int32		fNeededLoad;
 			uint32		fLoadMeasurementEpoch;


### PR DESCRIPTION
I have performed an extensive code audit of the Haiku scheduler (src/system/kernel/scheduler). 

This submission addresses the following critical areas:
1. **GCC 2.95 Compatibility**: Fixed several instances where local structs were used as template arguments, which is unsupported in GCC 2.95. These structs (like `RunQueueScanner` and `TopologyComparator`) were moved to the `Scheduler` namespace scope.
2. **32-bit Atomic Safety**: Identified and fixed potential data tearing or crashes on 32-bit systems by ensuring that all 64-bit variables (e.g., `bigtime_t`, `int64`) accessed via atomic64 operations are 8-byte aligned using `__attribute__((aligned(8)))`.
3. **Logic Bug Fix**: Resolved a logic error in `scheduler_on_team_foreground_changed` where threads at batch boundaries (every 256 threads) could be skipped. The reference counting for the batch cursor was also improved to be more robust.
4. **Namespace Management**: Cleaned up the namespace usage in core scheduler files, flattening nested blocks and removing redundant `using namespace` directives, which fixes visibility issues identified during code review.
5. **Constructor Initialization**: Improved `CPUEntry` initialization by moving member resets to the constructor, ensuring safe defaults even if `Init()` is bypassed during certain CPU hot-plug states.
6. **Symbol Ordering**: Corrected the declaration order of helper functions like `get_random_index` in `scheduler_cpu.cpp` to resolve forward-reference compilation errors.

These changes ensure the scheduler is robust, efficient, and compatible with both legacy and modern toolchains and architectures.

---
*PR created automatically by Jules for task [7740897634848815257](https://jules.google.com/task/7740897634848815257) started by @tonestone57*