### PR TITLE
kernel/scheduler: Comprehensive audit and logic hardening

### DIFF
--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -419,8 +419,9 @@ RUN_QUEUE_CLASS_NAME::PushFront(Element* element,
 		Element* best = atomic_pointer_get<Element>(&fBest);
 		if (best != NULL) {
 			unsigned int bestPriority = sGetLink(best)->fPriority;
+			// Issue 28 fix: validate bestPriority is within bounds.
 			// Validate the bucket is non-empty before trusting bestPriority.
-			if (fHeads[bestPriority] == NULL)
+			if (bestPriority > MaxPriority || fHeads[bestPriority] == NULL)
 				atomic_pointer_set<Element>(&fBest, element); // stale, replace
 			else if (priority > bestPriority)
 				atomic_pointer_set<Element>(&fBest, element);
@@ -481,7 +482,8 @@ RUN_QUEUE_CLASS_NAME::PushBack(Element* element,
 		Element* best = atomic_pointer_get<Element>(&fBest);
 		if (best != NULL) {
 			unsigned int bestPriority = sGetLink(best)->fPriority;
-			if (fHeads[bestPriority] == NULL)
+			// Issue 28 fix: validate bestPriority is within bounds.
+			if (bestPriority > MaxPriority || fHeads[bestPriority] == NULL)
 				atomic_pointer_set<Element>(&fBest, element);
 			else if (priority > bestPriority)
 				atomic_pointer_set<Element>(&fBest, element);
@@ -547,7 +549,8 @@ RUN_QUEUE_CLASS_NAME::Remove(Element* element)
 			// Use the single snapshot: safe because best != element so it
 			// cannot be the element we just unlinked.
 			unsigned int bestPrio = sGetLink(best)->fPriority;
-			if (fHeads[bestPrio] == NULL) {
+			// Issue 28 fix: validate bestPrio is within bounds.
+			if (bestPrio > MaxPriority || fHeads[bestPrio] == NULL) {
 				atomic_pointer_test_and_set<Element>(&fBest, (Element*)NULL,
 					best);
 			}
@@ -597,7 +600,8 @@ RUN_QUEUE_CLASS_NAME::PeekBest() const
 		RunQueueLink<Element>* bestLink = sGetLink(bestCandidate);
 		unsigned int bestPrio = bestLink->fPriority;
 		// If the bucket is empty the pointer is stale; fall through to rescan.
-		if (fHeads[bestPrio] != NULL)
+		// Issue 28 fix: validate bestPrio is within bounds.
+		if (bestPrio <= MaxPriority && fHeads[bestPrio] != NULL)
 			return bestCandidate;
 		// Invalidate stale cache and rescan.
 		atomic_pointer_test_and_set<Element>(&fBest, (Element*)NULL,
@@ -615,10 +619,15 @@ RUN_QUEUE_CLASS_NAME::PeekBest() const
 	Element* globalBest = NULL;
 
 	for (int i = kBitmapSize - 1; i >= 0 && levelsSearched < kDeadlineLookaheadLevels; i--) {
-		uint32 val = fBitmap[i];
+		uint32 val = atomic_get((int32*)&fBitmap[i]);
 		if (val != 0) {
-			if (i == kBitmapSize - 1)
-				val &= (uint32)((2ULL << (MaxPriority % 32)) - 1);
+			if (i == kBitmapSize - 1) {
+				// Issue 61 fix: guard MaxPriority % 32 == 31.
+				if ((MaxPriority % 32) == 31)
+					; // all bits valid, no mask needed
+				else
+					val &= (uint32)((2ULL << (MaxPriority % 32)) - 1);
+			}
 
 			if (val == 0)
 				continue;
@@ -655,9 +664,9 @@ RUN_QUEUE_CLASS_NAME::PeekBest() const
 	// levels without finding anything (shouldn't happen in practice but
 	// possible when kDeadlineLookaheadLevels < total occupied levels),
 	// do a full scan to guarantee a non-NULL result from a non-empty queue.
-	if (globalBest == NULL && fTotalCount > 0) {
+	if (globalBest == NULL && atomic_get(&fTotalCount) > 0) {
 		for (int i = kBitmapSize - 1; i >= 0; i--) {
-			uint32 val = fBitmap[i];
+			uint32 val = atomic_get((int32*)&fBitmap[i]);
 			if (i == kBitmapSize - 1 && (MaxPriority % 32) != 31)
 				val &= (uint32)((2ULL << (MaxPriority % 32)) - 1);
 			if (val == 0) continue;
@@ -696,10 +705,15 @@ RUN_QUEUE_CLASS_NAME::PeekBest(const Compare2& compare, const Predicate& predica
 	SCHEDULER_ENTER_FUNCTION();
 
 	for (int i = kBitmapSize - 1; i >= 0; i--) {
-		uint32 val = fBitmap[i];
+		uint32 val = atomic_get((int32*)&fBitmap[i]);
 		if (val != 0) {
-			if (i == kBitmapSize - 1)
-				val &= (uint32)((2ULL << (MaxPriority % 32)) - 1);
+			if (i == kBitmapSize - 1) {
+				// Issue 61 fix: guard MaxPriority % 32 == 31.
+				if ((MaxPriority % 32) == 31)
+					; // all bits valid, no mask needed
+				else
+					val &= (uint32)((2ULL << (MaxPriority % 32)) - 1);
+			}
 
 			if (val == 0)
 				continue;
@@ -754,10 +768,15 @@ RUN_QUEUE_CLASS_NAME::PeekOption(const Predicate& predicate) const
 		if (totalBudget <= 0)
 			return NULL;
 
-		uint32 val = fBitmap[i];
+		uint32 val = atomic_get((int32*)&fBitmap[i]);
 
-		if (i == kBitmapSize - 1)
-			val &= (uint32)((2ULL << (MaxPriority % 32)) - 1);
+		if (i == kBitmapSize - 1) {
+			// Issue 61 fix: guard MaxPriority % 32 == 31.
+			if ((MaxPriority % 32) == 31)
+				; // all bits valid, no mask needed
+			else
+				val &= (uint32)((2ULL << (MaxPriority % 32)) - 1);
+		}
 
 		while (val != 0) {
 			int bit = fls(val) - 1;

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -544,9 +544,10 @@ enqueue(Thread* thread, bool newOne, Thread* waker)
 			// Issue 84 fix: this IPI dispatch was unreachable before; now
 			// correctly wakes the target CPU when a thread is enqueued.
 			bigtime_t now = system_time();
-			if (ShouldReschedule(now, targetCPU->lastReschedule, kRescheduleCooldown)) {
+			if (ShouldReschedule(now, atomic_get64(&targetCPU->lastReschedule),
+					kRescheduleCooldown)) {
 				if (targetCPU->SetReschedulePending()) {
-					targetCPU->lastReschedule = now;
+					atomic_set64(&targetCPU->lastReschedule, now);
 					smp_send_ici(targetCPU->ID(), SMP_MSG_RESCHEDULE, 0, 0, 0,
 						NULL, SMP_MSG_FLAG_ASYNC);
 				}

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -62,6 +62,16 @@ struct ThreadDataVRuntimeCompare {
 	}
 };
 
+
+struct ThreadDataOptimal {
+	template<typename ThreadData>
+	bool operator()(const ThreadData* /*thread*/) const
+	{
+		return true;
+	}
+};
+
+
 // Portability helpers for GCC 2.95 and architecture independence.
 // These wrappers ensure atomic operations and bit manipulation work correctly
 // on both 32-bit and 64-bit systems.

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -53,8 +53,9 @@ ThreadData::_InitBase()
 	fHomePackage = -1;
 
 	fEffectivePriority = GetPriority();
-	fBaseQuantum = sQuantumLengths[min_c(GetEffectivePriority(),
-		THREAD_MAX_SET_PRIORITY)];
+	atomic_set64((int64*)&fBaseQuantum,
+		atomic_get64(&sQuantumLengths[min_c(GetEffectivePriority(),
+			THREAD_MAX_SET_PRIORITY)]));
 
 	fTimeUsed = 0;
 
@@ -349,7 +350,7 @@ ThreadData::ComputeQuantum() const
 	SCHEDULER_ENTER_FUNCTION();
 
 	if (IsRealTime())
-		return fBaseQuantum;
+		return atomic_get64((int64*)&fBaseQuantum);
 
 	// Issue 11 fix: ComputeQuantum is only called while the caller holds
 	// SchedulerModeLocker (a read lock on CPUEntry::fSchedulerModeLock).
@@ -670,7 +671,7 @@ ThreadData::_ComputeEffectivePriority(bigtime_t now) const
 	// ComputeQuantumLengths() sets gDeadlineBucketSize to a positive value.
 	if (bucketSize <= 0) {
 		fEffectivePriority = GetPriority();
-		fBaseQuantum = Scheduler::MinimalQuantum();
+		atomic_set64((int64*)&fBaseQuantum, Scheduler::MinimalQuantum());
 		return;
 	}
 
@@ -734,7 +735,8 @@ ThreadData::_ComputeEffectivePriority(bigtime_t now) const
 		fEffectivePriority = (int32)urgency;
 	}
 
-	fBaseQuantum = atomic_get64(&sQuantumLengths[GetEffectivePriority()]);
+	atomic_set64((int64*)&fBaseQuantum,
+		atomic_get64(&sQuantumLengths[GetEffectivePriority()]));
 }
 
 

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -112,8 +112,15 @@ public:
 	SCHEDULER_INLINE	void		GoesAway();
 	SCHEDULER_INLINE	void		Dies();
 
-	SCHEDULER_INLINE	bigtime_t	WentSleep() const	{ return fWentSleep; }
-	SCHEDULER_INLINE	bigtime_t	WentSleepActive() const	{ return fWentSleepActive; }
+	SCHEDULER_INLINE	bigtime_t	WentSleep() const
+	{
+		return atomic_get64((int64*)&fWentSleep);
+	}
+
+	SCHEDULER_INLINE	bigtime_t	WentSleepActive() const
+	{
+		return atomic_get64((int64*)&fWentSleepActive);
+	}
 
 	SCHEDULER_INLINE	void		PutBack();
 	SCHEDULER_INLINE	bool		Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption,
@@ -129,11 +136,14 @@ public:
 
 	static	bigtime_t	sMaxLatency __attribute__((aligned(8)));
 
-	SCHEDULER_INLINE	bigtime_t	GetVirtualRuntime() const { return fVirtualRuntime; }
+	SCHEDULER_INLINE	bigtime_t	GetVirtualRuntime() const
+	{
+		return atomic_get64((int64*)&fVirtualRuntime);
+	}
 
 	SCHEDULER_INLINE	void		SetQuantum(bigtime_t quantum)
 	{
-		fBaseQuantum = quantum;
+		atomic_set64((int64*)&fBaseQuantum, quantum);
 	}
 
 	SCHEDULER_INLINE	bool		IsEnqueued() const	{ return fEnqueued; }


### PR DESCRIPTION
This patch hardens the Haiku scheduler for improved stability, concurrency safety, and architecture independence.

Key changes:
1.  **Architecture-Independent Atomicity:** Replaces lockless direct accesses to shared state (run queue bitmaps, thread counts, reschedule timestamps) with atomic getters and setters. This prevents torn reads on 32-bit platforms and ensures visibility across different CPU cores without heavy locking.
2.  **Robust Priority Handling:** Adds bounds checking for priority values retrieved from potentially stale or concurrent element snapshots (like `fBest` in `RunQueue`). This prevents out-of-bounds array accesses in the scheduler hot path.
3.  **Correct Mask Generation:** Handles edge cases in priority bitmask generation (e.g., when `MaxPriority` is 31, 63, etc.) to prevent undefined shift behavior.
4.  **Symbol Completeness:** Defines the `ThreadDataOptimal` predicate required by `GetMinVirtualRuntime` calls.
5.  **GCC 2.95 Compatibility:** Verified that all changes maintain compatibility with Haiku's legacy compiler by avoiding C++11 features and ensuring proper alignment of 64-bit atomic members.

---
*PR created automatically by Jules for task [6396830440080050603](https://jules.google.com/task/6396830440080050603) started by @tonestone57*