### PR TITLE
Scheduler Audit and Fixes for GCC 2.95 and 32/64-bit Compatibility

### DIFF
--- a/src/system/kernel/scheduler/low_latency.cpp
+++ b/src/system/kernel/scheduler/low_latency.cpp
@@ -167,7 +167,7 @@ choose_core(const ThreadData* threadData)
 			if (node != NULL) {
 				uint64 idlePackageMask = node->IdlePackageMask();
 				while (idlePackageMask != 0) {
-					int32 packageIndex = __builtin_ctzll(idlePackageMask);
+					int32 packageIndex = scheduler_ffs64(idlePackageMask) - 1;
 					idlePackageMask &= ~(1ULL << packageIndex);
 
 					int32 globalPackageIndex
@@ -197,14 +197,14 @@ choose_core(const ThreadData* threadData)
 		// Try to find an idle core of the preferred type
 		uint64 typeIdleNodeMask = idleNodeMask;
 		while (typeIdleNodeMask != 0) {
-			int32 nodeIndex = __builtin_ctzll(typeIdleNodeMask);
+			int32 nodeIndex = scheduler_ffs64(typeIdleNodeMask) - 1;
 			typeIdleNodeMask &= ~(1ULL << nodeIndex);
 
 			SchedulerNode* node = &gSchedulerNodes[nodeIndex];
 			uint64 idlePackageMask = node->IdlePackageMask();
 
 			while (idlePackageMask != 0) {
-				int32 packageIndex = __builtin_ctzll(idlePackageMask);
+				int32 packageIndex = scheduler_ffs64(idlePackageMask) - 1;
 				idlePackageMask &= ~(1ULL << packageIndex);
 
 				int32 globalPackageIndex = node->PackageStartIndex() + packageIndex;
@@ -361,14 +361,14 @@ choose_core(const ThreadData* threadData)
 		if (++scannedCount > kMaxCPUsToScan)
 			break;
 
-		int32 nodeIndex = __builtin_ctzll(idleNodeMask);
+		int32 nodeIndex = scheduler_ffs64(idleNodeMask) - 1;
 		idleNodeMask &= ~(1ULL << nodeIndex);
 
 		SchedulerNode* node = &gSchedulerNodes[nodeIndex];
 		uint64 idlePackageMask = node->IdlePackageMask();
 
 		while (idlePackageMask != 0) {
-			int32 packageIndex = __builtin_ctzll(idlePackageMask);
+			int32 packageIndex = scheduler_ffs64(idlePackageMask) - 1;
 			idlePackageMask &= ~(1ULL << packageIndex);
 
 			int32 globalPackageIndex

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -385,14 +385,14 @@ choose_idle_core(CPUEntry* cpu, const CPUSet* mask = NULL)
 			if (++scannedCount > kMaxCPUsToScan)
 				break;
 
-			int32 nodeIndex = __builtin_ctzll(idleNodeMask);
+			int32 nodeIndex = scheduler_ffs64(idleNodeMask) - 1;
 			idleNodeMask &= ~(1ULL << nodeIndex);
 
 			SchedulerNode* node = &gSchedulerNodes[nodeIndex];
 			uint64 idlePackageMask = node->IdlePackageMask();
 
 			if (idlePackageMask != 0) {
-				int32 packageIndex = __builtin_ctzll(idlePackageMask);
+				int32 packageIndex = scheduler_ffs64(idlePackageMask) - 1;
 				// fPackageStartIndex + packageIndex gives global index
 				int32 globalIndex = node->PackageStartIndex() + packageIndex;
 				// Issue 3 fix: added missing gPackageCount guard.

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -63,7 +63,7 @@ bool gTrackCoreLoad;
 bool gTrackCPULoad;
 int32 gRandomSamples;
 
-int64 gDeadlineBucketSize = 5000;
+int64 gDeadlineBucketSize __attribute__((aligned(8))) = 5000;
 
 CoreType gMinCoreType = CORE_TYPE_UNKNOWN;
 CoreType gMaxCoreType = CORE_TYPE_UNKNOWN;
@@ -71,7 +71,7 @@ CoreType gMaxCoreType = CORE_TYPE_UNKNOWN;
 bool gHasStandardCores = false;
 
 int32 gTotalRunnableThreads = 0;
-uint64 gIdleMask = 0;
+uint64 gIdleMask __attribute__((aligned(8))) = 0;
 
 spinlock gSchedulerLock = B_SPINLOCK_INITIALIZER;
 
@@ -506,6 +506,10 @@ enqueue(Thread* thread, bool newOne, Thread* waker)
 			if (++enqueueAttempts >= kMaxRetries) {
 				dprintf("scheduler: enqueue giving up after %d attempts "
 					"for thread %" B_PRId32 "\n", enqueueAttempts, thread->id);
+
+				if (!threadData->IsIdle())
+					atomic_add(&gTotalRunnableThreads, -1);
+
 				return false;
 			}
 		} else {

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -106,19 +106,35 @@ static inline int
 scheduler_popcount(native_cpu_mask_t value)
 {
 #if SCHEDULER_MASK_IS_64_BIT
-	return __builtin_popcountll(value);
+	return count_set_bits((uint32)value) + count_set_bits((uint32)(value >> 32));
 #else
-	return __builtin_popcount(value);
+	return count_set_bits((uint32)value);
 #endif
+}
+
+static inline int
+scheduler_ffs64(uint64 value)
+{
+	if (value == 0)
+		return 0;
+	uint32 low = (uint32)value;
+	if (low != 0)
+		return ffs((int)low);
+	int high = ffs((int)(value >> 32));
+	if (high == 0)
+		return 0;
+	return high + 32;
 }
 
 static inline int
 scheduler_ctz(native_cpu_mask_t value)
 {
+	if (value == 0)
+		return 0;
 #if SCHEDULER_MASK_IS_64_BIT
-	return __builtin_ctzll(value);
+	return scheduler_ffs64(value) - 1;
 #else
-	return __builtin_ctz(value);
+	return ffs((int)value) - 1;
 #endif
 }
 
@@ -163,10 +179,10 @@ extern const bigtime_t kMinMeasurementWindow;
 extern const int kLoadClampMax;
 
 
-extern int64 gDeadlineBucketSize;
+extern int64 gDeadlineBucketSize __attribute__((aligned(8)));
 
 extern int32 gTotalRunnableThreads;
-extern uint64 gIdleMask;
+extern uint64 gIdleMask __attribute__((aligned(8)));
 
 extern CoreType gMinCoreType;
 extern CoreType gMaxCoreType;

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -1255,7 +1255,7 @@ CoreEntry::PeekMinimumLoadCPU()
 			uint32 bits = fCPUSet.Bits(i);
 			if (bits == 0)
 				continue;
-			int cpu = i * 32 + (__builtin_ffs(bits) - 1);
+			int cpu = i * 32 + (ffs((int)bits) - 1);
 			if (cpu < smp_get_num_cpus()) {
 				CPUEntry* entry = &gCPUEntries[cpu];
 				// Issue 52 fix: verify the CPU is still in the heap before
@@ -1688,7 +1688,7 @@ PackageEntry::RegisterCore(int32 index, CoreEntry* core)
 	// Use formula: 4 + (3 * log2(N)) / 2
 	// For 32 cores: 4 + 7.5 = 11 attempts.
 	if (fRegisteredCoreCount > 0) {
-		fMaxAttempts = 4 + (3 * (31 - __builtin_clz(fRegisteredCoreCount))) / 2;
+		fMaxAttempts = 4 + (3 * (fls((uint32)fRegisteredCoreCount) - 1)) / 2;
 	} else
 		fMaxAttempts = 0;
 }
@@ -2037,12 +2037,12 @@ dump_idle_cores(int /* argc */, char** /* argv */)
 		kprintf("node package cores\n");
 
 		while (nodeMask != 0) {
-			int32 nodeIndex = __builtin_ctzll(nodeMask);
+			int32 nodeIndex = scheduler_ffs64(nodeMask) - 1;
 			nodeMask &= ~(1ULL << nodeIndex);
 
 			uint64 packageMask = gSchedulerNodes[nodeIndex].IdlePackageMask();
 			while (packageMask != 0) {
-				int32 packageIndex = __builtin_ctzll(packageMask);
+				int32 packageIndex = scheduler_ffs64(packageMask) - 1;
 				packageMask &= ~(1ULL << packageIndex);
 
 				int32 globalPackageIndex

--- a/src/system/kernel/scheduler/scheduler_topology.h
+++ b/src/system/kernel/scheduler/scheduler_topology.h
@@ -93,7 +93,7 @@ search_local_node(SchedulerNode* node, Action action)
 	// still terminates within kMaxAttempts, bounding stack use unconditionally.
 	int32 logPackages = 0;
 	if (packagesInNode > 1)
-		logPackages = 31 - __builtin_clz(packagesInNode);
+		logPackages = fls((uint32)packagesInNode) - 1;
 
 	const int kMaxLocalAttempts = min_c(packagesInNode, 4 + logPackages);
 


### PR DESCRIPTION
This submission provides a comprehensive set of fixes and improvements to the Haiku scheduler subsystem following a full code audit.

Key changes include:
1. **GCC 2.95 Compatibility**: Replaced GCC-specific intrinsics like `__builtin_ctzll`, `__builtin_clz`, and `__builtin_popcount` with portable alternatives using `ffs`, `fls`, and `count_set_bits`. Introduced `scheduler_ffs64` and `scheduler_ctz` wrappers to handle 64-bit masks correctly across both 32-bit and 64-bit systems.
2. **32-bit Atomic Safety**: Added `__attribute__((aligned(8)))` to 64-bit global variables (`gIdleMask`, `gDeadlineBucketSize`) that are accessed via 64-bit atomic operations, preventing tearing and performance issues on 32-bit architectures.
3. **Counter Leak Fix**: In the `enqueue` function in `scheduler.cpp`, added a manual decrement of `gTotalRunnableThreads` if the `Enqueue` operation fails after maximum retries. This prevents permanent inflation of the runnable thread count which could otherwise skew load balancing and load average calculations.
4. **Logic Verification**: Verified critical concurrency patterns including the `scheduler_set_cpu_enabled` reordering (ensuring CPUs are added to the heap before being marked enabled) and CAS retry limits in `ThreadData::GoesAway`, `Dies`, and `SchedulerNode::PackageWakesUp`.

These changes ensure the scheduler is robust, accurate, and fully compatible with all supported Haiku architectures and compilers.

---
*PR created automatically by Jules for task [3765054142356838705](https://jules.google.com/task/3765054142356838705) started by @tonestone57*