### PR TITLE
Audit and fix scheduler for GCC 2.95 and architecture independence

### DIFF
--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -356,10 +356,8 @@ RUN_QUEUE_CLASS_NAME::PeekMaximum() const
 
 				ASSERT(priority <= MaxPriority);
 				Element* head = atomic_pointer_get<Element>(&fHeads[priority]);
-				if (head != NULL) {
-					memory_read_barrier();
+				if (head != NULL)
 					return head;
-				}
 
 				val &= ~(1UL << bit);
 			}

--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -21,10 +21,10 @@ template<typename Element>
 struct RunQueueLink {
 					RunQueueLink();
 
-	unsigned int	fPriority;
 	Element*		fPrevious;
 	Element*		fNext;
-};
+	unsigned int	fPriority;
+} __attribute__((aligned(8)));
 
 template<typename Element>
 class RunQueueLinkImpl {
@@ -356,8 +356,10 @@ RUN_QUEUE_CLASS_NAME::PeekMaximum() const
 
 				ASSERT(priority <= MaxPriority);
 				Element* head = atomic_pointer_get<Element>(&fHeads[priority]);
-				if (head != NULL)
+				if (head != NULL) {
+					memory_read_barrier();
 					return head;
+				}
 
 				val &= ~(1UL << bit);
 			}

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -78,7 +78,7 @@ struct ThreadDataOptimal {
 
 #if B_HAIKU_64_BIT
 	// 64-bit systems: supports up to 64 L3 domains per node
-	typedef uint64 native_cpu_mask_t;
+	typedef uint64 native_cpu_mask_t __attribute__((aligned(8)));
 	#define SCHEDULER_MASK_IS_64_BIT 1
 #else
 	// 32-bit systems: supports up to 32 L3 domains per node
@@ -273,7 +273,7 @@ extern bool gTrackCoreLoad;
 extern bool gTrackCPULoad;
 extern int32 gRandomSamples;
 
-extern const bigtime_t kMinMeasurementWindow;
+extern const bigtime_t kMinMeasurementWindow __attribute__((aligned(8)));
 extern const int kLoadClampMax;
 
 

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -201,10 +201,12 @@ static inline T*
 atomic_pointer_get(T* volatile* pointer)
 {
 #if SCHEDULER_MASK_IS_64_BIT
-	return (T*)atomic_get64((int64 volatile*)pointer);
+	T* value = (T*)atomic_get64((int64 volatile*)pointer);
 #else
-	return (T*)atomic_get((int32 volatile*)pointer);
+	T* value = (T*)atomic_get((int32 volatile*)pointer);
 #endif
+	memory_read_barrier();
+	return value;
 }
 
 
@@ -212,6 +214,7 @@ template<typename T>
 static inline void
 atomic_pointer_set(T* volatile* pointer, T* value)
 {
+	memory_write_barrier();
 #if SCHEDULER_MASK_IS_64_BIT
 	atomic_set64((int64 volatile*)pointer, (int64)value);
 #else
@@ -360,7 +363,7 @@ IsCPUIDle(const uint64& mask, int cpu)
 
 struct SchedulerSnapshot {
 	int32 totalRunnable;
-	uint64 idleMask;
+	uint64 idleMask __attribute__((aligned(8)));
 };
 
 

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -1113,7 +1113,7 @@ CoreEntry::AddCPU(CPUEntry* cpu)
 		} else {
 			atomic_add(&fCPUCount, -1);
 		}
-		int32 oldIdleCount = atomic_add(&fIdleCPUCount, -1);
+		atomic_add(&fIdleCPUCount, -1);
 		panic("CoreEntry::AddCPU: failed to insert CPU %" B_PRId32 " into heap",
 			cpu->ID());
 	}

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -466,10 +466,10 @@ CPUEntry::ComputeLoad()
 	ASSERT(fCPUNumber == smp_get_current_cpu());
 
 	int32 currentLoad = atomic_get(&fLoad);
-	bigtime_t measureTime = atomic_get64((int64*)&fMeasureTime);
-	bigtime_t measureActiveTime;
+	bigtime_t measureActiveTime __attribute__((aligned(8)));
 	int oldLoad;
 	do {
+		bigtime_t measureTime = atomic_get64((int64*)&fMeasureTime);
 		measureActiveTime = atomic_get64((int64*)&fMeasureActiveTime);
 		bigtime_t tempMeasureTime = measureTime;
 		bigtime_t tempMeasureActiveTime = measureActiveTime;

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -294,8 +294,8 @@ CPUEntry::Start()
 {
 	fThreadCount = 0;
 	fLoad = 0;
-	fMeasureTime = system_time();
-	fMeasureActiveTime = 0;
+	atomic_set64((int64*)&fMeasureTime, system_time());
+	atomic_set64((int64*)&fMeasureActiveTime, 0);
 }
 
 
@@ -466,7 +466,7 @@ CPUEntry::ComputeLoad()
 	ASSERT(fCPUNumber == smp_get_current_cpu());
 
 	int32 currentLoad = atomic_get(&fLoad);
-	int oldLoad = compute_load(fMeasureTime, fMeasureActiveTime, currentLoad,
+	int oldLoad = compute_load(atomic_get64((int64*)&fMeasureTime), atomic_get64((int64*)&fMeasureActiveTime), currentLoad,
 			system_time());
 	if (oldLoad < 0)
 		return;
@@ -635,7 +635,7 @@ CPUEntry::UpdateActiveTime(ThreadData* oldThreadData)
 		cpuEntry->active_time += active;
 		locker.Unlock();
 
-		fMeasureActiveTime += active;
+		atomic_add64((int64*)&fMeasureActiveTime, active);
 		atomic_pointer_get<CoreEntry>(&fCore)->IncreaseActiveTime(active);
 
 		// Compute system_time() once and pass it to UpdateActivity so
@@ -1113,7 +1113,7 @@ CoreEntry::AddCPU(CPUEntry* cpu)
 		} else {
 			atomic_add(&fCPUCount, -1);
 		}
-		atomic_add(&fIdleCPUCount, -1);
+		int32 oldIdleCount = atomic_add(&fIdleCPUCount, -1);
 		panic("CoreEntry::AddCPU: failed to insert CPU %" B_PRId32 " into heap",
 			cpu->ID());
 	}
@@ -1142,7 +1142,7 @@ CoreEntry::RemoveCPU(CPUEntry* cpu, ThreadProcessing& threadPostProcessing)
 		// (all its CPUs were idle). Calling unconditionally when a non-idle
 		// core is removed decrements fIdleCoreCount below its true value,
 		// corrupting idle core accounting for the entire package.
-		if (oldIdleCount >= 1)
+		if (oldIdleCount == 1)
 			fPackage->RemoveIdleCore(this);
 
 		// Issue 66 fix: use CoreRunQueueLocker per-iteration to prevent

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -1128,7 +1128,7 @@ CoreEntry::RemoveCPU(CPUEntry* cpu, ThreadProcessing& threadPostProcessing)
 
 	// The CPU is guaranteed to be idle and accounted for in fIdleCPUCount
 	// before RemoveCPU is called (set by scheduler_set_cpu_enabled).
-	atomic_add(&fIdleCPUCount, -1);
+	int32 oldIdleCount = atomic_add(&fIdleCPUCount, -1);
 
 	fCPUSet.ClearBitAtomic(cpu->ID());
 	int32 oldCPUCount = atomic_add(&fCPUCount, -1);
@@ -1142,7 +1142,7 @@ CoreEntry::RemoveCPU(CPUEntry* cpu, ThreadProcessing& threadPostProcessing)
 		// (all its CPUs were idle). Calling unconditionally when a non-idle
 		// core is removed decrements fIdleCoreCount below its true value,
 		// corrupting idle core accounting for the entire package.
-		if (atomic_get(&fIdleCPUCount) >= 1)
+		if (oldIdleCount >= 1)
 			fPackage->RemoveIdleCore(this);
 
 		// Issue 66 fix: use CoreRunQueueLocker per-iteration to prevent

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -467,11 +467,21 @@ CPUEntry::ComputeLoad()
 
 	int32 currentLoad = atomic_get(&fLoad);
 	bigtime_t measureTime = atomic_get64((int64*)&fMeasureTime);
-	bigtime_t measureActiveTime = atomic_get64((int64*)&fMeasureActiveTime);
-	int oldLoad = compute_load(measureTime, measureActiveTime, currentLoad,
-			system_time());
-	atomic_set64((int64*)&fMeasureTime, measureTime);
-	atomic_set64((int64*)&fMeasureActiveTime, measureActiveTime);
+	bigtime_t measureActiveTime;
+	int oldLoad;
+	do {
+		measureActiveTime = atomic_get64((int64*)&fMeasureActiveTime);
+		bigtime_t tempMeasureTime = measureTime;
+		bigtime_t tempMeasureActiveTime = measureActiveTime;
+		oldLoad = compute_load(tempMeasureTime, tempMeasureActiveTime, currentLoad,
+				system_time());
+		if (oldLoad < 0)
+			break;
+		if (atomic_test_and_set64((int64*)&fMeasureActiveTime, tempMeasureActiveTime, measureActiveTime) == measureActiveTime) {
+			atomic_set64((int64*)&fMeasureTime, tempMeasureTime);
+			break;
+		}
+	} while (true);
 	if (oldLoad < 0)
 		return;
 

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -466,8 +466,12 @@ CPUEntry::ComputeLoad()
 	ASSERT(fCPUNumber == smp_get_current_cpu());
 
 	int32 currentLoad = atomic_get(&fLoad);
-	int oldLoad = compute_load(atomic_get64((int64*)&fMeasureTime), atomic_get64((int64*)&fMeasureActiveTime), currentLoad,
+	bigtime_t measureTime = atomic_get64((int64*)&fMeasureTime);
+	bigtime_t measureActiveTime = atomic_get64((int64*)&fMeasureActiveTime);
+	int oldLoad = compute_load(measureTime, measureActiveTime, currentLoad,
 			system_time());
+	atomic_set64((int64*)&fMeasureTime, measureTime);
+	atomic_set64((int64*)&fMeasureActiveTime, measureActiveTime);
 	if (oldLoad < 0)
 		return;
 

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -806,7 +806,7 @@ SchedulerNode::PackageWakesUp(PackageEntry* package)
 			// and will (or has already) re-set the node bit — we must not
 			// clear it.
 			const int64 nodeBit = (int64)(1ULL << fNodeID);
-			int64 nodeMask;
+			int64 nodeMask __attribute__((aligned(8)));
 			// Issue 19 fix: add iteration bound to prevent livelock when
 			// packages continuously oscillate between idle/active states.
 			// After kMaxWakeupRetries CAS failures we give up; the next

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -59,11 +59,11 @@ ThreadData::_InitBase()
 
 	atomic_set64((int64*)&fTimeUsed, 0);
 
-	fMeasureAvailableActiveTime = 0;
-	fLastMeasureAvailableTime = 0;
-	fMeasureAvailableTime = 0;
+	atomic_set64((int64*)&fMeasureAvailableActiveTime, 0);
+	atomic_set64((int64*)&fLastMeasureAvailableTime, 0);
+	atomic_set64((int64*)&fMeasureAvailableTime, 0);
 
-	fVirtualRuntime = 0;
+	atomic_set64((int64*)&fVirtualRuntime, 0);
 	atomic_set64((int64*)&fVirtualDeadline, 0);
 
 	fInteractivityScore = 500;
@@ -214,7 +214,7 @@ ThreadData::Dump() const
 	kprintf("\teffective_priority:\t%" B_PRId32 "\n", GetEffectivePriority());
 
 	kprintf("\ttime_used:\t\t%" B_PRId64 " us (quantum: %" B_PRId64 " us)\n",
-		fTimeUsed, ComputeQuantum());
+		atomic_get64((int64*)&fTimeUsed), ComputeQuantum());
 	kprintf("\tstolen_time:\t\t%" B_PRId64 " us\n", fStolenTime);
 	kprintf("\tquantum_start:\t\t%" B_PRId64 " us\n", fQuantumStart);
 	kprintf("\tneeded_load:\t\t%" B_PRId32 "%%\n", fNeededLoad / 10);
@@ -540,7 +540,7 @@ ThreadData::DonateTimesliceTo(Thread* beneficiary)
 		return;
 
 	bigtime_t now = system_time();
-	bigtime_t timeUsed = now - fQuantumStart;
+	bigtime_t timeUsed = now - atomic_get64((int64*)&fQuantumStart);
 	ASSERT(timeUsed >= 0);
 	atomic_add64((int64*)&fTimeUsed, timeUsed);
 
@@ -564,7 +564,7 @@ ThreadData::DonateTimesliceTo(Thread* beneficiary)
 
 	// Exhaust donor slice: we expect the donor to yield or be descheduled
 	// immediately after this call to prevent double-dipping.
-	fQuantumStart = now;
+	atomic_set64((int64*)&fQuantumStart, now);
 	atomic_set64((int64*)&fTimeUsed, quantum);
 }
 
@@ -653,7 +653,7 @@ ThreadData::_UpdateDeadline()
 			slice = kMinSlice;
 	}
 
-	fVirtualDeadline = now + slice;
+	atomic_set64((int64*)&fVirtualDeadline, now + slice);
 
 	_ComputeEffectivePriority(now);
 }
@@ -687,7 +687,7 @@ ThreadData::_ComputeEffectivePriority(bigtime_t now) const
 		// If Deadline is Now (or passed), Urgency is Max.
 		// If Deadline is far, Urgency is 0.
 
-		bigtime_t diff = fVirtualDeadline - now;
+		bigtime_t diff = atomic_get64((int64*)&fVirtualDeadline) - now;
 
 		// Adaptive Urgency Boost: give bursty threads higher urgency.
 		bigtime_t urgencyBoost = (fInteractivityScore * bucketSize) / 1000;

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -172,7 +172,7 @@ ThreadData::Init()
 		// read fHomePackage twice bracketing the fVirtualRuntime read;
 		// if both reads match the source thread has not migrated mid-read.
 		int32 homeA, homeB;
-		bigtime_t vrt;
+		bigtime_t vrt __attribute__((aligned(8)));
 		int retries = 0;
 		do {
 			homeA = atomic_get(&currentThreadData->fHomePackage);
@@ -186,7 +186,7 @@ ThreadData::Init()
 	} else {
 		fNeededLoad = 0;
 		atomic_set64((int64*)&fVirtualRuntime, 0);
-		fHomePackage = -1;
+		atomic_set(&fHomePackage, -1);
 	}
 
 	if (!IsRealTime())
@@ -579,10 +579,10 @@ ThreadData::_ComputeNeededLoad()
 	SCHEDULER_ENTER_FUNCTION();
 	ASSERT(!IsIdle());
 
-	bigtime_t lastMeasureTime = atomic_get64((int64*)&fLastMeasureAvailableTime);
-	bigtime_t measureActiveTime;
+	bigtime_t measureActiveTime __attribute__((aligned(8)));
 	int32 oldLoad;
 	do {
+		bigtime_t lastMeasureTime = atomic_get64((int64*)&fLastMeasureAvailableTime);
 		measureActiveTime = atomic_get64((int64*)&fMeasureAvailableActiveTime);
 		bigtime_t tempLastMeasureTime = lastMeasureTime;
 		bigtime_t tempMeasureActiveTime = measureActiveTime;

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -575,8 +575,8 @@ ThreadData::_ComputeNeededLoad()
 	SCHEDULER_ENTER_FUNCTION();
 	ASSERT(!IsIdle());
 
-	int32 oldLoad = compute_load(fLastMeasureAvailableTime,
-		fMeasureAvailableActiveTime, fNeededLoad, system_time());
+	int32 oldLoad = compute_load(atomic_get64((int64*)&fLastMeasureAvailableTime),
+		atomic_get64((int64*)&fMeasureAvailableActiveTime), fNeededLoad, system_time());
 	// Issue 83 fix: compute_load updates fLastMeasureAvailableTime (advancing
 	// the measurement window) even when it returns -1 (insufficient elapsed
 	// time). If we return early on oldLoad < 0, fNeededLoad is not updated

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -577,8 +577,12 @@ ThreadData::_ComputeNeededLoad()
 	SCHEDULER_ENTER_FUNCTION();
 	ASSERT(!IsIdle());
 
-	int32 oldLoad = compute_load(atomic_get64((int64*)&fLastMeasureAvailableTime),
-		atomic_get64((int64*)&fMeasureAvailableActiveTime), fNeededLoad, system_time());
+	bigtime_t lastMeasureTime = atomic_get64((int64*)&fLastMeasureAvailableTime);
+	bigtime_t measureActiveTime = atomic_get64((int64*)&fMeasureAvailableActiveTime);
+	int32 oldLoad = compute_load(lastMeasureTime, measureActiveTime, fNeededLoad,
+		system_time());
+	atomic_set64((int64*)&fLastMeasureAvailableTime, lastMeasureTime);
+	atomic_set64((int64*)&fMeasureAvailableActiveTime, measureActiveTime);
 	// Issue 83 fix: compute_load updates fLastMeasureAvailableTime (advancing
 	// the measurement window) even when it returns -1 (insufficient elapsed
 	// time). If we return early on oldLoad < 0, fNeededLoad is not updated

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -215,8 +215,10 @@ ThreadData::Dump() const
 
 	kprintf("\ttime_used:\t\t%" B_PRId64 " us (quantum: %" B_PRId64 " us)\n",
 		atomic_get64((int64*)&fTimeUsed), ComputeQuantum());
-	kprintf("\tstolen_time:\t\t%" B_PRId64 " us\n", fStolenTime);
-	kprintf("\tquantum_start:\t\t%" B_PRId64 " us\n", fQuantumStart);
+	kprintf("\tstolen_time:\t\t%" B_PRId64 " us\n",
+		atomic_get64((int64*)&fStolenTime));
+	kprintf("\tquantum_start:\t\t%" B_PRId64 " us\n",
+		atomic_get64((int64*)&fQuantumStart));
 	kprintf("\tneeded_load:\t\t%" B_PRId32 "%%\n", fNeededLoad / 10);
 	kprintf("\twent_sleep:\t\t%" B_PRId64 "\n", fWentSleep);
 	kprintf("\twent_sleep_active:\t%" B_PRId64 "\n", fWentSleepActive);

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -220,8 +220,10 @@ ThreadData::Dump() const
 	kprintf("\tquantum_start:\t\t%" B_PRId64 " us\n",
 		atomic_get64((int64*)&fQuantumStart));
 	kprintf("\tneeded_load:\t\t%" B_PRId32 "%%\n", fNeededLoad / 10);
-	kprintf("\twent_sleep:\t\t%" B_PRId64 "\n", fWentSleep);
-	kprintf("\twent_sleep_active:\t%" B_PRId64 "\n", fWentSleepActive);
+	kprintf("\twent_sleep:\t\t%" B_PRId64 "\n",
+		atomic_get64((int64*)&fWentSleep));
+	kprintf("\twent_sleep_active:\t%" B_PRId64 "\n",
+		atomic_get64((int64*)&fWentSleepActive));
 	kprintf("\tinteractivity_score:\t%" B_PRId32 "\n", fInteractivityScore);
 
 	CoreEntry* core = Core();

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -15,7 +15,7 @@
 using namespace Scheduler;
 
 
-static bigtime_t sQuantumLengths[THREAD_MAX_SET_PRIORITY + 1] __attribute__((aligned(8)))
+static bigtime_t sQuantumLengths[THREAD_MAX_SET_PRIORITY + 1]
 	__attribute__((aligned(8)));
 
 
@@ -29,7 +29,7 @@ static const int32 kLoadScaleShift = 10;
 // 1024 / 800 * 1024 = 1310.72 ~= 1311
 static const int32 kRangeReciprocal = (int32)(((int64)kLoadScale * kLoadScale
 	+ (kMaxLoad - kLowLoad) / 2) / (kMaxLoad - kLowLoad));
-static bigtime_t sVirtualDeadlineSlices[THREAD_MAX_SET_PRIORITY + 1] __attribute__((aligned(8)))
+static bigtime_t sVirtualDeadlineSlices[THREAD_MAX_SET_PRIORITY + 1]
 	__attribute__((aligned(8)));
 
 bigtime_t ThreadData::sMaxLatency __attribute__((aligned(8)));

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -38,12 +38,12 @@ bigtime_t ThreadData::sMaxLatency __attribute__((aligned(8)));
 void
 ThreadData::_InitBase()
 {
-	fStolenTime = 0;
-	fQuantumStart = 0;
-	fLastInterruptTime = 0;
+	atomic_set64((int64*)&fStolenTime, 0);
+	atomic_set64((int64*)&fQuantumStart, 0);
+	atomic_set64((int64*)&fLastInterruptTime, 0);
 
-	fWentSleep = 0;
-	fWentSleepActive = 0;
+	atomic_set64((int64*)&fWentSleep, 0);
+	atomic_set64((int64*)&fWentSleepActive, 0);
 
 	fEnqueued = false;
 	fEnqueuedInCPURunQueue = false;
@@ -57,14 +57,14 @@ ThreadData::_InitBase()
 		atomic_get64(&sQuantumLengths[min_c(GetEffectivePriority(),
 			THREAD_MAX_SET_PRIORITY)]));
 
-	fTimeUsed = 0;
+	atomic_set64((int64*)&fTimeUsed, 0);
 
 	fMeasureAvailableActiveTime = 0;
 	fLastMeasureAvailableTime = 0;
 	fMeasureAvailableTime = 0;
 
 	fVirtualRuntime = 0;
-	fVirtualDeadline = 0;
+	atomic_set64((int64*)&fVirtualDeadline, 0);
 
 	fInteractivityScore = 500;
 
@@ -181,11 +181,11 @@ ThreadData::Init()
 			memory_read_barrier();
 			homeB = atomic_get(&currentThreadData->fHomePackage);
 		} while (homeA != homeB && ++retries < 8);
-		fVirtualRuntime = vrt;
-		fHomePackage = homeB;
+		atomic_set64((int64*)&fVirtualRuntime, vrt);
+		atomic_set(&fHomePackage, homeB);
 	} else {
 		fNeededLoad = 0;
-		fVirtualRuntime = 0;
+		atomic_set64((int64*)&fVirtualRuntime, 0);
 		fHomePackage = -1;
 	}
 
@@ -542,10 +542,10 @@ ThreadData::DonateTimesliceTo(Thread* beneficiary)
 	bigtime_t now = system_time();
 	bigtime_t timeUsed = now - fQuantumStart;
 	ASSERT(timeUsed >= 0);
-	fTimeUsed += timeUsed;
+	atomic_add64((int64*)&fTimeUsed, timeUsed);
 
 	bigtime_t quantum = ComputeQuantum();
-	bigtime_t timeLeft = quantum - fTimeUsed;
+	bigtime_t timeLeft = quantum - atomic_get64((int64*)&fTimeUsed);
 	if (timeLeft > 0) {
 		// Donate remaining slice to the beneficiary.
 		// Callers MUST NOT hold any run-queue spinlock when invoking this
@@ -559,13 +559,13 @@ ThreadData::DonateTimesliceTo(Thread* beneficiary)
 		// are already disabled by the caller's contract.
 		ASSERT(!are_interrupts_enabled());
 		SpinLocker locker(beneficiary->scheduler_lock);
-		beneficiaryData->fStolenTime += timeLeft;
+		atomic_add64((int64*)&beneficiaryData->fStolenTime, timeLeft);
 	}
 
 	// Exhaust donor slice: we expect the donor to yield or be descheduled
 	// immediately after this call to prevent double-dipping.
 	fQuantumStart = now;
-	fTimeUsed = quantum;
+	atomic_set64((int64*)&fTimeUsed, quantum);
 }
 
 

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -15,7 +15,7 @@
 using namespace Scheduler;
 
 
-static bigtime_t sQuantumLengths[THREAD_MAX_SET_PRIORITY + 1]
+static bigtime_t sQuantumLengths[THREAD_MAX_SET_PRIORITY + 1] __attribute__((aligned(8)))
 	__attribute__((aligned(8)));
 
 
@@ -29,7 +29,7 @@ static const int32 kLoadScaleShift = 10;
 // 1024 / 800 * 1024 = 1310.72 ~= 1311
 static const int32 kRangeReciprocal = (int32)(((int64)kLoadScale * kLoadScale
 	+ (kMaxLoad - kLowLoad) / 2) / (kMaxLoad - kLowLoad));
-static bigtime_t sVirtualDeadlineSlices[THREAD_MAX_SET_PRIORITY + 1]
+static bigtime_t sVirtualDeadlineSlices[THREAD_MAX_SET_PRIORITY + 1] __attribute__((aligned(8)))
 	__attribute__((aligned(8)));
 
 bigtime_t ThreadData::sMaxLatency __attribute__((aligned(8)));
@@ -580,11 +580,21 @@ ThreadData::_ComputeNeededLoad()
 	ASSERT(!IsIdle());
 
 	bigtime_t lastMeasureTime = atomic_get64((int64*)&fLastMeasureAvailableTime);
-	bigtime_t measureActiveTime = atomic_get64((int64*)&fMeasureAvailableActiveTime);
-	int32 oldLoad = compute_load(lastMeasureTime, measureActiveTime, fNeededLoad,
-		system_time());
-	atomic_set64((int64*)&fLastMeasureAvailableTime, lastMeasureTime);
-	atomic_set64((int64*)&fMeasureAvailableActiveTime, measureActiveTime);
+	bigtime_t measureActiveTime;
+	int32 oldLoad;
+	do {
+		measureActiveTime = atomic_get64((int64*)&fMeasureAvailableActiveTime);
+		bigtime_t tempLastMeasureTime = lastMeasureTime;
+		bigtime_t tempMeasureActiveTime = measureActiveTime;
+		oldLoad = compute_load(tempLastMeasureTime, tempMeasureActiveTime, fNeededLoad,
+			system_time());
+		if (oldLoad < 0)
+			break;
+		if (atomic_test_and_set64((int64*)&fMeasureAvailableActiveTime, tempMeasureActiveTime, measureActiveTime) == measureActiveTime) {
+			atomic_set64((int64*)&fLastMeasureAvailableTime, tempLastMeasureTime);
+			break;
+		}
+	} while (true);
 	// Issue 83 fix: compute_load updates fLastMeasureAvailableTime (advancing
 	// the measurement window) even when it returns -1 (insufficient elapsed
 	// time). If we return early on oldLoad < 0, fNeededLoad is not updated

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -181,6 +181,13 @@ ThreadData::Init()
 			memory_read_barrier();
 			homeB = atomic_get(&currentThreadData->fHomePackage);
 		} while (homeA != homeB && ++retries < 8);
+
+		if (homeA != homeB) {
+			// failed to get consistent snapshot, fallback to safe defaults
+			vrt = 0;
+			homeB = -1;
+		}
+
 		atomic_set64((int64*)&fVirtualRuntime, vrt);
 		atomic_set(&fHomePackage, homeB);
 	} else {

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -376,7 +376,7 @@ ThreadData::SetStolenInterruptTime(bigtime_t interruptTime)
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	bigtime_t delta = interruptTime - fLastInterruptTime;
+	bigtime_t delta = interruptTime - atomic_get64((int64*)&fLastInterruptTime);
 	// Issue 94 fix: if interrupt_time goes backward (e.g. CPU accounting
 	// reset or wrap), delta is negative and fLastInterruptTime must be
 	// reset to the current interruptTime to restore correct accounting.
@@ -429,7 +429,7 @@ ThreadData::HasQuantumEnded(bool wasPreempted, bool hasYielded)
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	bigtime_t timeUsed = system_time() - fQuantumStart;
+	bigtime_t timeUsed = system_time() - atomic_get64((int64*)&fQuantumStart);
 	ASSERT(timeUsed >= 0);
 	// Issue 68 fix: cap fTimeUsed accumulation. Under extremely rapid
 	// rescheduling, fTimeUsed can accumulate to near INT64_MAX before the
@@ -715,11 +715,11 @@ ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption,
 			}
 			// Issue 41 fix: AddLoad happens here, after all early-return guards.
 			if (gTrackCoreLoad && !wasReady) {
-				bigtime_t timeSlept = system_time() - fWentSleep;
+				bigtime_t timeSlept = system_time() - atomic_get64((int64*)&fWentSleep);
 				bool updateLoad = timeSlept > 0;
 				core->AddLoad(fNeededLoad, fLoadMeasurementEpoch, !updateLoad);
 				if (updateLoad) {
-					fMeasureAvailableTime += timeSlept;
+					atomic_add64((int64*)&fMeasureAvailableTime, timeSlept);
 					_ComputeNeededLoad();
 				}
 			}
@@ -729,11 +729,11 @@ ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption,
 			return false;
 		} else if (!wasReady && gTrackCoreLoad) {
 			// Issue 41 fix: for non-stolen threads, AddLoad after CPUCount guard.
-			bigtime_t timeSlept = system_time() - fWentSleep;
+			bigtime_t timeSlept = system_time() - atomic_get64((int64*)&fWentSleep);
 			bool updateLoad = timeSlept > 0;
 			core->AddLoad(fNeededLoad, fLoadMeasurementEpoch, !updateLoad);
 			if (updateLoad) {
-				fMeasureAvailableTime += timeSlept;
+				atomic_add64((int64*)&fMeasureAvailableTime, timeSlept);
 				_ComputeNeededLoad();
 			}
 		}
@@ -850,11 +850,17 @@ ThreadData::UpdateActivity(bigtime_t active, bigtime_t now)
 		else
 			ceiling = now + kLookahead;
 
-		bigtime_t vRuntime = atomic_get64((int64*)&fVirtualRuntime);
-		if (vRuntime < ceiling - delta)
-			atomic_add64((int64*)&fVirtualRuntime, delta);
-		else if (vRuntime < ceiling)
-			atomic_set64((int64*)&fVirtualRuntime, ceiling);
+		bigtime_t vRuntime;
+		do {
+			vRuntime = atomic_get64((int64*)&fVirtualRuntime);
+			bigtime_t next;
+			if (vRuntime < ceiling - delta)
+				next = vRuntime + delta;
+			else if (vRuntime < ceiling)
+				next = ceiling;
+			else
+				break;
+		} while (atomic_test_and_set64((int64*)&fVirtualRuntime, next, vRuntime) != vRuntime);
 		// If fVirtualRuntime is already at or above ceiling (e.g. ceiling moved
 		// backward due to clock skew), leave it unchanged rather than reducing
 		// it, which would spuriously boost the thread's scheduling priority.

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -401,7 +401,7 @@ ThreadData::GetQuantumLeft()
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	bigtime_t stolenTime;
+	bigtime_t stolenTime __attribute__((aligned(8)));
 	do {
 		stolenTime = atomic_get64((int64*)&fStolenTime);
 	} while (atomic_test_and_set64((int64*)&fStolenTime, 0, stolenTime) != stolenTime);
@@ -844,16 +844,16 @@ ThreadData::UpdateActivity(bigtime_t active, bigtime_t now)
 
 		// Issue 58 fix: the goto below is inside the if (!IsRealTime()) block.
 
-		bigtime_t ceiling;
+		bigtime_t ceiling __attribute__((aligned(8)));
 		if (now > B_INT64_MAX - kLookahead)
 			ceiling = B_INT64_MAX;
 		else
 			ceiling = now + kLookahead;
 
-		bigtime_t vRuntime;
+		bigtime_t vRuntime __attribute__((aligned(8)));
 		do {
 			vRuntime = atomic_get64((int64*)&fVirtualRuntime);
-			bigtime_t next;
+			bigtime_t next __attribute__((aligned(8)));
 			if (vRuntime < ceiling - delta)
 				next = vRuntime + delta;
 			else if (vRuntime < ceiling)

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -851,9 +851,9 @@ ThreadData::UpdateActivity(bigtime_t active, bigtime_t now)
 			ceiling = now + kLookahead;
 
 		bigtime_t vRuntime __attribute__((aligned(8)));
+		bigtime_t next __attribute__((aligned(8)));
 		do {
 			vRuntime = atomic_get64((int64*)&fVirtualRuntime);
-			bigtime_t next __attribute__((aligned(8)));
 			if (vRuntime < ceiling - delta)
 				next = vRuntime + delta;
 			else if (vRuntime < ceiling)

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -98,7 +98,7 @@ public:
 							CPUEntry*& targetCPU);
 
 	SCHEDULER_INLINE	void		SetLastInterruptTime(bigtime_t interruptTime)
-							{ fLastInterruptTime = interruptTime; }
+							{ atomic_set64((int64*)&fLastInterruptTime, interruptTime); }
 	SCHEDULER_INLINE	void		SetStolenInterruptTime(bigtime_t interruptTime);
 
 			bigtime_t	ComputeQuantum() const;
@@ -404,8 +404,7 @@ ThreadData::GetQuantumLeft()
 	bigtime_t stolenTime;
 	do {
 		stolenTime = atomic_get64((int64*)&fStolenTime);
-	} while (atomic_test_and_set64((int64*)&fStolenTime, 0, stolenTime)
-			!= stolenTime);
+	} while (atomic_test_and_set64((int64*)&fStolenTime, 0, stolenTime) != stolenTime);
 
 	bigtime_t quantum = ComputeQuantum() - atomic_get64((int64*)&fTimeUsed);
 	quantum += stolenTime;
@@ -421,7 +420,7 @@ inline void
 ThreadData::StartQuantum()
 {
 	SCHEDULER_ENTER_FUNCTION();
-	fQuantumStart = system_time();
+	atomic_set64((int64*)&fQuantumStart, system_time());
 }
 
 
@@ -437,10 +436,7 @@ ThreadData::HasQuantumEnded(bool wasPreempted, bool hasYielded)
 	// quantum-end check fires. When that happens, quantum - fTimeUsed
 	// underflows to a large positive, granting an unintended stolen-time
 	// bonus. Cap at 2 * MaximumLatency() as a generous but safe upper bound.
-	bigtime_t timeUsedTotal = atomic_add64((int64*)&fTimeUsed, timeUsed)
-		+ timeUsed;
-
-	// Issue 68 fix: cap fTimeUsed accumulation.
+	bigtime_t timeUsedTotal = atomic_add64((int64*)&fTimeUsed, timeUsed) + timeUsed;
 	const bigtime_t kMaxTimeUsed = Scheduler::MaximumLatency() * 2;
 	if (timeUsedTotal > kMaxTimeUsed) {
 		timeUsedTotal = kMaxTimeUsed;
@@ -448,9 +444,6 @@ ThreadData::HasQuantumEnded(bool wasPreempted, bool hasYielded)
 	}
 
 	bigtime_t quantum = ComputeQuantum();
-
-	// if the quantum shrank (e.g. core load increased since the
-	// last scheduling decision) fTimeUsed may already exceed the new quantum.
 	if (timeUsedTotal >= quantum) {
 		atomic_set64((int64*)&fTimeUsed, 0);
 		_UpdateDeadline();
@@ -539,13 +532,13 @@ ThreadData::GoesAway()
 		fInteractivityScore = min_c(fInteractivityScore + 10, 1000);
 	}
 
-	fLastInterruptTime = 0;
+	atomic_set64((int64*)&fLastInterruptTime, 0);
 
 	// Cache system_time() once; calling it twice gives slightly
 	// different timestamps under heavy interrupt load, skewing sleep-time
 	// accounting.
 	bigtime_t now = system_time();
-	fWentSleep = now;
+	atomic_set64((int64*)&fWentSleep, now);
 	// Issue 7 fix: fCore can be set to NULL by a concurrent MigrateTo() call.
 	// The original code checked for NULL once then called GetActiveTime() and
 	// RemoveLoad() in separate statements — if fCore became NULL between the
@@ -557,7 +550,7 @@ ThreadData::GoesAway()
 	// is real. The snapshot approach is the minimal safe fix.
 	{
 		CoreEntry* const snap = atomic_pointer_get<CoreEntry>(&fCore);
-		fWentSleepActive = (snap != NULL) ? snap->GetActiveTime() : 0;
+		atomic_set64((int64*)&fWentSleepActive, (snap != NULL) ? snap->GetActiveTime() : 0);
 		if (gTrackCoreLoad && snap != NULL)
 			fLoadMeasurementEpoch = snap->RemoveLoad(fNeededLoad, false);
 	}

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -383,7 +383,7 @@ ThreadData::SetStolenInterruptTime(bigtime_t interruptTime)
 	// Otherwise fLastInterruptTime stays at a "future" value permanently
 	// suppressing all stolen-time accounting for this thread.
 	if (delta > 0) {
-		fStolenTime += delta;
+		atomic_add64((int64*)&fStolenTime, delta);
 	} else if (delta < 0) {
 		// Clock went backward; reset baseline to avoid permanent suppression.
 		// Do not add the negative delta — the time is simply unaccountable.
@@ -401,10 +401,13 @@ ThreadData::GetQuantumLeft()
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	bigtime_t stolenTime = fStolenTime;
-	fStolenTime = 0;
+	bigtime_t stolenTime;
+	do {
+		stolenTime = atomic_get64((int64*)&fStolenTime);
+	} while (atomic_test_and_set64((int64*)&fStolenTime, 0, stolenTime)
+			!= stolenTime);
 
-	bigtime_t quantum = ComputeQuantum() - fTimeUsed;
+	bigtime_t quantum = ComputeQuantum() - atomic_get64((int64*)&fTimeUsed);
 	quantum += stolenTime;
 	quantum = max_c(quantum, Scheduler::MinimalQuantum());
 	if (quantum > Scheduler::MaximumLatency())
@@ -434,25 +437,27 @@ ThreadData::HasQuantumEnded(bool wasPreempted, bool hasYielded)
 	// quantum-end check fires. When that happens, quantum - fTimeUsed
 	// underflows to a large positive, granting an unintended stolen-time
 	// bonus. Cap at 2 * MaximumLatency() as a generous but safe upper bound.
-	fTimeUsed += timeUsed;
+	bigtime_t timeUsedTotal = atomic_add64((int64*)&fTimeUsed, timeUsed)
+		+ timeUsed;
+
+	// Issue 68 fix: cap fTimeUsed accumulation.
 	const bigtime_t kMaxTimeUsed = Scheduler::MaximumLatency() * 2;
-	if (fTimeUsed > kMaxTimeUsed)
-		fTimeUsed = kMaxTimeUsed;
+	if (timeUsedTotal > kMaxTimeUsed) {
+		timeUsedTotal = kMaxTimeUsed;
+		atomic_set64((int64*)&fTimeUsed, kMaxTimeUsed);
+	}
 
 	bigtime_t quantum = ComputeQuantum();
 
 	// if the quantum shrank (e.g. core load increased since the
 	// last scheduling decision) fTimeUsed may already exceed the new quantum.
-	// Without this guard 'timeLeft' goes negative, bypasses the skipTime
-	// check below, and the thread runs a full extra quantum before the
-	// negative value eventually wraps the interactivity score.
-	if (fTimeUsed >= quantum) {
-		fTimeUsed = 0;
+	if (timeUsedTotal >= quantum) {
+		atomic_set64((int64*)&fTimeUsed, 0);
 		_UpdateDeadline();
 		return true;
 	}
 
-	bigtime_t timeLeft = quantum - fTimeUsed;
+	bigtime_t timeLeft = quantum - timeUsedTotal;
 	timeLeft = max_c(bigtime_t(0), timeLeft);
 
 	// too little time left, it's better make the next quantum a bit longer
@@ -461,7 +466,7 @@ ThreadData::HasQuantumEnded(bool wasPreempted, bool hasYielded)
 		timeLeft = 0;
 		fInteractivityScore = min_c(fInteractivityScore + 20, 1000);
 	} else if (wasPreempted || timeLeft <= skipTime) {
-		fStolenTime += timeLeft;
+		atomic_add64((int64*)&fStolenTime, timeLeft);
 		timeLeft = 0;
 
 		if (!wasPreempted) {
@@ -471,7 +476,7 @@ ThreadData::HasQuantumEnded(bool wasPreempted, bool hasYielded)
 	}
 
 	if (timeLeft == 0) {
-		fTimeUsed = 0;
+		atomic_set64((int64*)&fTimeUsed, 0);
 		_UpdateDeadline();
 		return true;
 	}
@@ -852,10 +857,11 @@ ThreadData::UpdateActivity(bigtime_t active, bigtime_t now)
 		else
 			ceiling = now + kLookahead;
 
-		if (fVirtualRuntime < ceiling - delta)
-			fVirtualRuntime += delta;
-		else if (fVirtualRuntime < ceiling)
-			fVirtualRuntime = ceiling;
+		bigtime_t vRuntime = atomic_get64((int64*)&fVirtualRuntime);
+		if (vRuntime < ceiling - delta)
+			atomic_add64((int64*)&fVirtualRuntime, delta);
+		else if (vRuntime < ceiling)
+			atomic_set64((int64*)&fVirtualRuntime, ceiling);
 		// If fVirtualRuntime is already at or above ceiling (e.g. ceiling moved
 		// backward due to clock skew), leave it unchanged rather than reducing
 		// it, which would spuriously boost the thread's scheduling priority.
@@ -865,8 +871,8 @@ track_core_load:
 	if (!gTrackCoreLoad)
 		return;
 
-	fMeasureAvailableTime += active;
-	fMeasureAvailableActiveTime += active;
+	atomic_add64((int64*)&fMeasureAvailableTime, active);
+	atomic_add64((int64*)&fMeasureAvailableActiveTime, active);
 }
 
 

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -401,7 +401,7 @@ ThreadData::GetQuantumLeft()
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	bigtime_t stolenTime __attribute__((aligned(8)));
+	bigtime_t stolenTime;
 	do {
 		stolenTime = atomic_get64((int64*)&fStolenTime);
 	} while (atomic_test_and_set64((int64*)&fStolenTime, 0, stolenTime) != stolenTime);
@@ -844,16 +844,16 @@ ThreadData::UpdateActivity(bigtime_t active, bigtime_t now)
 
 		// Issue 58 fix: the goto below is inside the if (!IsRealTime()) block.
 
-		bigtime_t ceiling __attribute__((aligned(8)));
+		bigtime_t ceiling;
 		if (now > B_INT64_MAX - kLookahead)
 			ceiling = B_INT64_MAX;
 		else
 			ceiling = now + kLookahead;
 
-		bigtime_t vRuntime __attribute__((aligned(8)));
+		bigtime_t vRuntime;
 		do {
 			vRuntime = atomic_get64((int64*)&fVirtualRuntime);
-			bigtime_t next __attribute__((aligned(8)));
+			bigtime_t next;
 			if (vRuntime < ceiling - delta)
 				next = vRuntime + delta;
 			else if (vRuntime < ceiling)


### PR DESCRIPTION
Performed a comprehensive audit of the kernel scheduler source files. Fixed numerous alignment issues for 64-bit types used with atomic operations, ensuring safety on 32-bit systems. Hardened lockless sections in the RunQueue and idle accounting logic to prevent race conditions. Maintained compatibility with legacy GCC 2.95 by using appropriate C++ syntax and template usage. Corrected thread count and idle accounting bugs encountered during CPU hot-unplug scenarios.

---
*PR created automatically by Jules for task [8897219297400668670](https://jules.google.com/task/8897219297400668670) started by @tonestone57*