### PR TITLE
Haiku Scheduler Audit and GCC 2.95 Compatibility Fixes

### DIFF
--- a/headers/private/kernel/scheduling_analysis.h
+++ b/headers/private/kernel/scheduling_analysis.h
@@ -17,8 +17,17 @@ struct rw_lock;
 #if SCHEDULING_ANALYSIS_TRACING
 namespace SchedulingAnalysisTracing {
 
+enum WaitObjectTraceEntryType {
+	WAIT_OBJECT_TRACE_ENTRY_TYPE_CREATE_SEMAPHORE = 200,
+	WAIT_OBJECT_TRACE_ENTRY_TYPE_INIT_CONDITION_VARIABLE,
+	WAIT_OBJECT_TRACE_ENTRY_TYPE_INIT_MUTEX,
+	WAIT_OBJECT_TRACE_ENTRY_TYPE_INIT_RW_LOCK,
+};
+
 class WaitObjectTraceEntry : public AbstractTraceEntry {
 public:
+	virtual uint16 EntryType() const = 0;
+
 	virtual uint32 Type() const = 0;
 	virtual void* Object() const = 0;
 	virtual const char* Name() const = 0;
@@ -32,6 +41,11 @@ public:
 
 class CreateSemaphore : public WaitObjectTraceEntry {
 public:
+	virtual uint16 EntryType() const
+	{
+		return WAIT_OBJECT_TRACE_ENTRY_TYPE_CREATE_SEMAPHORE;
+	}
+
 	CreateSemaphore(sem_id id, const char* name)
 		:
 		fID(id),
@@ -68,6 +82,11 @@ private:
 
 class InitConditionVariable : public WaitObjectTraceEntry {
 public:
+	virtual uint16 EntryType() const
+	{
+		return WAIT_OBJECT_TRACE_ENTRY_TYPE_INIT_CONDITION_VARIABLE;
+	}
+
 	InitConditionVariable(ConditionVariable* variable, const void* object,
 		const char* objectType)
 		:
@@ -113,6 +132,11 @@ private:
 
 class InitMutex : public WaitObjectTraceEntry {
 public:
+	virtual uint16 EntryType() const
+	{
+		return WAIT_OBJECT_TRACE_ENTRY_TYPE_INIT_MUTEX;
+	}
+
 	InitMutex(mutex* lock, const char* name)
 		:
 		fMutex(lock),
@@ -149,6 +173,11 @@ private:
 
 class InitRWLock : public WaitObjectTraceEntry {
 public:
+	virtual uint16 EntryType() const
+	{
+		return WAIT_OBJECT_TRACE_ENTRY_TYPE_INIT_RW_LOCK;
+	}
+
 	InitRWLock(rw_lock* lock, const char* name)
 		:
 		fLock(lock),

--- a/headers/private/kernel/scheduling_analysis.h
+++ b/headers/private/kernel/scheduling_analysis.h
@@ -17,6 +17,8 @@ struct rw_lock;
 #if SCHEDULING_ANALYSIS_TRACING
 namespace SchedulingAnalysisTracing {
 
+// Manual RTTI IDs for wait object tracing.
+// Range 200-299 reserved for SchedulingAnalysisTracing namespace.
 enum WaitObjectTraceEntryType {
 	WAIT_OBJECT_TRACE_ENTRY_TYPE_CREATE_SEMAPHORE = 200,
 	WAIT_OBJECT_TRACE_ENTRY_TYPE_INIT_CONDITION_VARIABLE,

--- a/headers/private/kernel/tracing.h
+++ b/headers/private/kernel/tracing.h
@@ -80,7 +80,8 @@ class TraceEntry {
 
 		// EntryType: manual RTTI for GCC 2.95 kernel compatibility.
 		// Returns a unique ID for the entry class. IDs 100-299 are reserved
-		// for the scheduler and its analysis tools.
+		// for the scheduler and its analysis tools. IDs >= 1 identify
+		// AbstractTraceEntry and its descendants.
 		virtual uint16 EntryType() const { return 0; }
 
 		size_t Size() const		{ return ToTraceEntry()->size; }
@@ -120,6 +121,8 @@ public:
 	virtual void Dump(TraceOutput& out);
 
 	virtual void AddDump(TraceOutput& out);
+
+	virtual uint16 EntryType() const { return 1; }
 
 	thread_id ThreadID() const	{ return fThread; }
 	thread_id TeamID() const	{ return fTeam; }

--- a/headers/private/kernel/tracing.h
+++ b/headers/private/kernel/tracing.h
@@ -78,6 +78,9 @@ class TraceEntry {
 		virtual void Dump(TraceOutput& out);
 		virtual void DumpStackTrace(TraceOutput& out);
 
+		// EntryType: manual RTTI for GCC 2.95 kernel compatibility.
+		// Returns a unique ID for the entry class. IDs 100-299 are reserved
+		// for the scheduler and its analysis tools.
 		virtual uint16 EntryType() const { return 0; }
 
 		size_t Size() const		{ return ToTraceEntry()->size; }

--- a/headers/private/kernel/tracing.h
+++ b/headers/private/kernel/tracing.h
@@ -78,6 +78,8 @@ class TraceEntry {
 		virtual void Dump(TraceOutput& out);
 		virtual void DumpStackTrace(TraceOutput& out);
 
+		virtual uint16 EntryType() const { return 0; }
+
 		size_t Size() const		{ return ToTraceEntry()->size; }
 		uint16 Flags() const	{ return ToTraceEntry()->flags; }
 
@@ -115,8 +117,6 @@ public:
 	virtual void Dump(TraceOutput& out);
 
 	virtual void AddDump(TraceOutput& out);
-
-	virtual uint16 EntryType() const { return 0; }
 
 	thread_id ThreadID() const	{ return fThread; }
 	thread_id TeamID() const	{ return fTeam; }
@@ -267,6 +267,7 @@ TraceOutput::Print(const char* format,...)
 
 int dump_tracing(int argc, char** argv, WrapperTraceFilter* wrapperFilter);
 
+// tracing_is_entry_valid: safe validation for trace entries.
 bool tracing_is_entry_valid(AbstractTraceEntry* entry,
 	bigtime_t entryTime = -1);
 

--- a/headers/private/kernel/tracing.h
+++ b/headers/private/kernel/tracing.h
@@ -116,6 +116,8 @@ public:
 
 	virtual void AddDump(TraceOutput& out);
 
+	virtual uint16 EntryType() const { return 0; }
+
 	thread_id ThreadID() const	{ return fThread; }
 	thread_id TeamID() const	{ return fTeam; }
 	bigtime_t Time() const		{ return fTime; }

--- a/headers/private/kernel/tracing.h
+++ b/headers/private/kernel/tracing.h
@@ -79,9 +79,9 @@ class TraceEntry {
 		virtual void DumpStackTrace(TraceOutput& out);
 
 		// EntryType: manual RTTI for GCC 2.95 kernel compatibility.
-		// Returns a unique ID for the entry class. IDs 100-299 are reserved
-		// for the scheduler and its analysis tools. IDs >= 1 identify
-		// AbstractTraceEntry and its descendants.
+		// Returns a unique ID for the entry class. IDs >= 100 are reserved
+		// for specific trace entry classes (scheduler, analysis, etc.).
+		// IDs >= 1 identify AbstractTraceEntry and its descendants.
 		virtual uint16 EntryType() const { return 0; }
 
 		size_t Size() const		{ return ToTraceEntry()->size; }

--- a/src/system/kernel/debug/tracing.cpp
+++ b/src/system/kernel/debug/tracing.cpp
@@ -1725,13 +1725,16 @@ dump_tracing(int argc, char** argv, WrapperTraceFilter* wrapperFilter)
 }
 
 
-// tracing_is_entry_valid: verifies if a trace entry pointer is valid.
+// tracing_is_entry_valid: verifies if a trace entry pointer is valid and
+// optionally matches a specific timestamp.  Used for safe type-casting.
 bool
 tracing_is_entry_valid(AbstractTraceEntry* candidate, bigtime_t entryTime)
 {
 #if ENABLE_TRACING
-	if (!sTracingMetaData->IsInBuffer(candidate, sizeof(*candidate)))
+	if (candidate == NULL || !sTracingMetaData->IsInBuffer(candidate,
+			sizeof(*candidate))) {
 		return false;
+	}
 
 	if (entryTime < 0)
 		return true;
@@ -1745,7 +1748,8 @@ tracing_is_entry_valid(AbstractTraceEntry* candidate, bigtime_t entryTime)
 		if (abstract != candidate && abstract->Time() > entryTime)
 			return false;
 
-		return candidate->Time() == entryTime;
+		if (abstract == candidate)
+			return candidate->Time() == entryTime;
 	}
 #endif
 

--- a/src/system/kernel/debug/tracing.cpp
+++ b/src/system/kernel/debug/tracing.cpp
@@ -869,6 +869,8 @@ AbstractTraceEntryWithStackTrace::DumpStackTrace(TraceOutput& out)
 
 class KernelTraceEntry : public AbstractTraceEntry {
 	public:
+		virtual uint16 EntryType() const { return 300; }
+
 		KernelTraceEntry(const char* message)
 		{
 			fMessage = alloc_tracing_buffer_strcpy(message, 256, false);
@@ -902,6 +904,8 @@ class KernelTraceEntry : public AbstractTraceEntry {
 
 class UserTraceEntry : public AbstractTraceEntry {
 	public:
+		virtual uint16 EntryType() const { return 301; }
+
 		UserTraceEntry(const char* message)
 		{
 			fMessage = alloc_tracing_buffer_strcpy(message, 256, true);
@@ -935,6 +939,8 @@ class UserTraceEntry : public AbstractTraceEntry {
 
 class TracingLogStartEntry : public AbstractTraceEntry {
 	public:
+		virtual uint16 EntryType() const { return 302; }
+
 		TracingLogStartEntry()
 		{
 			Initialized();
@@ -969,8 +975,10 @@ class ThreadTraceFilter : public TraceFilter {
 public:
 	virtual bool Filter(const TraceEntry* _entry, LazyTraceOutput& out)
 	{
+		if (_entry == NULL || _entry->EntryType() == 0)
+			return false;
 		const AbstractTraceEntry* entry = (const AbstractTraceEntry*)_entry;
-		return (entry != NULL && entry->ThreadID() == fThread);
+		return entry->ThreadID() == fThread;
 	}
 };
 
@@ -979,8 +987,10 @@ class TeamTraceFilter : public TraceFilter {
 public:
 	virtual bool Filter(const TraceEntry* _entry, LazyTraceOutput& out)
 	{
+		if (_entry == NULL || _entry->EntryType() == 0)
+			return false;
 		const AbstractTraceEntry* entry = (const AbstractTraceEntry*)_entry;
-		return (entry != NULL && entry->TeamID() == fTeam);
+		return entry->TeamID() == fTeam;
 	}
 };
 
@@ -1741,10 +1751,10 @@ tracing_is_entry_valid(AbstractTraceEntry* candidate, bigtime_t entryTime)
 
 	TraceEntryIterator iterator;
 	while (TraceEntry* entry = iterator.Next()) {
-		AbstractTraceEntry* abstract = (AbstractTraceEntry*)entry;
-		if (abstract == NULL)
+		if (entry == NULL || entry->EntryType() == 0)
 			continue;
 
+		AbstractTraceEntry* abstract = (AbstractTraceEntry*)entry;
 		if (abstract != candidate && abstract->Time() > entryTime)
 			return false;
 

--- a/src/system/kernel/debug/tracing.cpp
+++ b/src/system/kernel/debug/tracing.cpp
@@ -104,6 +104,29 @@ public:
 
 			bool				IsInBuffer(void* address, size_t size);
 
+			bool				VerifyEntry(trace_entry* entry)
+			{
+				if (entry == NULL || !IsInBuffer(entry, sizeof(trace_entry)))
+					return false;
+
+				if (((uintptr_t)entry - (uintptr_t)fBuffer) % sizeof(trace_entry) != 0)
+					return false;
+
+				if (entry->size == 0 || entry->size > kMaxTracingEntryByteSize / sizeof(trace_entry))
+					return false;
+
+				trace_entry* next = NextEntry(entry);
+				if (next != NULL) {
+					if (next->previous_size != entry->size)
+						return false;
+				} else {
+					if (fAfterLastEntry->previous_size != entry->size)
+						return false;
+				}
+
+				return true;
+			}
+
 private:
 			bool				_FreeFirstEntry();
 			bool				_MakeSpace(size_t needed);
@@ -1741,26 +1764,20 @@ bool
 tracing_is_entry_valid(AbstractTraceEntry* candidate, bigtime_t entryTime)
 {
 #if ENABLE_TRACING
-	if (candidate == NULL || !sTracingMetaData->IsInBuffer(candidate,
-			sizeof(*candidate))) {
+	if (candidate == NULL)
 		return false;
-	}
 
-	if (entryTime < 0)
-		return true;
+	if (!sTracingMetaData->VerifyEntry(candidate->ToTraceEntry()))
+		return false;
 
-	TraceEntryIterator iterator;
-	while (TraceEntry* entry = iterator.Next()) {
-		if (entry == NULL || entry->EntryType() == 0)
-			continue;
-
-		AbstractTraceEntry* abstract = (AbstractTraceEntry*)entry;
-		if (abstract != candidate && abstract->Time() > entryTime)
+	if (entryTime >= 0) {
+		if (!(candidate->ToTraceEntry()->flags & ENTRY_INITIALIZED))
 			return false;
-
-		if (abstract == candidate)
-			return candidate->Time() == entryTime;
+		if (candidate->Time() != entryTime)
+			return false;
 	}
+
+	return true;
 #endif
 
 	return false;

--- a/src/system/kernel/debug/tracing.cpp
+++ b/src/system/kernel/debug/tracing.cpp
@@ -969,8 +969,7 @@ class ThreadTraceFilter : public TraceFilter {
 public:
 	virtual bool Filter(const TraceEntry* _entry, LazyTraceOutput& out)
 	{
-		const AbstractTraceEntry* entry
-			= dynamic_cast<const AbstractTraceEntry*>(_entry);
+		const AbstractTraceEntry* entry = (const AbstractTraceEntry*)_entry;
 		return (entry != NULL && entry->ThreadID() == fThread);
 	}
 };
@@ -980,8 +979,7 @@ class TeamTraceFilter : public TraceFilter {
 public:
 	virtual bool Filter(const TraceEntry* _entry, LazyTraceOutput& out)
 	{
-		const AbstractTraceEntry* entry
-			= dynamic_cast<const AbstractTraceEntry*>(_entry);
+		const AbstractTraceEntry* entry = (const AbstractTraceEntry*)_entry;
 		return (entry != NULL && entry->TeamID() == fTeam);
 	}
 };
@@ -1727,6 +1725,7 @@ dump_tracing(int argc, char** argv, WrapperTraceFilter* wrapperFilter)
 }
 
 
+// tracing_is_entry_valid: verifies if a trace entry pointer is valid.
 bool
 tracing_is_entry_valid(AbstractTraceEntry* candidate, bigtime_t entryTime)
 {
@@ -1739,7 +1738,7 @@ tracing_is_entry_valid(AbstractTraceEntry* candidate, bigtime_t entryTime)
 
 	TraceEntryIterator iterator;
 	while (TraceEntry* entry = iterator.Next()) {
-		AbstractTraceEntry* abstract = dynamic_cast<AbstractTraceEntry*>(entry);
+		AbstractTraceEntry* abstract = (AbstractTraceEntry*)entry;
 		if (abstract == NULL)
 			continue;
 

--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -135,12 +135,12 @@ public:
 private:
 			status_t	fInitStatus;
 
-			uint32		fBitmap[kBitmapSize];
+			uint32		fBitmap[kBitmapSize] __attribute__((aligned(8)));
 
-			Element*	fHeads[MaxPriority + 1];
-			Element*	fTails[MaxPriority + 1];
+			Element*	fHeads[MaxPriority + 1] __attribute__((aligned(8)));
+			Element*	fTails[MaxPriority + 1] __attribute__((aligned(8)));
 
-	mutable	Element*	fBest;
+	mutable	Element*	fBest __attribute__((aligned(8)));
 
 			int32		fTotalCount;
 

--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -416,18 +416,18 @@ RUN_QUEUE_CLASS_NAME::PushFront(Element* element,
 	// caller holds here), 'best' cannot be freed within this critical section,
 	// but we must still validate the bucket to catch stale priority caches.
 	{
-		Element* best = (Element*)atomic_pointer_get((void**)&fBest);
+		Element* best = (Element*)atomic_pointer_get<void>((void**)&fBest);
 		if (best != NULL) {
 			unsigned int bestPriority = sGetLink(best)->fPriority;
 			// Validate the bucket is non-empty before trusting bestPriority.
 			if (fHeads[bestPriority] == NULL)
-				atomic_pointer_set((void**)&fBest, element); // stale, replace
+				atomic_pointer_set<void>((void**)&fBest, element); // stale, replace
 			else if (priority > bestPriority)
-				atomic_pointer_set((void**)&fBest, element);
+				atomic_pointer_set<void>((void**)&fBest, element);
 			else if (priority == bestPriority && sCompare(element, best))
-				atomic_pointer_set((void**)&fBest, element);
+				atomic_pointer_set<void>((void**)&fBest, element);
 		} else if (isEmpty || PeekMaximum() == element) {
-			atomic_pointer_set((void**)&fBest, element);
+			atomic_pointer_set<void>((void**)&fBest, element);
 		}
 	}
 }
@@ -478,17 +478,17 @@ RUN_QUEUE_CLASS_NAME::PushBack(Element* element,
 
 	// Issue 46 fix: same snapshot-based fBest update as PushFront.
 	{
-		Element* best = (Element*)atomic_pointer_get((void**)&fBest);
+		Element* best = (Element*)atomic_pointer_get<void>((void**)&fBest);
 		if (best != NULL) {
 			unsigned int bestPriority = sGetLink(best)->fPriority;
 			if (fHeads[bestPriority] == NULL)
-				atomic_pointer_set((void**)&fBest, element);
+				atomic_pointer_set<void>((void**)&fBest, element);
 			else if (priority > bestPriority)
-				atomic_pointer_set((void**)&fBest, element);
+				atomic_pointer_set<void>((void**)&fBest, element);
 			else if (priority == bestPriority && sCompare(element, best))
-				atomic_pointer_set((void**)&fBest, element);
+				atomic_pointer_set<void>((void**)&fBest, element);
 		} else if (isEmpty || PeekMaximum() == element) {
-			atomic_pointer_set((void**)&fBest, element);
+			atomic_pointer_set<void>((void**)&fBest, element);
 		}
 	}
 }
@@ -539,15 +539,15 @@ RUN_QUEUE_CLASS_NAME::Remove(Element* element)
 	// Single-read + immediate use is safe because the object cannot be
 	// freed while we hold the lock (object-cache reclaim requires the lock).
 	{
-		Element* best = (Element*)atomic_pointer_get((void**)&fBest);
+		Element* best = (Element*)atomic_pointer_get<void>((void**)&fBest);
 		if (best == element) {
-			atomic_pointer_test_and_set((void**)&fBest, (Element*)NULL, element);
+			atomic_pointer_test_and_set<void>((void**)&fBest, (Element*)NULL, element);
 		} else if (best != NULL) {
 			// Use the single snapshot: safe because best != element so it
 			// cannot be the element we just unlinked.
 			unsigned int bestPrio = sGetLink(best)->fPriority;
 			if (fHeads[bestPrio] == NULL)
-				atomic_pointer_test_and_set((void**)&fBest, (Element*)NULL, best);
+				atomic_pointer_test_and_set<void>((void**)&fBest, (Element*)NULL, best);
 		}
 	}
 }
@@ -584,7 +584,7 @@ RUN_QUEUE_TEMPLATE_LIST
 Element*
 RUN_QUEUE_CLASS_NAME::PeekBest() const
 {
-	Element* bestCandidate = (Element*)atomic_pointer_get((void**)&fBest);
+	Element* bestCandidate = (Element*)atomic_pointer_get<void>((void**)&fBest);
 	if (bestCandidate != NULL)
 	// Issue 1 fix: validate that fBest is still actually in a non-empty
 	// priority bucket before trusting it. A priority change followed by a
@@ -597,7 +597,7 @@ RUN_QUEUE_CLASS_NAME::PeekBest() const
 		if (fHeads[bestPrio] != NULL)
 		return bestCandidate;
 		// Invalidate stale cache and rescan.
-		atomic_pointer_test_and_set((void**)&fBest, (Element*)NULL, bestCandidate);
+		atomic_pointer_test_and_set<void>((void**)&fBest, (Element*)NULL, bestCandidate);
 	}
 
 	// search up to kDeadlineLookaheadLevels non-empty priority
@@ -670,9 +670,9 @@ RUN_QUEUE_CLASS_NAME::PeekBest() const
 	// Issue 1 fix: use atomic_pointer_test_and_set to avoid regressing quality
 	// if a concurrent PushFront has already set a better fBest.
 	if (globalBest != NULL) {
-		Element* best = (Element*)atomic_pointer_get((void**)&fBest);
+		Element* best = (Element*)atomic_pointer_get<void>((void**)&fBest);
 		while (best == NULL || sCompare(globalBest, best)) {
-			Element* was = (Element*)atomic_pointer_test_and_set((void**)&fBest,
+			Element* was = (Element*)atomic_pointer_test_and_set<void>((void**)&fBest,
 				globalBest, best);
 			if (was == best)
 				break;

--- a/src/system/kernel/scheduler/low_latency.cpp
+++ b/src/system/kernel/scheduler/low_latency.cpp
@@ -468,7 +468,7 @@ choose_core(const ThreadData* threadData)
 			for (int32 i = 0; i < kCPUSetArraySize; i++) {
 				uint32 bits = mask.Bits(i);
 				while (bits != 0) {
-					int bit = __builtin_ctz(bits);
+					int bit = ffs((int)bits) - 1;
 					bits &= ~(1U << bit);
 					int32 cpuID = i * 32 + bit;
 

--- a/src/system/kernel/scheduler/low_latency.cpp
+++ b/src/system/kernel/scheduler/low_latency.cpp
@@ -468,7 +468,7 @@ choose_core(const ThreadData* threadData)
 			for (int32 i = 0; i < kCPUSetArraySize; i++) {
 				uint32 bits = mask.Bits(i);
 				while (bits != 0) {
-					int bit = ffs((int)bits) - 1;
+					int bit = scheduler_ctz((native_cpu_mask_t)bits);
 					bits &= ~(1U << bit);
 					int32 cpuID = i * 32 + bit;
 

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -482,7 +482,7 @@ check_masked_packages_packing(CPUEntry* cpu, const CPUSet& mask,
 			continue;
 
 		while (bits != 0) {
-			int bit = ffs((int)bits) - 1;
+			int bit = scheduler_ctz((native_cpu_mask_t)bits);
 			bits &= ~(1U << bit);
 			int32 cpuID = i * 32 + bit;
 
@@ -705,7 +705,7 @@ choose_core(const ThreadData* threadData)
 			for (int32 i = 0; i < kCPUSetArraySize; i++) {
 				uint32 bits = mask.Bits(i);
 				while (bits != 0) {
-					int bit = ffs((int)bits) - 1;
+					int bit = scheduler_ctz((native_cpu_mask_t)bits);
 					bits &= ~(1U << bit);
 					int32 cpuID = i * 32 + bit;
 

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -482,7 +482,7 @@ check_masked_packages_packing(CPUEntry* cpu, const CPUSet& mask,
 			continue;
 
 		while (bits != 0) {
-			int bit = __builtin_ctz(bits);
+			int bit = ffs((int)bits) - 1;
 			bits &= ~(1U << bit);
 			int32 cpuID = i * 32 + bit;
 
@@ -705,7 +705,7 @@ choose_core(const ThreadData* threadData)
 			for (int32 i = 0; i < kCPUSetArraySize; i++) {
 				uint32 bits = mask.Bits(i);
 				while (bits != 0) {
-					int bit = __builtin_ctz(bits);
+					int bit = ffs((int)bits) - 1;
 					bits &= ~(1U << bit);
 					int32 cpuID = i * 32 + bit;
 

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -124,7 +124,7 @@ switch_to_mode()
 	}
 	if (sSmallTaskCore != NULL) {
 		for (int32 i = 0; i < gNodeCount; i++)
-			atomic_pointer_set(&sSmallTaskCore[i], (CoreEntry*)NULL);
+			atomic_pointer_set<CoreEntry>(&sSmallTaskCore[i], (CoreEntry*)NULL);
 	}
 }
 
@@ -134,7 +134,7 @@ set_cpu_enabled(int32 cpu, bool enabled)
 {
 	if (!enabled && sSmallTaskCore != NULL) {
 		for (int32 i = 0; i < gNodeCount; i++)
-			atomic_pointer_set(&sSmallTaskCore[i], (CoreEntry*)NULL);
+			atomic_pointer_set<CoreEntry>(&sSmallTaskCore[i], (CoreEntry*)NULL);
 	}
 }
 
@@ -229,7 +229,7 @@ choose_small_task_core(CPUEntry* cpu)
 		if (currentNodeID < 0 || currentNodeID >= gNodeCount)
 			return NULL;
 
-		CoreEntry* current = (CoreEntry*)atomic_pointer_get(
+		CoreEntry* current = (CoreEntry*)atomic_pointer_get<CoreEntry>(
 			&sSmallTaskCore[currentNodeID]);
 		if (current != NULL && current->Type() == gMinCoreType
 				&& current->GetScore() < kHighLoad) {
@@ -273,14 +273,14 @@ choose_small_task_core(CPUEntry* cpu)
 				return eCore;
 
 			while (true) {
-				CoreEntry* currentE = (CoreEntry*)atomic_pointer_get(
+				CoreEntry* currentE = (CoreEntry*)atomic_pointer_get<CoreEntry>(
 					&sSmallTaskCore[nodeID]);
 				if (currentE != NULL && currentE->Type() == gMinCoreType
 						&& currentE->GetScore() < kHighLoad) {
 					return currentE;
 				}
 
-				if (atomic_pointer_test_and_set(&sSmallTaskCore[nodeID], eCore,
+				if (atomic_pointer_test_and_set<CoreEntry>(&sSmallTaskCore[nodeID], eCore,
 						currentE) == currentE) {
 					return eCore;
 				}
@@ -296,7 +296,7 @@ choose_small_task_core(CPUEntry* cpu)
 		if (currentNodeID < 0 || currentNodeID >= gNodeCount)
 			return NULL;
 
-		CoreEntry* current = (CoreEntry*)atomic_pointer_get(
+		CoreEntry* current = (CoreEntry*)atomic_pointer_get<CoreEntry>(
 			&sSmallTaskCore[currentNodeID]);
 		if (current != NULL && current->GetScore() < kHighLoad)
 			return current;
@@ -347,19 +347,19 @@ choose_small_task_core(CPUEntry* cpu)
 		int casRetries = 0;
 		const int kMaxCASRetries = 16;
 		while (true) {
-			CoreEntry* current = (CoreEntry*)atomic_pointer_get(
+			CoreEntry* current = (CoreEntry*)atomic_pointer_get<CoreEntry>(
 				&sSmallTaskCore[nodeID]);
 			if (current != NULL && current->GetScore() < kHighLoad)
 				return current;
 
-			if (atomic_pointer_test_and_set(&sSmallTaskCore[nodeID], core,
+			if (atomic_pointer_test_and_set<CoreEntry>(&sSmallTaskCore[nodeID], core,
 					current) == current) {
 				return core;
 			}
 
 			if (++casRetries >= kMaxCASRetries) {
 				// Give up; return best known candidate to avoid spinning.
-				CoreEntry* latest = (CoreEntry*)atomic_pointer_get(
+				CoreEntry* latest = (CoreEntry*)atomic_pointer_get<CoreEntry>(
 					&sSmallTaskCore[nodeID]);
 				return (latest != NULL) ? latest : core;
 			}
@@ -787,8 +787,8 @@ rebalance(const ThreadData* threadData)
 		// sSmallTaskCore branch below is skipped safely.
 
 		if (nodeID >= 0 && nodeID < gNodeCount && sSmallTaskCore != NULL
-				&& atomic_pointer_get(&sSmallTaskCore[nodeID]) == core) {
-			atomic_pointer_set(&sSmallTaskCore[nodeID], (CoreEntry*)NULL);
+				&& atomic_pointer_get<CoreEntry>(&sSmallTaskCore[nodeID]) == core) {
+			atomic_pointer_set<CoreEntry>(&sSmallTaskCore[nodeID], (CoreEntry*)NULL);
 			CoreEntry* smallTaskCore = choose_small_task_core(cpu);
 
 			if (threadLoad > coreScore / 3 || smallTaskCore == NULL
@@ -941,7 +941,7 @@ rebalance_irqs(bool idle)
 	bool hasSmallTaskCore = false;
 	if (sSmallTaskCore != NULL) {
 		for (int32 i = 0; i < gNodeCount; i++) {
-			if (atomic_pointer_get(&sSmallTaskCore[i]) != NULL) {
+			if (atomic_pointer_get<CoreEntry>(&sSmallTaskCore[i]) != NULL) {
 				hasSmallTaskCore = true;
 				break;
 			}
@@ -973,7 +973,7 @@ rebalance_irqs(bool idle)
 			&& currentCore->Package()->Node() != NULL) {
 		int32 nodeID = currentCore->Package()->Node()->ID();
 		if (nodeID >= 0 && nodeID < gNodeCount
-				&& atomic_pointer_get(&sSmallTaskCore[nodeID]) == currentCore) {
+				&& atomic_pointer_get<CoreEntry>(&sSmallTaskCore[nodeID]) == currentCore) {
 			return;
 		}
 	}
@@ -1015,7 +1015,7 @@ rebalance_irqs(bool idle)
 				&& currentCore->Package()->Node() != NULL) {
 			int32 nodeID = currentCore->Package()->Node()->ID();
 			if (nodeID >= 0 && nodeID < gNodeCount)
-				other = (CoreEntry*)atomic_pointer_get(&sSmallTaskCore[nodeID]);
+				other = (CoreEntry*)atomic_pointer_get<CoreEntry>(&sSmallTaskCore[nodeID]);
 		}
 	} else {
 		int32 bestScore = -2;

--- a/src/system/kernel/scheduler/scheduler_assessment.md
+++ b/src/system/kernel/scheduler/scheduler_assessment.md
@@ -69,7 +69,7 @@ The system supports switchable operation modes (`scheduler_modes.h`) to adapt to
 ## 7. Performance Optimizations Highlighted
 
 *   **Fast Division:** `ThreadData::ComputeQuantum` uses `kRangeReciprocal` to replace expensive integer division with multiplication and shifts.
-*   **Bitmap Intrinsics:** Extensive use of `__builtin_ctz` and `fls` for bit manipulation.
+*   **Bitmap Intrinsics:** Extensive use of portable `ffs` and `fls` wrappers for bit manipulation, ensuring compatibility with GCC 2.95.
 *   **Stack Allocation:** `search_global_random` allocates its visited bitmask (up to 512 bytes) on the stack to avoid heap allocation overhead in the hot path.
 *   **Cache Locality:** `ThreadData` caches `fHomePackage` and `fCore` to prefer scheduling on the same physical resources (Warm Cache affinity).
 
@@ -104,7 +104,7 @@ While the updated scheduler is highly responsive, its "Statistical Fairness" (bu
 2.  **Increase Priority Resolution**
     *   **Strategy:** Expand `THREAD_MAX_SET_PRIORITY` from 99 to 255 (matching one byte).
     *   **Fairness Improvement:** **Moderate (Rank 2)**. Reduces bucket width from ~5ms to ~2ms, statistically reducing collisions by ~60%.
-    *   **Performance Impact:** **Negligible**. Bitmaps grow slightly (from 4 words to 8 words), but `__builtin_ctz` efficiency remains identical.
+    *   **Performance Impact:** **Negligible**. Bitmaps grow slightly (from 4 words to 8 words), but `ffs` efficiency remains identical.
     *   **Status:** Partially addressed by Issue 40's multi-level `PeekBest` search.
 
 3.  ~~**Simplified Lag Tracking (Starvation Protection)**~~ - **REJECTED**

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -60,6 +60,10 @@ struct ThreadDataVRuntimeCompare {
 	}
 };
 
+// Portability helpers for GCC 2.95 and architecture independence.
+// These wrappers ensure atomic operations and bit manipulation work correctly
+// on both 32-bit and 64-bit systems.
+
 #if defined(__x86_64__) || defined(__aarch64__) || defined(__riscv64__)
 	// 64-bit systems: supports up to 64 L3 domains per node
 	typedef uint64 native_cpu_mask_t;

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -76,6 +76,8 @@ struct ThreadDataVRuntimeCompare {
 #endif
 
 // Helpers for atomic operations and bit manipulation on native_cpu_mask_t
+// These wrappers provide architecture-independent atomic access (32/64-bit).
+
 static inline native_cpu_mask_t
 scheduler_atomic_or(native_cpu_mask_t* value, native_cpu_mask_t orValue)
 {
@@ -86,6 +88,7 @@ scheduler_atomic_or(native_cpu_mask_t* value, native_cpu_mask_t orValue)
 #endif
 }
 
+
 static inline native_cpu_mask_t
 scheduler_atomic_and(native_cpu_mask_t* value, native_cpu_mask_t andValue)
 {
@@ -95,6 +98,7 @@ scheduler_atomic_and(native_cpu_mask_t* value, native_cpu_mask_t andValue)
 	return (native_cpu_mask_t)atomic_and((int32*)value, (int32)andValue);
 #endif
 }
+
 
 static inline native_cpu_mask_t
 scheduler_atomic_get(native_cpu_mask_t* value)
@@ -130,6 +134,7 @@ scheduler_ffs64(uint64 value)
 	return high + 32;
 }
 
+// scheduler_ctz: portable Count Trailing Zeros for GCC 2.95.
 static inline int
 scheduler_ctz(native_cpu_mask_t value)
 {

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -128,10 +128,11 @@ scheduler_ffs64(uint64 value)
 	uint32 low = (uint32)value;
 	if (low != 0)
 		return ffs((int)low);
-	int high = ffs((int)(value >> 32));
-	if (high == 0)
+	uint32 high = (uint32)(value >> 32);
+	int bit = ffs((int)high);
+	if (bit == 0)
 		return 0;
-	return high + 32;
+	return bit + 32;
 }
 
 // scheduler_ctz: portable Count Trailing Zeros for GCC 2.95.
@@ -141,7 +142,7 @@ scheduler_ctz(native_cpu_mask_t value)
 	if (value == 0)
 		return 0;
 #if SCHEDULER_MASK_IS_64_BIT
-	return scheduler_ffs64(value) - 1;
+	return scheduler_ffs64((uint64)value) - 1;
 #else
 	return ffs((int)value) - 1;
 #endif

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -13,6 +13,7 @@
 #include <smp.h>
 #include <thread.h>
 #include <user_debugger.h>
+#include <util/atomic.h>
 #include <util/MinMaxHeap.h>
 
 #include "RunQueue.h"
@@ -145,6 +146,20 @@ scheduler_ctz(native_cpu_mask_t value)
 	return scheduler_ffs64((uint64)value) - 1;
 #else
 	return ffs((int)value) - 1;
+#endif
+}
+
+
+// atomic_pointer_get: architecture-independent atomic pointer read.
+// Necessary for GCC 2.95 compatibility and 32/64-bit portability.
+template<typename T>
+static inline T*
+atomic_pointer_get(T* const* pointer)
+{
+#if defined(__x86_64__) || defined(__aarch64__) || defined(__riscv64__)
+	return (T*)atomic_get64((int64*)pointer);
+#else
+	return (T*)atomic_get((int32*)pointer);
 #endif
 }
 

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -1243,7 +1243,7 @@ CoreEntry::PeekMinimumLoadCPU()
 {
 	// Optimization: If a physical core is idle, explicitly return the
 	// Primary logical CPU first.
-	// Issue 20 fix: use fCPUSet.FindFirstSet() equivalent via ffs()
+	// Issue 20 fix: use fCPUSet.FindFirstSet() equivalent via scheduler_ctz()
 	// on each bitmap word rather than iterating all (SMP_MAX_CPUS+31)/32
 	// words. For a core with CPUs in a small ID range this avoids scanning
 	// all zero words before finding the first set bit.
@@ -1255,7 +1255,7 @@ CoreEntry::PeekMinimumLoadCPU()
 			uint32 bits = fCPUSet.Bits(i);
 			if (bits == 0)
 				continue;
-			int cpu = i * 32 + (ffs((int)bits) - 1);
+			int cpu = i * 32 + scheduler_ctz((native_cpu_mask_t)bits);
 			if (cpu < smp_get_num_cpus()) {
 				CPUEntry* entry = &gCPUEntries[cpu];
 				// Issue 52 fix: verify the CPU is still in the heap before

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -1243,7 +1243,7 @@ CoreEntry::PeekMinimumLoadCPU()
 {
 	// Optimization: If a physical core is idle, explicitly return the
 	// Primary logical CPU first.
-	// Issue 20 fix: use fCPUSet.FindFirstSet() equivalent via __builtin_ffs
+	// Issue 20 fix: use fCPUSet.FindFirstSet() equivalent via ffs()
 	// on each bitmap word rather than iterating all (SMP_MAX_CPUS+31)/32
 	// words. For a core with CPUs in a small ID range this avoids scanning
 	// all zero words before finding the first set bit.

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -381,7 +381,7 @@ public:
 
 private:
 						int32				fNodeID;
-						native_cpu_mask_t	fIdlePackageMask;
+						native_cpu_mask_t	fIdlePackageMask __attribute__((aligned(8)));
 
 						int32				fPackageStartIndex;
 						int32				fPackageCount;
@@ -437,8 +437,8 @@ private:
 						SchedulerNode*		fNode;
 						int32				fNodeIndex;
 
-						CoreEntry*			fCores[kMaxCoresPerPackage];
-						native_cpu_mask_t	fIdleCoreMask;
+						CoreEntry*			fCores[kMaxCoresPerPackage] __attribute__((aligned(8)));
+						native_cpu_mask_t	fIdleCoreMask __attribute__((aligned(8)));
 						int32				fIdleCoreCount;
 						int32				fCoreCount;
 						int32				fRegisteredCoreCount;
@@ -448,8 +448,8 @@ public:
 private:
 	mutable				rw_spinlock			fCoreLock;
 
-						int32				fCoreLoads[kMaxCoresPerPackage];
-						native_cpu_mask_t	fEnabledCoreMask;
+						int32				fCoreLoads[kMaxCoresPerPackage] __attribute__((aligned(8)));
+						native_cpu_mask_t	fEnabledCoreMask __attribute__((aligned(8)));
 
 						friend class DebugDumper;
 } __attribute__((aligned(64)));
@@ -807,21 +807,33 @@ SchedulerNode::PackageWakesUp(PackageEntry* package)
 			// PackageGoesIdle call will re-set the bit if needed.
 			const int kMaxWakeupRetries = 64;
 			int wakeupRetries = 0;
-			do {
+			while (true) {
+				nodeMask = atomic_get64((int64*)&gIdleNodeMask);
+				if (!(nodeMask & nodeBit))
+					break; // already cleared by a concurrent PackageWakesUp
+
 				if (scheduler_atomic_get(&fIdlePackageMask)
 						!= (native_cpu_mask_t)0) {
 					// A package in this node went idle concurrently; the node
 					// bit must remain set.
 					break;
 				}
-				nodeMask = atomic_get64((int64*)&gIdleNodeMask);
-				if (!(nodeMask & nodeBit))
-					break; // already cleared by a concurrent PackageWakesUp
+
+				if (atomic_test_and_set64((int64*)&gIdleNodeMask,
+						nodeMask & ~nodeBit, nodeMask) == nodeMask) {
+					// Successfully cleared. Re-check for safety to catch the
+					// race where a package went idle between our last check
+					// and the CAS.
+					if (scheduler_atomic_get(&fIdlePackageMask)
+							!= (native_cpu_mask_t)0) {
+						atomic_or64((int64*)&gIdleNodeMask, nodeBit);
+					}
+					break;
+				}
 
 				if (++wakeupRetries >= kMaxWakeupRetries)
 					break;
-			} while (atomic_test_and_set64((int64*)&gIdleNodeMask,
-					nodeMask & ~nodeBit, nodeMask) != nodeMask);
+			}
 		}
 	}
 }
@@ -946,7 +958,7 @@ PackageEntry::GetLeastIdlePackage()
 
 		// For all practical package counts (33-4096) the log2 formula always
 		// evaluates to a value <= kMaxFallbackAttempts, so use the global
-		// constant directly.  This avoids recomputing __builtin_clz on every
+		// constant directly.  This avoids recomputing fls() on every
 		// call in this hot path and keeps the probe count consistent with the
 		// rest of the scheduler.
 		for (int32 i = 0; i < kMaxFallbackAttempts; i++) {

--- a/src/system/kernel/scheduler/scheduler_load.cpp
+++ b/src/system/kernel/scheduler/scheduler_load.cpp
@@ -26,7 +26,7 @@ using namespace Scheduler;
  */
 const static int kFShift = 11;
 const static long kFScale = 1 << kFShift;
-static struct loadavg sAverageRunnable = {{0, 0, 0}, kFScale};
+static struct loadavg sAverageRunnable __attribute__((aligned(8))) = {{0, 0, 0}, kFScale};
 const static uint64 sCExp[3] __attribute__((aligned(8))) = {(uint64)(0.9200444146293232 * kFScale),
 	(uint64)(0.9834714538216174 * kFScale), (uint64)(0.9944598480048967 * kFScale)};
 

--- a/src/system/kernel/scheduler/scheduler_profiler.cpp
+++ b/src/system/kernel/scheduler/scheduler_profiler.cpp
@@ -320,7 +320,7 @@ Profiler::_FindFunction(const char* function)
 	uint32 index = hash % kHashTableSize;
 	uint32 startIndex = index;
 	do {
-		FunctionData* entry = atomic_pointer_get(&fHashTable[index]);
+		FunctionData* entry = atomic_pointer_get<FunctionData>(&fHashTable[index]);
 		if (entry == NULL)
 			break;
 
@@ -340,7 +340,7 @@ Profiler::_FindFunction(const char* function)
 	index = hash % kHashTableSize;
 	startIndex = index;
 	do {
-		FunctionData* entry = atomic_pointer_get(&fHashTable[index]);
+		FunctionData* entry = atomic_pointer_get<FunctionData>(&fHashTable[index]);
 		if (entry == NULL)
 			break;
 
@@ -361,11 +361,11 @@ Profiler::_FindFunction(const char* function)
 
 		// Insert into hash table.
 		index = hash % kHashTableSize;
-		while (atomic_pointer_get(&fHashTable[index]) != NULL)
+		while (atomic_pointer_get<FunctionData>(&fHashTable[index]) != NULL)
 			index = (index + 1) % kHashTableSize;
 
 		memory_write_barrier();
-		atomic_pointer_set(&fHashTable[index], entry);
+		atomic_pointer_set<FunctionData>(&fHashTable[index], entry);
 
 		return entry;
 	}

--- a/src/system/kernel/scheduler/scheduler_profiler.h
+++ b/src/system/kernel/scheduler/scheduler_profiler.h
@@ -49,8 +49,8 @@ private:
 
 			int32			fCalled;
 
-			bigtime_t		fTimeInclusive;
-			bigtime_t		fTimeExclusive;
+			bigtime_t		fTimeInclusive __attribute__((aligned(8)));
+			bigtime_t		fTimeExclusive __attribute__((aligned(8)));
 	} __attribute__((aligned(8)));
 
 	struct FunctionEntry {

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -569,8 +569,12 @@ ThreadData::Dies()
 		}
 	}
 
-	if (gTrackCoreLoad)
-		fCore->RemoveLoad(fNeededLoad, true);
+	if (gTrackCoreLoad) {
+		CoreEntry* const snap = atomic_pointer_get(
+			const_cast<CoreEntry* volatile*>(&fCore));
+		if (snap != NULL)
+			snap->RemoveLoad(fNeededLoad, true);
+	}
 	fReady = false;
 }
 

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -537,7 +537,7 @@ ThreadData::GoesAway()
 	// SchedulerModeLocker (read). These are different locks, so the race
 	// is real. The snapshot approach is the minimal safe fix.
 	{
-		CoreEntry* const snap = atomic_pointer_get(
+		CoreEntry* const snap = atomic_pointer_get<CoreEntry>(
 			const_cast<CoreEntry* volatile*>(&fCore));
 		fWentSleepActive = (snap != NULL) ? snap->GetActiveTime() : 0;
 		if (gTrackCoreLoad && snap != NULL)
@@ -570,7 +570,7 @@ ThreadData::Dies()
 	}
 
 	if (gTrackCoreLoad) {
-		CoreEntry* const snap = atomic_pointer_get(
+		CoreEntry* const snap = atomic_pointer_get<CoreEntry>(
 			const_cast<CoreEntry* volatile*>(&fCore));
 		if (snap != NULL)
 			snap->RemoveLoad(fNeededLoad, true);

--- a/src/system/kernel/scheduler/scheduler_topology.h
+++ b/src/system/kernel/scheduler/scheduler_topology.h
@@ -283,7 +283,7 @@ CheckMaskedPackagesMinimumLoad(CPUEntry* cpu, const CPUSet& mask,
 			continue;
 
 		while (bits != 0) {
-			int bit = ffs((int)bits) - 1;
+			int bit = scheduler_ctz((native_cpu_mask_t)bits);
 			bits &= ~(1U << bit);
 			int32 cpuID = i * 32 + bit;
 

--- a/src/system/kernel/scheduler/scheduler_topology.h
+++ b/src/system/kernel/scheduler/scheduler_topology.h
@@ -283,7 +283,7 @@ CheckMaskedPackagesMinimumLoad(CPUEntry* cpu, const CPUSet& mask,
 			continue;
 
 		while (bits != 0) {
-			int bit = __builtin_ctz(bits);
+			int bit = ffs((int)bits) - 1;
 			bits &= ~(1U << bit);
 			int32 cpuID = i * 32 + bit;
 

--- a/src/system/kernel/scheduler/scheduler_tracing.cpp
+++ b/src/system/kernel/scheduler/scheduler_tracing.cpp
@@ -151,13 +151,20 @@ cmd_scheduler(int argc, char** argv)
 
 	TraceEntryIterator iterator;
 	while (TraceEntry* _entry = iterator.Next()) {
-		if (dynamic_cast<SchedulerTraceEntry*>(_entry) == NULL)
+		// Manual RTTI replacement for dynamic_cast
+		// Use tracing_is_entry_valid for a basic sanity check, then rely on
+		// EntryType() from SchedulerTraceEntry.
+		if (!tracing_is_entry_valid((AbstractTraceEntry*)_entry))
 			continue;
 
-		if (ScheduleThread* entry = dynamic_cast<ScheduleThread*>(_entry)) {
-			if (entry->ThreadID() == threadID) {
+		AbstractTraceEntry* entry = (AbstractTraceEntry*)_entry;
+		uint16 type = entry->EntryType();
+
+		if (type == SCHEDULER_TRACE_ENTRY_TYPE_SCHEDULE_THREAD) {
+			ScheduleThread* scheduleEntry = (ScheduleThread*)entry;
+			if (scheduleEntry->ThreadID() == threadID) {
 				// thread scheduled
-				bigtime_t diffTime = entry->Time() - lastTime;
+				bigtime_t diffTime = scheduleEntry->Time() - lastTime;
 
 				if (state == READY) {
 					// thread scheduled after having been woken up
@@ -184,17 +191,17 @@ cmd_scheduler(int argc, char** argv)
 				if (state == STILL_RUNNING) {
 					// Thread was running and continues to run.
 					// Update lastTime to start of this segment.
-					lastTime = entry->Time();
+					lastTime = scheduleEntry->Time();
 					state = RUNNING;
 				}
 
 				if (state != RUNNING) {
-					lastTime = entry->Time();
+					lastTime = scheduleEntry->Time();
 					state = RUNNING;
 				}
-			} else if (entry->PreviousThreadID() == threadID) {
+			} else if (scheduleEntry->PreviousThreadID() == threadID) {
 				// thread unscheduled
-				bigtime_t diffTime = entry->Time() - lastTime;
+				bigtime_t diffTime = scheduleEntry->Time() - lastTime;
 
 				if (state == STILL_RUNNING) {
 					// thread preempted
@@ -207,11 +214,11 @@ cmd_scheduler(int argc, char** argv)
 						maxRunTime = diffTime;
 
 					state = PREEMPTED;
-					lastTime = entry->Time();
+					lastTime = scheduleEntry->Time();
 				} else if (state == RUNNING) {
 					// thread starts waiting (it hadn't been added to the run
 					// queue before being unscheduled)
-					bigtime_t diffTime = entry->Time() - lastTime;
+					bigtime_t diffTime = scheduleEntry->Time() - lastTime;
 					runs++;
 					totalRunTime += diffTime;
 					if (minRunTime < 0 || diffTime < minRunTime)
@@ -220,12 +227,12 @@ cmd_scheduler(int argc, char** argv)
 						maxRunTime = diffTime;
 
 					state = WAITING;
-					lastTime = entry->Time();
+					lastTime = scheduleEntry->Time();
 				}
 			}
-		} else if (EnqueueThread* entry
-				= dynamic_cast<EnqueueThread*>(_entry)) {
-			if (entry->ThreadID() != threadID)
+		} else if (type == SCHEDULER_TRACE_ENTRY_TYPE_ENQUEUE_THREAD) {
+			EnqueueThread* enqueueEntry = (EnqueueThread*)entry;
+			if (enqueueEntry->ThreadID() != threadID)
 				continue;
 
 			// thread enqueued in run queue
@@ -236,11 +243,12 @@ cmd_scheduler(int argc, char** argv)
 				state = STILL_RUNNING;
 			} else {
 				// Thread was waiting and is ready now.
-				lastTime = entry->Time();
+				lastTime = enqueueEntry->Time();
 				state = READY;
 			}
-		} else if (RemoveThread* entry = dynamic_cast<RemoveThread*>(_entry)) {
-			if (entry->ThreadID() != threadID)
+		} else if (type == SCHEDULER_TRACE_ENTRY_TYPE_REMOVE_THREAD) {
+			RemoveThread* removeEntry = (RemoveThread*)entry;
+			if (removeEntry->ThreadID() != threadID)
 				continue;
 
 			// thread removed from run queue
@@ -250,7 +258,7 @@ cmd_scheduler(int argc, char** argv)
 
 			if (state == RUNNING) {
 				// This should never happen.
-				bigtime_t diffTime = entry->Time() - lastTime;
+				bigtime_t diffTime = removeEntry->Time() - lastTime;
 				runs++;
 				totalRunTime += diffTime;
 				if (minRunTime < 0 || diffTime < minRunTime)

--- a/src/system/kernel/scheduler/scheduler_tracing.cpp
+++ b/src/system/kernel/scheduler/scheduler_tracing.cpp
@@ -151,9 +151,6 @@ cmd_scheduler(int argc, char** argv)
 
 	TraceEntryIterator iterator;
 	while (TraceEntry* _entry = iterator.Next()) {
-		// Manual RTTI replacement for dynamic_cast
-		// Use tracing_is_entry_valid for a basic sanity check, then rely on
-		// EntryType() from SchedulerTraceEntry.
 		if (!tracing_is_entry_valid((AbstractTraceEntry*)_entry))
 			continue;
 

--- a/src/system/kernel/scheduler/scheduler_tracing.h
+++ b/src/system/kernel/scheduler/scheduler_tracing.h
@@ -17,6 +17,8 @@
 
 namespace SchedulerTracing {
 
+// Manual RTTI IDs for scheduler tracing.
+// Range 100-199 reserved for SchedulerTracing namespace.
 enum SchedulerTraceEntryType {
 	SCHEDULER_TRACE_ENTRY_TYPE_ENQUEUE_THREAD = 100,
 	SCHEDULER_TRACE_ENTRY_TYPE_REMOVE_THREAD,

--- a/src/system/kernel/scheduler/scheduler_tracing.h
+++ b/src/system/kernel/scheduler/scheduler_tracing.h
@@ -17,6 +17,12 @@
 
 namespace SchedulerTracing {
 
+enum SchedulerTraceEntryType {
+	SCHEDULER_TRACE_ENTRY_TYPE_ENQUEUE_THREAD = 100,
+	SCHEDULER_TRACE_ENTRY_TYPE_REMOVE_THREAD,
+	SCHEDULER_TRACE_ENTRY_TYPE_SCHEDULE_THREAD,
+};
+
 class SchedulerTraceEntry : public AbstractTraceEntry {
 public:
 	SchedulerTraceEntry(Thread* thread)
@@ -28,6 +34,7 @@ public:
 	thread_id ThreadID() const	{ return fID; }
 
 	virtual const char* Name() const = 0;
+	virtual uint16 EntryType() const = 0;
 
 protected:
 	thread_id			fID;
@@ -36,6 +43,11 @@ protected:
 
 class EnqueueThread : public SchedulerTraceEntry {
 public:
+	virtual uint16 EntryType() const
+	{
+		return SCHEDULER_TRACE_ENTRY_TYPE_ENQUEUE_THREAD;
+	}
+
 	EnqueueThread(Thread* thread, int32 effectivePriority)
 		:
 		SchedulerTraceEntry(thread),
@@ -60,6 +72,11 @@ private:
 
 class RemoveThread : public SchedulerTraceEntry {
 public:
+	virtual uint16 EntryType() const
+	{
+		return SCHEDULER_TRACE_ENTRY_TYPE_REMOVE_THREAD;
+	}
+
 	RemoveThread(Thread* thread)
 		:
 		SchedulerTraceEntry(thread),
@@ -79,6 +96,11 @@ private:
 
 class ScheduleThread : public SchedulerTraceEntry {
 public:
+	virtual uint16 EntryType() const
+	{
+		return SCHEDULER_TRACE_ENTRY_TYPE_SCHEDULE_THREAD;
+	}
+
 	ScheduleThread(Thread* thread, Thread* previous)
 		:
 		SchedulerTraceEntry(thread),

--- a/src/system/kernel/scheduler/scheduling_analysis.cpp
+++ b/src/system/kernel/scheduler/scheduling_analysis.cpp
@@ -672,8 +672,8 @@ private:
 	HashObject**		fHashTable;
 	uint32				fHashTableSize;
 
-	uintptr_t	fNextAllocation;
-	size_t		fRemainingBytes;
+	uintptr_t	fNextAllocation __attribute__((aligned(8)));
+	size_t		fRemainingBytes __attribute__((aligned(8)));
 };
 
 

--- a/src/system/kernel/scheduler/scheduling_analysis.cpp
+++ b/src/system/kernel/scheduler/scheduling_analysis.cpp
@@ -699,8 +699,8 @@ analyze_scheduling(bigtime_t from, bigtime_t until,
 		// Actually, we can use the fact that our enums are distinct.
 
 		// For now, use the safest available check.
-		// In a real Haiku kernel audit, we'd add Type() to AbstractTraceEntry.
-		// Here we'll use a hack based on our known subclasses.
+		// We use the EntryType() method added to AbstractTraceEntry to
+		// distinguish between different trace entry types without RTTI.
 
 		AbstractTraceEntry* baseEntry = (AbstractTraceEntry*)_entry;
 		if (baseEntry->Time() >= until)

--- a/src/system/kernel/scheduler/scheduling_analysis.cpp
+++ b/src/system/kernel/scheduler/scheduling_analysis.cpp
@@ -684,19 +684,46 @@ analyze_scheduling(bigtime_t from, bigtime_t until,
 	TraceEntryIterator iterator;
 	iterator.MoveTo(INT_MAX);
 	while (TraceEntry* _entry = iterator.Previous()) {
-		SchedulerTraceEntry* baseEntry
-			= dynamic_cast<SchedulerTraceEntry*>(_entry);
-		if (baseEntry == NULL || baseEntry->Time() >= until)
+		// Manual RTTI replacement for dynamic_cast
+		if (!tracing_is_entry_valid((AbstractTraceEntry*)_entry))
+			continue;
+
+		// Since SchedulerTraceEntry doesn't have a Type() method we can use
+		// without risking illegal casts, and we only have SchedulerTraceEntries
+		// or WaitObjectTraceEntries that we care about, we use a different approach.
+		//
+		// We'll rely on the EntryType() we added to SchedulerTraceEntry subclasses.
+		// But first we must be sure it IS a SchedulerTraceEntry.
+		//
+		// Given kernel constraints and GCC 2.95, we'll assume standard layout.
+		// Actually, we can use the fact that our enums are distinct.
+
+		// For now, use the safest available check.
+		// In a real Haiku kernel audit, we'd add Type() to AbstractTraceEntry.
+		// Here we'll use a hack based on our known subclasses.
+
+		AbstractTraceEntry* baseEntry = (AbstractTraceEntry*)_entry;
+		if (baseEntry->Time() >= until)
 			continue;
 		if (baseEntry->Time() < from)
 			break;
 
-		status_t error = manager.AddThread(baseEntry->ThreadID(),
-			baseEntry->Name());
+		uint16 entryType = baseEntry->EntryType();
+
+		if (entryType < SCHEDULER_TRACE_ENTRY_TYPE_ENQUEUE_THREAD
+			|| entryType > SCHEDULER_TRACE_ENTRY_TYPE_SCHEDULE_THREAD) {
+			continue;
+		}
+
+		SchedulerTraceEntry* schedulerEntry = (SchedulerTraceEntry*)baseEntry;
+
+		status_t error = manager.AddThread(schedulerEntry->ThreadID(),
+			schedulerEntry->Name());
 		if (error != B_OK)
 			return error;
 
-		if (ScheduleThread* entry = dynamic_cast<ScheduleThread*>(_entry)) {
+		if (entryType == SCHEDULER_TRACE_ENTRY_TYPE_SCHEDULE_THREAD) {
+			ScheduleThread* entry = (ScheduleThread*)baseEntry;
 			error = manager.AddThread(entry->PreviousThreadID(), NULL);
 			if (error != B_OK)
 				return error;
@@ -730,9 +757,29 @@ analyze_scheduling(bigtime_t from, bigtime_t until,
 #endif
 
 	while (TraceEntry* _entry = iterator.Next()) {
+		if (!tracing_is_entry_valid((AbstractTraceEntry*)_entry))
+			continue;
+
 #if SCHEDULING_ANALYSIS_TRACING
-		if (WaitObjectTraceEntry* waitObjectEntry
-				= dynamic_cast<WaitObjectTraceEntry*>(_entry)) {
+		// How to distinguish WaitObjectTraceEntry from SchedulerTraceEntry?
+		// We'll use a simple heuristic or add a common base.
+		// For this task, I'll assume we can distinguish them by their first member
+		// if we are careful, but let's use the EntryType().
+		// Since they are different hierarchies, this is dangerous.
+
+		// Better: use the fact that they are in SchedulingAnalysisTracing namespace.
+		// Actually, I'll just use a C-style cast and hope for the best, or
+		// better, add a Type() to AbstractTraceEntry.
+		// Since I can't easily modify tracing.h without possibly breaking other things,
+		// I'll assume the caller of these entries knows what's in the buffer.
+
+		AbstractTraceEntry* abstractEntry = (AbstractTraceEntry*)_entry;
+		uint16 entryType = abstractEntry->EntryType();
+
+		// Check if it's one of ours.
+		if (entryType >= WAIT_OBJECT_TRACE_ENTRY_TYPE_CREATE_SEMAPHORE
+			&& entryType <= WAIT_OBJECT_TRACE_ENTRY_TYPE_INIT_RW_LOCK) {
+			WaitObjectTraceEntry* waitObjectEntry = (WaitObjectTraceEntry*)abstractEntry;
 			status_t error = manager.UpdateWaitObject(waitObjectEntry->Type(),
 				waitObjectEntry->Object(), waitObjectEntry->Name(),
 				waitObjectEntry->ReferencedObject());
@@ -742,14 +789,14 @@ analyze_scheduling(bigtime_t from, bigtime_t until,
 		}
 #endif
 
-		SchedulerTraceEntry* baseEntry
-			= dynamic_cast<SchedulerTraceEntry*>(_entry);
-		if (baseEntry == NULL)
-			continue;
+		AbstractTraceEntry* baseEntry = (AbstractTraceEntry*)_entry;
 		if (baseEntry->Time() >= until)
 			break;
 
-		if (ScheduleThread* entry = dynamic_cast<ScheduleThread*>(_entry)) {
+		uint16 entryType = baseEntry->EntryType();
+
+		if (entryType == SCHEDULER_TRACE_ENTRY_TYPE_SCHEDULE_THREAD) {
+			ScheduleThread* entry = (ScheduleThread*)baseEntry;
 			Thread* thread = manager.ThreadFor(entry->ThreadID());
 
 			bigtime_t diffTime = entry->Time() - thread->lastTime;
@@ -842,8 +889,8 @@ analyze_scheduling(bigtime_t from, bigtime_t until,
 					thread->state = PREEMPTED;
 				}
 			}
-		} else if (EnqueueThread* entry
-				= dynamic_cast<EnqueueThread*>(_entry)) {
+		} else if (entryType == SCHEDULER_TRACE_ENTRY_TYPE_ENQUEUE_THREAD) {
+			EnqueueThread* entry = (EnqueueThread*)baseEntry;
 			Thread* thread = manager.ThreadFor(entry->ThreadID());
 
 			if (thread->state == RUNNING || thread->state == STILL_RUNNING) {
@@ -860,7 +907,8 @@ analyze_scheduling(bigtime_t from, bigtime_t until,
 				thread->lastTime = entry->Time();
 				thread->state = READY;
 			}
-		} else if (RemoveThread* entry = dynamic_cast<RemoveThread*>(_entry)) {
+		} else if (entryType == SCHEDULER_TRACE_ENTRY_TYPE_REMOVE_THREAD) {
+			RemoveThread* entry = (RemoveThread*)baseEntry;
 			Thread* thread = manager.ThreadFor(entry->ThreadID());
 
 			bigtime_t diffTime = entry->Time() - thread->lastTime;
@@ -886,8 +934,14 @@ analyze_scheduling(bigtime_t from, bigtime_t until,
 	if (missingWaitObjects > 0) {
 		iterator.MoveTo(startEntryIndex + 1);
 		while (TraceEntry* _entry = iterator.Previous()) {
-			if (WaitObjectTraceEntry* waitObjectEntry
-					= dynamic_cast<WaitObjectTraceEntry*>(_entry)) {
+			if (!tracing_is_entry_valid((AbstractTraceEntry*)_entry))
+				continue;
+
+			AbstractTraceEntry* abstractEntry = (AbstractTraceEntry*)_entry;
+			uint16 entryType = abstractEntry->EntryType();
+			if (entryType >= WAIT_OBJECT_TRACE_ENTRY_TYPE_CREATE_SEMAPHORE
+				&& entryType <= WAIT_OBJECT_TRACE_ENTRY_TYPE_INIT_RW_LOCK) {
+				WaitObjectTraceEntry* waitObjectEntry = (WaitObjectTraceEntry*)abstractEntry;
 				if (manager.UpdateWaitObjectDontAdd(
 						waitObjectEntry->Type(), waitObjectEntry->Object(),
 						waitObjectEntry->Name(),

--- a/src/system/kernel/scheduler/scheduling_analysis.cpp
+++ b/src/system/kernel/scheduler/scheduling_analysis.cpp
@@ -684,23 +684,8 @@ analyze_scheduling(bigtime_t from, bigtime_t until,
 	TraceEntryIterator iterator;
 	iterator.MoveTo(INT_MAX);
 	while (TraceEntry* _entry = iterator.Previous()) {
-		// Manual RTTI replacement for dynamic_cast
 		if (!tracing_is_entry_valid((AbstractTraceEntry*)_entry))
 			continue;
-
-		// Since SchedulerTraceEntry doesn't have a Type() method we can use
-		// without risking illegal casts, and we only have SchedulerTraceEntries
-		// or WaitObjectTraceEntries that we care about, we use a different approach.
-		//
-		// We'll rely on the EntryType() we added to SchedulerTraceEntry subclasses.
-		// But first we must be sure it IS a SchedulerTraceEntry.
-		//
-		// Given kernel constraints and GCC 2.95, we'll assume standard layout.
-		// Actually, we can use the fact that our enums are distinct.
-
-		// For now, use the safest available check.
-		// We use the EntryType() method added to AbstractTraceEntry to
-		// distinguish between different trace entry types without RTTI.
 
 		AbstractTraceEntry* baseEntry = (AbstractTraceEntry*)_entry;
 		if (baseEntry->Time() >= until)
@@ -761,18 +746,6 @@ analyze_scheduling(bigtime_t from, bigtime_t until,
 			continue;
 
 #if SCHEDULING_ANALYSIS_TRACING
-		// How to distinguish WaitObjectTraceEntry from SchedulerTraceEntry?
-		// We'll use a simple heuristic or add a common base.
-		// For this task, I'll assume we can distinguish them by their first member
-		// if we are careful, but let's use the EntryType().
-		// Since they are different hierarchies, this is dangerous.
-
-		// Better: use the fact that they are in SchedulingAnalysisTracing namespace.
-		// Actually, I'll just use a C-style cast and hope for the best, or
-		// better, add a Type() to AbstractTraceEntry.
-		// Since I can't easily modify tracing.h without possibly breaking other things,
-		// I'll assume the caller of these entries knows what's in the buffer.
-
 		AbstractTraceEntry* abstractEntry = (AbstractTraceEntry*)_entry;
 		uint16 entryType = abstractEntry->EntryType();
 

--- a/src/system/kernel/syscalls.cpp
+++ b/src/system/kernel/syscalls.cpp
@@ -337,6 +337,8 @@ get_syscall_name(uint32 syscall)
 
 class PreSyscall : public AbstractTraceEntry {
 	public:
+		virtual uint16 EntryType() const { return 303; }
+
 		PreSyscall(uint32 syscall, const void* parameters)
 			:
 			fSyscall(syscall),
@@ -432,6 +434,8 @@ class PreSyscall : public AbstractTraceEntry {
 
 class PostSyscall : public AbstractTraceEntry {
 	public:
+		virtual uint16 EntryType() const { return 304; }
+
 		PostSyscall(uint32 syscall, uint64 returnValue)
 			:
 			fSyscall(syscall),
@@ -513,7 +517,10 @@ public:
 		if (fDirection < 0)
 			return fFilter->Filter(_entry, out);
 
-		if (const PreSyscall* entry = dynamic_cast<const PreSyscall*>(_entry)) {
+		uint16 entryType = _entry->EntryType();
+
+		if (entryType == 303) {
+			const PreSyscall* entry = (const PreSyscall*)_entry;
 			_RemovePendingThread(entry->ThreadID());
 
 			bool accepted = fFilter->Filter(entry, out);
@@ -521,14 +528,14 @@ public:
 				_AddPendingThread(entry->ThreadID());
 			return accepted;
 
-		} else if (const PostSyscall* entry
-				= dynamic_cast<const PostSyscall*>(_entry)) {
+		} else if (entryType == 304) {
+			const PostSyscall* entry = (const PostSyscall*)_entry;
 			bool wasPending = _RemovePendingThread(entry->ThreadID());
 
 			return wasPending || fFilter->Filter(entry, out);
 
-		} else if (const AbstractTraceEntry* entry
-				= dynamic_cast<const AbstractTraceEntry*>(_entry)) {
+		} else if (entryType != 0) {
+			const AbstractTraceEntry* entry = (const AbstractTraceEntry*)_entry;
 			bool isPending = _IsPendingThread(entry->ThreadID());
 
 			return isPending || fFilter->Filter(entry, out);


### PR DESCRIPTION
This PR provides a comprehensive set of fixes and refinements resulting from an extensive audit of the Haiku scheduler subsystem.

Key improvements:
1. **GCC 2.95 Compatibility**: Eliminated C++11+ constructs and replaced non-portable GCC built-ins. Replaced `dynamic_cast` with a manual RTTI system for tracing analysis.
2. **Platform Portability**: Ensured correct 8-byte alignment for 64-bit atomic members, ensuring safe and accurate operation on both 32-bit and 64-bit systems.
3. **Concurrency Robustness**: Resolved subtle race conditions in package wakeup notifications and thread destruction paths.
4. **Logic Completeness**: Audited and corrected batch processing for team foreground changes and verified all division-by-zero guards.
5. **Documentation**: Updated the scheduler assessment and code comments to reflect the new implementation details and portable intrinsics.

---
*PR created automatically by Jules for task [15300898368505951227](https://jules.google.com/task/15300898368505951227) started by @tonestone57*