### PR TITLE
scheduler: fix CPU enable lock/startup ordering race

### DIFF
--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -1095,20 +1095,27 @@ scheduler_set_cpu_enabled(int32 cpuID, bool enabled)
 		// Resolve FIXME in scheduler_cpu.h issue 89:
 		// serialize AddCPU with the same global scheduler lock scope used by
 		// the disable/remove path to avoid races with idle-core state updates.
+		{
 			InterruptsBigSchedulerLocker bigLocker;
 			CoreCPUHeapLocker heapLocker(core);
-			cpu->Start();
-		// Issue 39 fix: AddCPU inserts the CPU into the heap. A concurrent
-		// enqueue() that races between disabled=false and the heap insert
-		// can call UpdatePriority on a CPU with no heap link, panicking.
-		// Fix: complete AddCPU FIRST while disabled is still true, then
-		// clear the disabled flag and publish the CPU via gCPUEnabled.
-		core->AddCPU(cpu);
-		// Issue 69 fix: set disabled=false and SetBitAtomic atomically
+
+			// Issue 39 fix: AddCPU inserts the CPU into the heap. A concurrent
+			// enqueue() that races between disabled=false and the heap insert
+			// can call UpdatePriority on a CPU with no heap link, panicking.
+			// Fix: complete AddCPU FIRST while disabled is still true, then
+			// clear the disabled flag and publish the CPU via gCPUEnabled.
+			core->AddCPU(cpu);
+			// Issue 69 fix: set disabled=false and SetBitAtomic atomically
 			// under CoreCPUHeapLocker. GetCPUMask reads gCPUEnabled; enqueue
 			// checks !gCPU[id].disabled. Both must agree simultaneously.
 			gCPU[cpuID].disabled = false;
 			gCPUEnabled.SetBitAtomic(cpuID);
+		}
+
+		// Start the CPU after publishing all scheduler state and after
+		// releasing scheduler/core locks to avoid lock-order inversions if the
+		// startup path enters the scheduler immediately.
+		cpu->Start();
 	} else {
 		// Improve serialization of queue migration/removal:
 		// hold the global scheduler lock scope so concurrent scheduling on


### PR DESCRIPTION
### Motivation
- Avoid lock-order inversion and potential deadlocks/livelocks when bringing a CPU online by ensuring the scheduler/core locks are not held while the new CPU can immediately enter the scheduler.
- Ensure scheduler-visible CPU state (`gCPU[cpuID].disabled` and `gCPUEnabled`) is fully published before the CPU is started to prevent races where other paths observe partially-initialized CPU state.
- Address a previously-documented FIXME around serializing `AddCPU()` with the same global scheduler lock scope used by the disable/remove path.

### Description
- Modified `src/system/kernel/scheduler/scheduler.cpp` in `scheduler_set_cpu_enabled()` to keep `core->AddCPU(cpu)` and the `gCPU`/`gCPUEnabled` publication inside the global/core lock scope guarded by `InterruptsBigSchedulerLocker` and `CoreCPUHeapLocker`.
- Added an explicit scope block around the lockers and moved `cpu->Start()` to execute after that scope, so the CPU start runs after scheduler/core locks are released.
- Added explanatory comments clarifying the ordering change and the reason for starting the CPU after publishing scheduler-visible state.

### Testing
- Ran repository checks `git diff -- src/system/kernel/scheduler/scheduler.cpp`, `git status --short`, and performed the `git commit` which all completed successfully.
- Performed source inspections and grep-based scans of scheduler files to validate related lock/race annotations and to find the affected code paths, which succeeded.
- No unit/integration/kernel runtime tests were executed in this change; recommend a full kernel build and scheduler regression test on target hardware or simulator before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff62a9843083239b929edc39494eb8)