### PR TITLE
Audit and modernize scheduler for GCC 13 and 32/64-bit

### DIFF
--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -73,7 +73,7 @@ public:
 
 	inline	bool		IsEmpty() const
 	{
-		return atomic_get(const_cast<int32*>(&fTotalCount)) == 0;
+		return atomic_get(const_cast<int32 volatile*>(&fTotalCount)) == 0;
 	}
 
 	class ConstIterator {
@@ -112,7 +112,7 @@ public:
 
 	inline	int32		Count() const
 	{
-		return atomic_get(const_cast<int32*>(&fTotalCount));
+		return atomic_get(const_cast<int32 volatile*>(&fTotalCount));
 	}
 
 	inline	Element*	GetHead(unsigned int priority) const;
@@ -338,7 +338,7 @@ RUN_QUEUE_CLASS_NAME::PeekMaximum() const
 	SCHEDULER_ENTER_FUNCTION();
 
 	for (int i = kBitmapSize - 1; i >= 0; i--) {
-		uint32 val = atomic_get((int32*)&fBitmap[i]);
+		uint32 val = atomic_get(const_cast<int32 volatile*>(reinterpret_cast<const int32*>(&fBitmap[i])));
 		if (val != 0) {
 			if (i == kBitmapSize - 1) {
 				// Issue 61 fix: guard MaxPriority % 32 == 31.
@@ -388,12 +388,12 @@ RUN_QUEUE_CLASS_NAME::PushFront(Element* element,
 	// Issue 10/24 fix: capture isEmpty before the bitmap update.
 	// Since we hold the run-queue spinlock, this check is atomic
 	// with the subsequent insertion.
-	bool isEmpty = (atomic_get(&fTotalCount) == 0);
+	bool isEmpty = (atomic_get(const_cast<int32 volatile*>(&fTotalCount)) == 0);
 
-	atomic_add(&fTotalCount, 1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fTotalCount), 1);
 
 #ifdef DEBUG_SCHEDULER
-	atomic_add(&fDebugEnqueueCount, 1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fDebugEnqueueCount), 1);
 #endif
 
 	Traits::SetInRunQueue(element, true);
@@ -410,7 +410,7 @@ RUN_QUEUE_CLASS_NAME::PushFront(Element* element,
 		atomic_pointer_set<Element>(&fTails[priority], element);
 		atomic_pointer_set<Element>(&fHeads[priority], element);
 		memory_write_barrier();
-		atomic_or((int32*)&fBitmap[priority / 32], (1UL << (priority % 32)));
+		atomic_or(reinterpret_cast<int32 volatile*>(&fBitmap[priority / 32]), (1UL << (priority % 32)));
 	}
 
 	// Issue 46 fix: read fBest once and validate its bucket before reading
@@ -461,12 +461,12 @@ RUN_QUEUE_CLASS_NAME::PushBack(Element* element,
 	// For priority > bestPriority the new element is unconditionally better.
 	// For priority < bestPriority the new element cannot be fBest.
 	// This logic is intentional and correct for all three cases.
-	bool isEmpty = (atomic_get(&fTotalCount) == 0);
+	bool isEmpty = (atomic_get(const_cast<int32 volatile*>(&fTotalCount)) == 0);
 
-	atomic_add(&fTotalCount, 1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fTotalCount), 1);
 
 #ifdef DEBUG_SCHEDULER
-	atomic_add(&fDebugEnqueueCount, 1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fDebugEnqueueCount), 1);
 #endif
 
 	Traits::SetInRunQueue(element, true);
@@ -483,7 +483,7 @@ RUN_QUEUE_CLASS_NAME::PushBack(Element* element,
 		atomic_pointer_set<Element>(&fHeads[priority], element);
 		atomic_pointer_set<Element>(&fTails[priority], element);
 		memory_write_barrier();
-		atomic_or((int32*)&fBitmap[priority / 32], (1UL << (priority % 32)));
+		atomic_or(reinterpret_cast<int32 volatile*>(&fBitmap[priority / 32]), (1UL << (priority % 32)));
 	}
 
 	// Issue 46 fix: same snapshot-based fBest update as PushFront.
@@ -537,11 +537,11 @@ RUN_QUEUE_CLASS_NAME::Remove(Element* element)
 			&& atomic_pointer_get<Element>(&fTails[priority]) != NULL));
 
 	if (atomic_pointer_get<Element>(&fHeads[priority]) == NULL) {
-		atomic_and((int32*)&fBitmap[priority / 32], ~(1UL << (priority % 32)));
+		atomic_and(reinterpret_cast<int32 volatile*>(&fBitmap[priority / 32]), ~(1UL << (priority % 32)));
 		memory_write_barrier();
 	}
 
-	atomic_add(&fTotalCount, -1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fTotalCount), -1);
 
 	Traits::SetInRunQueue(element, false);
 
@@ -638,7 +638,7 @@ RUN_QUEUE_CLASS_NAME::PeekBest() const
 	Element* globalBest = NULL;
 
 	for (int i = kBitmapSize - 1; i >= 0 && levelsSearched < kDeadlineLookaheadLevels; i--) {
-		uint32 val = atomic_get((int32*)&fBitmap[i]);
+		uint32 val = atomic_get(const_cast<int32 volatile*>(reinterpret_cast<const int32*>(&fBitmap[i])));
 		if (val != 0) {
 			if (i == kBitmapSize - 1) {
 				// Issue 61 fix: guard MaxPriority % 32 == 31.
@@ -683,9 +683,9 @@ RUN_QUEUE_CLASS_NAME::PeekBest() const
 	// levels without finding anything (shouldn't happen in practice but
 	// possible when kDeadlineLookaheadLevels < total occupied levels),
 	// do a full scan to guarantee a non-NULL result from a non-empty queue.
-	if (globalBest == NULL && atomic_get(&fTotalCount) > 0) {
+	if (globalBest == NULL && atomic_get(const_cast<int32 volatile*>(&fTotalCount)) > 0) {
 		for (int i = kBitmapSize - 1; i >= 0; i--) {
-			uint32 val = atomic_get((int32*)&fBitmap[i]);
+			uint32 val = atomic_get(const_cast<int32 volatile*>(reinterpret_cast<const int32*>(&fBitmap[i])));
 			if (i == kBitmapSize - 1 && (MaxPriority % 32) != 31)
 				val &= (uint32)((2ULL << (MaxPriority % 32)) - 1);
 			if (val == 0) continue;
@@ -724,7 +724,7 @@ RUN_QUEUE_CLASS_NAME::PeekBest(const Compare2& compare, const Predicate& predica
 	SCHEDULER_ENTER_FUNCTION();
 
 	for (int i = kBitmapSize - 1; i >= 0; i--) {
-		uint32 val = atomic_get((int32*)&fBitmap[i]);
+		uint32 val = atomic_get(const_cast<int32 volatile*>(reinterpret_cast<const int32*>(&fBitmap[i])));
 		if (val != 0) {
 			if (i == kBitmapSize - 1) {
 				// Issue 61 fix: guard MaxPriority % 32 == 31.
@@ -787,7 +787,7 @@ RUN_QUEUE_CLASS_NAME::PeekOption(const Predicate& predicate) const
 		if (totalBudget <= 0)
 			return NULL;
 
-		uint32 val = atomic_get((int32*)&fBitmap[i]);
+		uint32 val = atomic_get(const_cast<int32 volatile*>(reinterpret_cast<const int32*>(&fBitmap[i])));
 
 		if (i == kBitmapSize - 1) {
 			// Issue 61 fix: guard MaxPriority % 32 == 31.

--- a/src/system/kernel/scheduler/low_latency.cpp
+++ b/src/system/kernel/scheduler/low_latency.cpp
@@ -174,7 +174,7 @@ choose_core(const ThreadData* threadData, const CPUSet& mask, bigtime_t now)
 	CoreEntry* core = NULL;
 
 	// Thread Coloring: Search for a core of the preferred type first
-	uint64 idleNodeMask = atomic_get64((int64*)&gIdleNodeMask);
+	uint64 idleNodeMask = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&gIdleNodeMask)));
 
 	if (preferMax || preferMin) {
 		CoreType preferredType = preferMax ? gMaxCoreType : gMinCoreType;
@@ -602,8 +602,7 @@ rebalance(const ThreadData* threadData, const CPUSet& mask, bigtime_t now)
 	// Issue 53 fix: document both bounds explicitly. The lower bound prevents
 	// subtraction underflow; the upper bound prevents addition overflow.
 	// Both are required and neither can be safely removed.
-	// static_assert replaced by comment for GCC 2.95
-	// sizeof(bigtime_t) == 8
+	static_assert(sizeof(bigtime_t) == 8, "bigtime_t must be 64-bit");
 	bool congested = (coreVRuntime >= (bigtime_t)(B_INT64_MIN + 20000LL))
 		&& (coreVRuntime <= (bigtime_t)(B_INT64_MAX - 20000LL))
 		&& (otherVRuntime > coreVRuntime + 20000LL);

--- a/src/system/kernel/scheduler/power_saving.cpp
+++ b/src/system/kernel/scheduler/power_saving.cpp
@@ -369,7 +369,7 @@ choose_idle_core(CPUEntry* cpu, const CPUSet* mask = NULL)
 
 	if (package == NULL) {
 		// No partially idle packages. Check for any idle package using the mask.
-		uint64 idleNodeMask = atomic_get64((int64*)&gIdleNodeMask);
+		uint64 idleNodeMask = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&gIdleNodeMask)));
 		int scannedCount = 0;
 		while (idleNodeMask != 0) {
 			if (++scannedCount > kMaxCPUsToScan)

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -116,17 +116,17 @@ update_quantum_lengths_dpc(void* /*arg*/)
 {
 	// Use the latest requested target from sPendingDPCTarget
 	// instead of the stale value passed via arg.
-	int64 targetResolution = (int64)atomic_get(&sPendingDPCTarget);
+	int64 targetResolution = (int64)atomic_get(const_cast<int32 volatile*>(&sPendingDPCTarget));
 
 	{
 		InterruptsBigSchedulerLocker locker;
-		if (atomic_get64(&gDeadlineBucketSize) != targetResolution) {
-			atomic_set64(&gDeadlineBucketSize, targetResolution);
+		if (atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&gDeadlineBucketSize))) != targetResolution) {
+			atomic_set64(reinterpret_cast<int64 volatile*>(&gDeadlineBucketSize), targetResolution);
 			UpdateDeadlineScalingScalable();
 		}
 	}
 
-	atomic_set(&sDPCPending, 0);
+	atomic_set(reinterpret_cast<int32 volatile*>(&sDPCPending), 0);
 }
 
 static status_t
@@ -142,15 +142,15 @@ interaction_timer_hook(struct timer* timer)
 	//
 	// By clearing sTimerArmed first we allow re-arming immediately if needed,
 	// and the DPC guard (sDPCPending) prevents duplicate DPC enqueueing.
-	atomic_set(&sTimerArmed, 0);
+	atomic_set(reinterpret_cast<int32 volatile*>(&sTimerArmed), 0);
 
-	atomic_set(&sPendingDPCTarget, 5000);
-	if (atomic_get_and_set(&sDPCPending, 1) == 0) {
-		int64 target = (int64)atomic_get(&sPendingDPCTarget);
+	atomic_set(reinterpret_cast<int32 volatile*>(&sPendingDPCTarget), 5000);
+	if (atomic_get_and_set(reinterpret_cast<int32 volatile*>(&sDPCPending), 1) == 0) {
+		int64 target = (int64)atomic_get(const_cast<int32 volatile*>(&sPendingDPCTarget));
 		if (DPCQueue::DefaultQueue(B_URGENT_DISPLAY_PRIORITY)->Add(
 				&update_quantum_lengths_dpc, (void*)(addr_t)target) != B_OK) {
-			atomic_set(&sDPCPending, 0);
-			atomic_set(&sPendingDPCTarget, 0);
+			atomic_set(reinterpret_cast<int32 volatile*>(&sDPCPending), 0);
+			atomic_set(reinterpret_cast<int32 volatile*>(&sPendingDPCTarget), 0);
 			// DPC queue full; sTimerArmed already cleared above so the
 			// next interaction event can re-arm the timer.
 		}
@@ -180,11 +180,11 @@ scheduler_update_interaction_state(bigtime_t now)
 	 // Issue 28: Deadline bucket caching. Cache gDeadlineBucketSize once - it is read twice below and
 	// the two reads could observe different values if a concurrent DPC is
 	// updating it.  A single cached read is also cheaper on the hot path.
-	int64 currentBucketSize = atomic_get64(&gDeadlineBucketSize);
+	int64 currentBucketSize = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&gDeadlineBucketSize)));
 
 	if (now == 0)
 		now = system_time();
-	bigtime_t lastTime = atomic_get64(&sLastInteractionTime);
+	bigtime_t lastTime = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&sLastInteractionTime)));
 	// Issue 97 fix: Scheduler::MinimalQuantum() reads sCurrentMode->minimal_quantum
 	// in two separate memory accesses (pointer load + field read). On 32-bit
 	// targets, a concurrent mode switch can change sCurrentMode between these,
@@ -195,12 +195,12 @@ scheduler_update_interaction_state(bigtime_t now)
 		: 1200; // fallback: 1.2ms minimal quantum
 
 	while (now - lastTime >= threshold) {
-		if (atomic_test_and_set64(&sLastInteractionTime, now, lastTime) == lastTime) {
+		if (atomic_test_and_set64(reinterpret_cast<int64 volatile*>(&sLastInteractionTime), now, lastTime) == lastTime) {
 			lastTime = now;
 			break;
 		}
 
-		lastTime = atomic_get64(&sLastInteractionTime);
+		lastTime = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&sLastInteractionTime)));
 		if (now - lastTime < threshold)
 			return;
 	}
@@ -208,7 +208,7 @@ scheduler_update_interaction_state(bigtime_t now)
 	if (currentBucketSize == 1000) {
 		// Replace non-atomic timer_is_active()+add_timer() pair
 		// with an atomic test-and-set so only one CPU arms the timer.
-		if (atomic_get_and_set(&sTimerArmed, 1) == 0) {
+		if (atomic_get_and_set(reinterpret_cast<int32 volatile*>(&sTimerArmed), 1) == 0) {
 			add_timer(&sInteractionTimer, &interaction_timer_hook, 500000,
 				B_ONE_SHOT_RELATIVE_TIMER);
 		}
@@ -227,13 +227,13 @@ scheduler_update_interaction_state(bigtime_t now)
 	// atomic_get_and_set below.  Clearing sDPCPending unconditionally before
 	// the CAS wiped a concurrent CPU's already-queued flag, allowing both CPUs
 	// to satisfy the "old == 0" check and enqueue duplicate DPCs.
-	atomic_set(&sPendingDPCTarget, 1000);
-	if (atomic_get_and_set(&sDPCPending, 1) == 0) {
-		int64 target = (int64)atomic_get(&sPendingDPCTarget);
+	atomic_set(reinterpret_cast<int32 volatile*>(&sPendingDPCTarget), 1000);
+	if (atomic_get_and_set(reinterpret_cast<int32 volatile*>(&sDPCPending), 1) == 0) {
+		int64 target = (int64)atomic_get(const_cast<int32 volatile*>(&sPendingDPCTarget));
 		if (DPCQueue::DefaultQueue(B_URGENT_DISPLAY_PRIORITY)->Add(
 				&update_quantum_lengths_dpc, (void*)(addr_t)target) != B_OK) {
-			atomic_set(&sDPCPending, 0);
-			atomic_set(&sPendingDPCTarget, 0);
+			atomic_set(reinterpret_cast<int32 volatile*>(&sDPCPending), 0);
+			atomic_set(reinterpret_cast<int32 volatile*>(&sPendingDPCTarget), 0);
 			// Issue 28 fix: when DPC queue is full, ensure sTimerArmed is
 			// also cleared so the next interaction event can re-arm the timer.
 			// Without this, sTimerArmed stays 0 (it was never set in this
@@ -247,7 +247,7 @@ scheduler_update_interaction_state(bigtime_t now)
 	// Only arm the timer if the DPC was successfully queued above.
 	// Issue 28 fix: sTimerArmed must not be set if Add() failed, since we
 	// returned early above in that case and never reach this line.
-	if (atomic_get_and_set(&sTimerArmed, 1) == 0) {
+	if (atomic_get_and_set(reinterpret_cast<int32 volatile*>(&sTimerArmed), 1) == 0) {
 		add_timer(&sInteractionTimer, &interaction_timer_hook, 500000,
 			B_ONE_SHOT_RELATIVE_TIMER);
 	}
@@ -375,8 +375,8 @@ UpdatePriorityBoostScalable(CoreEntry* core, CPUEntry* cpu, bigtime_t now = 0)
 	static const uint32 kTopWordMask =
 		(uint32)((2ULL << (THREAD_MAX_SET_PRIORITY % 32)) - 1);
 
-	// static_assert replaced by comment for GCC 2.95
-	// THREAD_MAX_SET_PRIORITY < ThreadRunQueue::kBitmapSize * 32
+	static_assert(THREAD_MAX_SET_PRIORITY < ThreadRunQueue::kBitmapSize * 32,
+		"THREAD_MAX_SET_PRIORITY exceeds bitmap capacity");
 
 	// Throttle: only run the boost scan every 10 context switches to reduce overhead.
 	if (cpu->fRescheduleCount++ % 10 != 0)
@@ -522,7 +522,7 @@ enqueue(Thread* thread, bool newOne, Thread* waker, bigtime_t now)
 
 			if (++enqueueAttempts > kMaxRetries) {
 				if (threadData->IsReady() && !threadData->IsIdle())
-					atomic_add(&gTotalRunnableThreads, -1);
+					atomic_add(reinterpret_cast<int32 volatile*>(&gTotalRunnableThreads), -1);
 				return false;
 			}
 
@@ -531,7 +531,7 @@ enqueue(Thread* thread, bool newOne, Thread* waker, bigtime_t now)
 				targetCore = targetCPU->Core();
 				if (targetCore == NULL || gCPU[targetCPU->ID()].disabled) {
 					if (threadData->IsReady() && !threadData->IsIdle())
-						atomic_add(&gTotalRunnableThreads, -1);
+						atomic_add(reinterpret_cast<int32 volatile*>(&gTotalRunnableThreads), -1);
 					return false;
 				}
 			}
@@ -570,10 +570,10 @@ enqueue(Thread* thread, bool newOne, Thread* waker, bigtime_t now)
 		} else {
 			// Issue 84 fix: this IPI dispatch was unreachable before; now
 			// correctly wakes the target CPU when a thread is enqueued.
-			if (ShouldReschedule(now, atomic_get64(&targetCPU->lastReschedule),
+			if (ShouldReschedule(now, atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&targetCPU->lastReschedule))),
 					kRescheduleCooldown)) {
 				if (targetCPU->SetReschedulePending()) {
-					atomic_set64(&targetCPU->lastReschedule, now);
+					atomic_set64(reinterpret_cast<int64 volatile*>(&targetCPU->lastReschedule), now);
 					smp_send_ici(targetCPU->ID(), SMP_MSG_RESCHEDULE, 0, 0, 0,
 						NULL, SMP_MSG_FLAG_ASYNC);
 				}
@@ -972,7 +972,7 @@ scheduler_reschedule(int32 nextState)
 	ASSERT(!are_interrupts_enabled());
 	SCHEDULER_ENTER_FUNCTION();
 
-	if (!atomic_get(&sSchedulerEnabled)) {
+	if (!atomic_get(const_cast<int32 volatile*>(&sSchedulerEnabled))) {
 		Thread* thread = thread_get_current_thread();
 		if (thread != NULL && nextState != B_THREAD_READY)
 			panic("scheduler_reschedule_no_op() called in non-ready thread");
@@ -1000,7 +1000,7 @@ scheduler_on_thread_init(Thread* thread)
 
 	if (thread_is_idle_thread(thread)) {
 		static int32 sIdleThreadsID;
-		int32 cpuID = atomic_add(&sIdleThreadsID, 1);
+		int32 cpuID = atomic_add(reinterpret_cast<int32 volatile*>(&sIdleThreadsID), 1);
 
 		thread->previous_cpu = &gCPU[cpuID];
 		thread->pinned_to_cpu = 1;
@@ -1918,7 +1918,7 @@ void
 scheduler_enable_scheduling()
 {
 	// use atomic store so all CPUs observe the flag immediately.
-	atomic_set(&sSchedulerEnabled, 1);
+	atomic_set(reinterpret_cast<int32 volatile*>(&sSchedulerEnabled), 1);
 }
 
 void

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -56,9 +56,9 @@ struct ThreadDataVRuntimeCompare {
 		if (b->IsForeground())
 			bRuntime -= kForegroundVRuntimeOffset;
 
-		// Use signed delta to handle potential wrap-around or
-		// comparison near the zero-boundary robustly.
-		return (int64)(aRuntime - bRuntime) < 0;
+		// bigtime_t is a signed 64-bit integer. Standard subtraction natively
+		// handles potential wrap-around or near-zero boundary comparisons.
+		return (aRuntime - bRuntime) < 0;
 	}
 };
 
@@ -72,7 +72,7 @@ struct ThreadDataOptimal {
 };
 
 
-// Portability helpers for GCC 2.95 and architecture independence.
+// Portability helpers for modern GCC and architecture independence.
 // These wrappers ensure atomic operations and bit manipulation work correctly
 // on both 32-bit and 64-bit systems.
 
@@ -94,9 +94,9 @@ static inline native_cpu_mask_t
 scheduler_atomic_or(native_cpu_mask_t* value, native_cpu_mask_t orValue)
 {
 #if SCHEDULER_MASK_IS_64_BIT
-	return (native_cpu_mask_t)atomic_or64((int64 volatile*)value, (int64)orValue);
+	return (native_cpu_mask_t)atomic_or64(reinterpret_cast<int64 volatile*>(value), (int64)orValue);
 #else
-	return (native_cpu_mask_t)atomic_or((int32 volatile*)value, (int32)orValue);
+	return (native_cpu_mask_t)atomic_or(reinterpret_cast<int32 volatile*>(value), (int32)orValue);
 #endif
 }
 
@@ -104,7 +104,7 @@ scheduler_atomic_or(native_cpu_mask_t* value, native_cpu_mask_t orValue)
 static inline uint64
 scheduler_atomic_or64(uint64 volatile* value, uint64 orValue)
 {
-	return (uint64)atomic_or64((int64 volatile*)value, (int64)orValue);
+	return (uint64)atomic_or64(reinterpret_cast<int64 volatile*>(const_cast<uint64*>(value)), (int64)orValue);
 }
 
 
@@ -112,9 +112,9 @@ static inline native_cpu_mask_t
 scheduler_atomic_and(native_cpu_mask_t* value, native_cpu_mask_t andValue)
 {
 #if SCHEDULER_MASK_IS_64_BIT
-	return (native_cpu_mask_t)atomic_and64((int64 volatile*)value, (int64)andValue);
+	return (native_cpu_mask_t)atomic_and64(reinterpret_cast<int64 volatile*>(value), (int64)andValue);
 #else
-	return (native_cpu_mask_t)atomic_and((int32 volatile*)value, (int32)andValue);
+	return (native_cpu_mask_t)atomic_and(reinterpret_cast<int32 volatile*>(value), (int32)andValue);
 #endif
 }
 
@@ -123,9 +123,9 @@ static inline native_cpu_mask_t
 scheduler_atomic_get(native_cpu_mask_t* value)
 {
 #if SCHEDULER_MASK_IS_64_BIT
-	return (native_cpu_mask_t)atomic_get64((int64 volatile*)value);
+	return (native_cpu_mask_t)atomic_get64(reinterpret_cast<int64 volatile*>(value));
 #else
-	return (native_cpu_mask_t)atomic_get((int32 volatile*)value);
+	return (native_cpu_mask_t)atomic_get(reinterpret_cast<int32 volatile*>(value));
 #endif
 }
 
@@ -133,9 +133,9 @@ static inline void
 scheduler_atomic_set(native_cpu_mask_t* value, native_cpu_mask_t newValue)
 {
 #if SCHEDULER_MASK_IS_64_BIT
-	atomic_set64((int64 volatile*)value, (int64)newValue);
+	atomic_set64(reinterpret_cast<int64 volatile*>(value), (int64)newValue);
 #else
-	atomic_set((int32 volatile*)value, (int32)newValue);
+	atomic_set(reinterpret_cast<int32 volatile*>(value), (int32)newValue);
 #endif
 }
 
@@ -144,10 +144,10 @@ scheduler_atomic_test_and_set(native_cpu_mask_t* value, native_cpu_mask_t newVal
 	native_cpu_mask_t expectedValue)
 {
 #if SCHEDULER_MASK_IS_64_BIT
-	return (native_cpu_mask_t)atomic_test_and_set64((int64 volatile*)value,
+	return (native_cpu_mask_t)atomic_test_and_set64(reinterpret_cast<int64 volatile*>(value),
 		(int64)newValue, (int64)expectedValue);
 #else
-	return (native_cpu_mask_t)atomic_test_and_set((int32 volatile*)value,
+	return (native_cpu_mask_t)atomic_test_and_set(reinterpret_cast<int32 volatile*>(value),
 		(int32)newValue, (int32)expectedValue);
 #endif
 }
@@ -156,61 +156,50 @@ static inline int
 scheduler_popcount(native_cpu_mask_t value)
 {
 #if SCHEDULER_MASK_IS_64_BIT
-	return (int)(count_set_bits((uint32)value)
-		+ count_set_bits((uint32)(value >> 32)));
+	return __builtin_popcountll(value);
 #else
-	return (int)count_set_bits((uint32)value);
+	return __builtin_popcount(value);
 #endif
 }
 
-// scheduler_ffs: portable Find First Set bit for GCC 2.95.
+// scheduler_ffs: Native intrinsic Find First Set bit.
 // Returns 1-based index of the first bit set, or 0 if value is 0.
 static inline int
 scheduler_ffs(uint32 value)
 {
-	if (value == 0)
-		return 0;
-	// fls(x & -x) is correct for isolating and finding the lowest bit.
-	return (int)fls(value & (uint32)-(int32)value);
+	return __builtin_ffs(value);
 }
 
 static inline int
 scheduler_ffs64(uint64 value)
 {
-	uint32 low = (uint32)value;
-	if (low != 0)
-		return scheduler_ffs(low);
-	uint32 high = (uint32)(value >> 32);
-	int bit = scheduler_ffs(high);
-	if (bit == 0)
-		return 0;
-	return bit + 32;
+	return __builtin_ffsll(value);
 }
 
-// scheduler_ctz: portable Count Trailing Zeros for GCC 2.95.
+// scheduler_ctz: Native intrinsic Count Trailing Zeros.
 static inline int
 scheduler_ctz(native_cpu_mask_t value)
 {
 	if (value == 0)
 		return -1;
 #if SCHEDULER_MASK_IS_64_BIT
-	return scheduler_ffs64((uint64)value) - 1;
+	return __builtin_ctzll(value);
 #else
-	return scheduler_ffs((uint32)value) - 1;
+	return __builtin_ctz(value);
 #endif
 }
 
 
 // atomic_pointer: architecture-independent atomic pointer operations.
-// Necessary for GCC 2.95 compatibility and 32/64-bit portability.
+// Necessary for 32/64-bit portability.
 template<typename T>
 static inline T*
 atomic_pointer_get(T* volatile* pointer)
 {
 #if SCHEDULER_MASK_IS_64_BIT
-	T* value = (T*)atomic_get64((int64 volatile*)pointer);
+	T* value = reinterpret_cast<T*>(atomic_get64(reinterpret_cast<int64 volatile*>(pointer)));
 #else
-	T* value = (T*)atomic_get((int32 volatile*)pointer);
+	T* value = reinterpret_cast<T*>(atomic_get(reinterpret_cast<int32 volatile*>(pointer)));
 #endif
 	memory_read_barrier();
 	return value;
@@ -223,9 +212,9 @@ atomic_pointer_set(T* volatile* pointer, T* value)
 {
 	memory_write_barrier();
 #if SCHEDULER_MASK_IS_64_BIT
-	atomic_set64((int64 volatile*)pointer, (int64)value);
+	atomic_set64(reinterpret_cast<int64 volatile*>(pointer), reinterpret_cast<int64>(value));
 #else
-	atomic_set((int32 volatile*)pointer, (int32)value);
+	atomic_set(reinterpret_cast<int32 volatile*>(pointer), reinterpret_cast<int32>(value));
 #endif
 }
 
@@ -235,11 +224,11 @@ static inline T*
 atomic_pointer_test_and_set(T* volatile* pointer, T* newValue, T* expectedValue)
 {
 #if SCHEDULER_MASK_IS_64_BIT
-	return (T*)atomic_test_and_set64((int64 volatile*)pointer, (int64)newValue,
-		(int64)expectedValue);
+	return reinterpret_cast<T*>(atomic_test_and_set64(reinterpret_cast<int64 volatile*>(pointer),
+		reinterpret_cast<int64>(newValue), reinterpret_cast<int64>(expectedValue)));
 #else
-	return (T*)atomic_test_and_set((int32 volatile*)pointer, (int32)newValue,
-		(int32)expectedValue);
+	return reinterpret_cast<T*>(atomic_test_and_set(reinterpret_cast<int32 volatile*>(pointer),
+		reinterpret_cast<int32>(newValue), reinterpret_cast<int32>(expectedValue)));
 #endif
 }
 
@@ -322,28 +311,28 @@ AssertThreadQueued(Thread* thread)
 inline int
 LoadAcquire(const int32& value)
 {
-	return atomic_get(const_cast<int32*>(&value));
+	return atomic_get(const_cast<int32 volatile*>(&value));
 }
 
 
 inline void
 StoreRelease(int32& value, int v)
 {
-	atomic_set(&value, v);
+	atomic_set(reinterpret_cast<int32 volatile*>(&value), v);
 }
 
 
 inline void
 AddRelease(int32& value, int v)
 {
-	atomic_add(&value, v);
+	atomic_add(reinterpret_cast<int32 volatile*>(&value), v);
 }
 
 
 inline void
 SubAcquireRelease(int32& value, int v)
 {
-	atomic_add(&value, -v);
+	atomic_add(reinterpret_cast<int32 volatile*>(&value), -v);
 }
 
 
@@ -352,7 +341,7 @@ SetCPUIDle(uint64& mask, int cpu)
 {
 	if ((unsigned)cpu >= 64)
 		return;
-	atomic_or64((int64*)&mask, 1ULL << cpu);
+	atomic_or64(reinterpret_cast<int64 volatile*>(&mask), 1ULL << cpu);
 }
 
 
@@ -361,7 +350,7 @@ ClearCPUIDle(uint64& mask, int cpu)
 {
 	if ((unsigned)cpu >= 64)
 		return;
-	atomic_and64((int64*)&mask, ~(1ULL << cpu));
+	atomic_and64(reinterpret_cast<int64 volatile*>(&mask), ~(1ULL << cpu));
 }
 
 
@@ -370,7 +359,7 @@ IsCPUIDle(const uint64& mask, int cpu)
 {
 	if ((unsigned)cpu >= 64)
 		return false;
-	return (atomic_get64((int64*)&mask) & (1ULL << cpu)) != 0;
+	return (atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&mask))) & (1ULL << cpu)) != 0;
 }
 
 
@@ -388,8 +377,8 @@ MakeSchedulerSnapshot(const int32& total,
 	const uint64& idleMask)
 {
 	SchedulerSnapshot s;
-	s.totalRunnable = atomic_get(const_cast<int32*>(&total));
-	s.idleMask = atomic_get64((int64*)&idleMask);
+	s.totalRunnable = atomic_get(const_cast<int32 volatile*>(&total));
+	s.idleMask = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&idleMask)));
 	return s;
 }
 
@@ -425,7 +414,7 @@ public:
 		scheduler_mode_operations* operations)
 	{
 		atomic_pointer_set<scheduler_mode_operations>(&sCurrentMode, operations);
-		atomic_set((int32*)&sCurrentModeID, (int32)mode);
+		atomic_set(reinterpret_cast<int32 volatile*>(&sCurrentModeID), (int32)mode);
 	}
 
 	// expose sCurrentMode via a public accessor.
@@ -440,7 +429,7 @@ public:
 
 	static inline scheduler_mode Mode()
 	{
-		return (scheduler_mode)atomic_get((int32*)&sCurrentModeID);
+		return (scheduler_mode)atomic_get(const_cast<int32 volatile*>(reinterpret_cast<const int32*>(&sCurrentModeID)));
 	}
 
 	static inline void SwitchToMode()

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -292,8 +292,8 @@ CPUEntry::Start()
 {
 	fThreadCount = 0;
 	fLoad = 0;
-	atomic_set64((int64*)&fMeasureTime, system_time());
-	atomic_set64((int64*)&fMeasureActiveTime, 0);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fMeasureTime), system_time());
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fMeasureActiveTime), 0);
 }
 
 
@@ -359,7 +359,7 @@ CPUEntry::PushFront(ThreadData* thread, int32 priority)
 {
 	SCHEDULER_ENTER_FUNCTION();
 	fRunQueue.PushFront(thread, priority);
-	atomic_add(&fThreadCount, 1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fThreadCount), 1);
 
 	if (!thread->IsIdle()) {
 		Core()->IncrementTotalThreadCount();
@@ -374,7 +374,7 @@ CPUEntry::PushBack(ThreadData* thread, int32 priority)
 {
 	SCHEDULER_ENTER_FUNCTION();
 	fRunQueue.PushBack(thread, priority);
-	atomic_add(&fThreadCount, 1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fThreadCount), 1);
 
 	if (!thread->IsIdle()) {
 		Core()->IncrementTotalThreadCount();
@@ -399,7 +399,7 @@ CPUEntry::Remove(ThreadData* thread)
 
 	thread->SetDequeued();
 	fRunQueue.Remove(thread);
-	atomic_add(&fThreadCount, -1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fThreadCount), -1);
 
 	if (!thread->IsIdle()) {
 		Core()->DecrementTotalThreadCount();
@@ -466,20 +466,20 @@ CPUEntry::ComputeLoad(bigtime_t now)
 	if (now == 0)
 		now = system_time();
 
-	int32 currentLoad = atomic_get(&fLoad);
+	int32 currentLoad = atomic_get(const_cast<int32 volatile*>(&fLoad));
 	bigtime_t measureActiveTime __attribute__((aligned(8)));
 	int oldLoad;
 	do {
-		bigtime_t measureTime = atomic_get64((int64*)&fMeasureTime);
-		measureActiveTime = atomic_get64((int64*)&fMeasureActiveTime);
+		bigtime_t measureTime = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fMeasureTime)));
+		measureActiveTime = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fMeasureActiveTime)));
 		bigtime_t tempMeasureTime = measureTime;
 		bigtime_t tempMeasureActiveTime = measureActiveTime;
 		oldLoad = compute_load(tempMeasureTime, tempMeasureActiveTime, currentLoad,
 				now);
 		if (oldLoad < 0)
 			break;
-		if (atomic_test_and_set64((int64*)&fMeasureActiveTime, tempMeasureActiveTime, measureActiveTime) == measureActiveTime) {
-			atomic_set64((int64*)&fMeasureTime, tempMeasureTime);
+		if (atomic_test_and_set64(reinterpret_cast<int64 volatile*>(&fMeasureActiveTime), tempMeasureActiveTime, measureActiveTime) == measureActiveTime) {
+			atomic_set64(reinterpret_cast<int64 volatile*>(&fMeasureTime), tempMeasureTime);
 			break;
 		}
 	} while (true);
@@ -492,7 +492,7 @@ CPUEntry::ComputeLoad(bigtime_t now)
 	else if (currentLoad > kLoadClampMax)
 		currentLoad = kLoadClampMax;
 
-	atomic_set(&fLoad, currentLoad);
+	atomic_set(reinterpret_cast<int32 volatile*>(&fLoad), currentLoad);
 
 	if (GetLoad() > kVeryHighLoad)
 		Scheduler::RebalanceIRQs(false);
@@ -647,7 +647,7 @@ CPUEntry::UpdateActiveTime(ThreadData* oldThreadData, bigtime_t now)
 		cpuEntry->active_time += active;
 		locker.Unlock();
 
-		atomic_add64((int64*)&fMeasureActiveTime, active);
+		atomic_add64(reinterpret_cast<int64 volatile*>(&fMeasureActiveTime), active);
 		atomic_pointer_get<CoreEntry>(&fCore)->IncreaseActiveTime(active);
 
 		// Use the provided timestamp for UpdateActivity.
@@ -667,7 +667,7 @@ CPUEntry::TrackLoad(ThreadData* nextThreadData, bigtime_t now)
 #ifdef DEBUG_SCHEDULER
 	TRACE("scheduler: cpu=%d load=%d idle=%d\n",
 		fCPUNumber,
-		atomic_get(&fLoad),
+		atomic_get(const_cast<int32 volatile*>(&fLoad)),
 		gCPU[fCPUNumber].idle);
 #endif
 
@@ -1000,7 +1000,7 @@ CoreEntry::PushFront(ThreadData* thread, int32 priority)
 	SCHEDULER_ENTER_FUNCTION();
 
 	fRunQueue.PushFront(thread, priority);
-	atomic_add(&fThreadCount, 1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fThreadCount), 1);
 	IncrementTotalThreadCount();
 	if (priority >= B_DISPLAY_PRIORITY)
 		IncrementDisplayThreadCount();
@@ -1013,7 +1013,7 @@ CoreEntry::PushBack(ThreadData* thread, int32 priority)
 	SCHEDULER_ENTER_FUNCTION();
 
 	fRunQueue.PushBack(thread, priority);
-	atomic_add(&fThreadCount, 1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fThreadCount), 1);
 	IncrementTotalThreadCount();
 	if (priority >= B_DISPLAY_PRIORITY)
 		IncrementDisplayThreadCount();
@@ -1034,7 +1034,7 @@ CoreEntry::Remove(ThreadData* thread)
 
 	thread->SetDequeued();
 
-	atomic_add(&fThreadCount, -1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fThreadCount), -1);
 	DecrementTotalThreadCount();
 	if (priority >= B_DISPLAY_PRIORITY)
 		DecrementDisplayThreadCount();
@@ -1064,10 +1064,10 @@ void
 CoreEntry::AddCPU(CPUEntry* cpu)
 {
 	ASSERT(fCPUCount >= 0);
-	ASSERT(atomic_get(&fIdleCPUCount) >= 0);
+	ASSERT(atomic_get(const_cast<int32 volatile*>(&fIdleCPUCount)) >= 0);
 
-	atomic_add(&fIdleCPUCount, 1);
-	bool firstCPU = (atomic_add(&fCPUCount, 1) == 0);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fIdleCPUCount), 1);
+	bool firstCPU = (atomic_add(reinterpret_cast<int32 volatile*>(&fCPUCount), 1) == 0);
 
 	// Find the first available local index using a CAS loop.
 	// This ensures unique index assignment even after arbitrary CPU hot-unplugging.
@@ -1101,9 +1101,9 @@ CoreEntry::AddCPU(CPUEntry* cpu)
 	if (firstCPU) {
 		didAddIdle = true;
 		fLoad = 0;
-		atomic_set64(&fCombinedLoad, 0);
+		atomic_set64(reinterpret_cast<int64 volatile*>(&fCombinedLoad), 0);
 
-		atomic_set(&fPackage->fCoreLoads[fPackageIndex], 0);
+		atomic_set(reinterpret_cast<int32 volatile*>(&fPackage->fCoreLoads[fPackageIndex]), 0);
 		scheduler_atomic_or(&fPackage->fEnabledCoreMask,
 			(native_cpu_mask_t)1 << fPackageIndex);
 
@@ -1117,17 +1117,17 @@ CoreEntry::AddCPU(CPUEntry* cpu)
 			~((native_cpu_mask_t)1 << localIndex));
 		if (firstCPU) {
 			fLoad = 0;
-			atomic_set64(&fCombinedLoad, 0);
-			atomic_set(&fPackage->fCoreLoads[fPackageIndex], 0);
+			atomic_set64(reinterpret_cast<int64 volatile*>(&fCombinedLoad), 0);
+			atomic_set(reinterpret_cast<int32 volatile*>(&fPackage->fCoreLoads[fPackageIndex]), 0);
 			if (didAddIdle)
 				fPackage->RemoveIdleCore(this);
 			scheduler_atomic_and(&fPackage->fEnabledCoreMask,
 				~((native_cpu_mask_t)1 << fPackageIndex));
-			atomic_add(&fCPUCount, -1);
+			atomic_add(reinterpret_cast<int32 volatile*>(&fCPUCount), -1);
 		} else {
-			atomic_add(&fCPUCount, -1);
+			atomic_add(reinterpret_cast<int32 volatile*>(&fCPUCount), -1);
 		}
-		atomic_add(&fIdleCPUCount, -1);
+		atomic_add(reinterpret_cast<int32 volatile*>(&fIdleCPUCount), -1);
 		panic("CoreEntry::AddCPU: failed to insert CPU %" B_PRId32 " into heap",
 			cpu->ID());
 	}
@@ -1138,14 +1138,14 @@ void
 CoreEntry::RemoveCPU(CPUEntry* cpu, ThreadProcessing& threadPostProcessing)
 {
 	ASSERT(fCPUCount > 0);
-	ASSERT(atomic_get(&fIdleCPUCount) >= 1);
+	ASSERT(atomic_get(const_cast<int32 volatile*>(&fIdleCPUCount)) >= 1);
 
 	// The CPU is guaranteed to be idle and accounted for in fIdleCPUCount
 	// before RemoveCPU is called (set by scheduler_set_cpu_enabled).
-	int32 oldIdleCount = atomic_add(&fIdleCPUCount, -1);
+	int32 oldIdleCount = atomic_add(reinterpret_cast<int32 volatile*>(&fIdleCPUCount), -1);
 
 	fCPUSet.ClearBitAtomic(cpu->ID());
-	int32 oldCPUCount = atomic_add(&fCPUCount, -1);
+	int32 oldCPUCount = atomic_add(reinterpret_cast<int32 volatile*>(&fCPUCount), -1);
 
 	if (oldCPUCount == 1) {
 		// core has been disabled
@@ -1189,11 +1189,11 @@ CoreEntry::RemoveCPU(CPUEntry* cpu, ThreadProcessing& threadPostProcessing)
 		// If a concurrent steal occurred in the narrow window, fThreadCount
 		// may be positive. Force it to zero since CPUCount==0 prevents
 		// further enqueues, making any residual count a permanent leak.
-		int32 residual = atomic_get(&fThreadCount);
+	int32 residual = atomic_get(const_cast<int32 volatile*>(&fThreadCount));
 		if (residual != 0) {
 			dprintf("CoreEntry::RemoveCPU: fThreadCount=%" B_PRId32
 				" after drain (expected 0) - resetting\n", residual);
-			atomic_set(&fThreadCount, 0);
+		atomic_set(reinterpret_cast<int32 volatile*>(&fThreadCount), 0);
 		}
 	}
 
@@ -1301,7 +1301,7 @@ CoreEntry::_UpdateLoad(bool forceUpdate, bigtime_t now)
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	int32 cpuCount = atomic_get((int32*)&fCPUCount);
+	int32 cpuCount = atomic_get(const_cast<int32 volatile*>(&fCPUCount));
 	if (cpuCount <= 0)
 		return;
 
@@ -1310,18 +1310,18 @@ CoreEntry::_UpdateLoad(bool forceUpdate, bigtime_t now)
 
 	// one system_time() call shared by both branches eliminates
 	// a redundant syscall and ensures consistent timestamps.
-	bigtime_t lastUpdate = atomic_get64(&fLastLoadUpdate);
+	bigtime_t lastUpdate = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fLastLoadUpdate)));
 	if (!forceUpdate) {
 		if (now < kLoadMeasureInterval + lastUpdate)
 			return;
-		if (atomic_test_and_set64(&fLastLoadUpdate, now, lastUpdate)
+		if (atomic_test_and_set64(reinterpret_cast<int64 volatile*>(&fLastLoadUpdate), now, lastUpdate)
 				!= lastUpdate) {
 			return;
 		}
 	} else {
 		// on CAS failure another CPU won the update race; that
 		// update is sufficient, so return rather than silently skipping.
-		if (atomic_test_and_set64(&fLastLoadUpdate, now, lastUpdate)
+		if (atomic_test_and_set64(reinterpret_cast<int64 volatile*>(&fLastLoadUpdate), now, lastUpdate)
 				!= lastUpdate) {
 			return;
 		}
@@ -1335,14 +1335,14 @@ CoreEntry::_UpdateLoad(bool forceUpdate, bigtime_t now)
 	// added to fLoad) or the new epoch (and are captured in the next snapshot),
 	// with no double-counting or loss.
 	int32 currentLoad = 0;
-	int64 oldCombined = atomic_get64(&fCombinedLoad);
+	int64 oldCombined = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fCombinedLoad)));
 	int outerRetryCount = 0;
 	while (true) {
 		currentLoad = (int32)(oldCombined >> 32);
 		uint32 nextEpoch = (uint32)oldCombined + 1;
 		int64 newCombined = (int64)nextEpoch; // Load reset to 0
 
-		int64 actual = atomic_test_and_set64(&fCombinedLoad, newCombined,
+		int64 actual = atomic_test_and_set64(reinterpret_cast<int64 volatile*>(&fCombinedLoad), newCombined,
 			oldCombined);
 		if (actual == oldCombined) {
 			// Issue 7 fix: snapshot prevLoad immediately after winning the
@@ -1353,7 +1353,7 @@ CoreEntry::_UpdateLoad(bool forceUpdate, bigtime_t now)
 			// Reading here minimises the race window to the CAS itself.
 			// currentFLoad starts equal to prevLoad; the inner retry loop
 			// updates it on CAS failure and correctly adds delta each time.
-			int32 prevLoad = atomic_get(&fLoad);
+			int32 prevLoad = atomic_get(const_cast<int32 volatile*>(&fLoad));
 			int32 currentFLoad = prevLoad;
 
 			// Issue 48 fix: snapshot prevLoad immediately after winning the
@@ -1377,7 +1377,7 @@ CoreEntry::_UpdateLoad(bool forceUpdate, bigtime_t now)
 				if (newFLoad < 0)
 					newFLoad = 0;
 
-				int32 actualLoad = atomic_test_and_set(&fLoad, newFLoad,
+				int32 actualLoad = atomic_test_and_set(reinterpret_cast<int32 volatile*>(&fLoad), newFLoad,
 					currentFLoad);
 				if (actualLoad == currentFLoad)
 					break;
@@ -1385,7 +1385,7 @@ CoreEntry::_UpdateLoad(bool forceUpdate, bigtime_t now)
 				currentFLoad = actualLoad;
 				if (++innerRetryCount >= kMaxFLoadRetries) {
 					// Best-effort: apply delta to most recently observed value.
-					atomic_add(&fLoad, delta);
+					atomic_add(reinterpret_cast<int32 volatile*>(&fLoad), delta);
 					break;
 				}
 			}
@@ -1402,13 +1402,13 @@ CoreEntry::_UpdateLoad(bool forceUpdate, bigtime_t now)
 			// Issue 85 fix: re-read cpuCount to get a fresh value after
 			// many retry failures. The value from function entry may be
 			// several epochs stale on a heavily contended system.
-			int32 freshCPUCount = atomic_get((int32*)&fCPUCount);
+			int32 freshCPUCount = atomic_get(const_cast<int32 volatile*>(&fCPUCount));
 			if (freshCPUCount <= 0)
 				return;
 
 			int32 load = (int32)(oldCombined >> 32) / freshCPUCount;
 			load = ((int64)load * fScoreFactor) >> 16;
-			atomic_set(&fPackage->fCoreLoads[fPackageIndex],
+			atomic_set(reinterpret_cast<int32 volatile*>(&fPackage->fCoreLoads[fPackageIndex]),
 				min_c(load, (int32)kMaxLoad));
 			return;
 		}
@@ -1419,8 +1419,8 @@ CoreEntry::_UpdateLoad(bool forceUpdate, bigtime_t now)
 		int32 load = currentLoad / cpuCount;
 		load = ((int64)load * fScoreFactor) >> 16;
 
-		int32 oldLoad = atomic_get(&fPackage->fCoreLoads[fPackageIndex]);
-		atomic_set(&fPackage->fCoreLoads[fPackageIndex],
+		int32 oldLoad = atomic_get(const_cast<int32 volatile*>(&fPackage->fCoreLoads[fPackageIndex]));
+		atomic_set(reinterpret_cast<int32 volatile*>(&fPackage->fCoreLoads[fPackageIndex]),
 			SmoothLoad(oldLoad, min_c(load, (int32)kMaxLoad)));
 	}
 }
@@ -1493,7 +1493,7 @@ PackageEntry::AddIdleCore(CoreEntry* core)
 	WriteSpinLocker coreLocker(fCoreLock);
 	native_cpu_mask_t oldMask = scheduler_atomic_or(&fIdleCoreMask,
 		(native_cpu_mask_t)1 << core->PackageIndex());
-	atomic_add(&fIdleCoreCount, 1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fIdleCoreCount), 1);
 
 	if (oldMask == 0) {
 		// Issue 45 fix: document that fCoreLock is held here but NOT held
@@ -1520,7 +1520,7 @@ PackageEntry::RemoveIdleCore(CoreEntry* core)
 	native_cpu_mask_t clearBit = (native_cpu_mask_t)1 << core->PackageIndex();
 	native_cpu_mask_t oldMask = scheduler_atomic_and(&fIdleCoreMask, ~clearBit);
 
-	atomic_add(&fIdleCoreCount, -1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fIdleCoreCount), -1);
 
 	if ((oldMask & ~clearBit) == 0) {
 		// Package wakes up (last idle core became active).  Delegate to
@@ -1750,7 +1750,7 @@ PackageEntry::PeekMinimumLoadCore(CPUEntry* cpu, const CPUSet* mask,
 			if (type != CORE_TYPE_UNKNOWN && candidate->Type() != type)
 				continue;
 
-			int32 load = atomic_get(&fCoreLoads[i]);
+		int32 load = atomic_get(const_cast<int32 volatile*>(&fCoreLoads[i]));
 
 			// Track the best core across all attempts (Power-of-N-Choices).
 			if (minEntry == NULL || load < minLoad) {
@@ -1779,7 +1779,7 @@ PackageEntry::PeekMinimumLoadCore(CPUEntry* cpu, const CPUSet* mask,
 		if (type != CORE_TYPE_UNKNOWN && candidate->Type() != type)
 			continue;
 
-		int32 load = atomic_get(&fCoreLoads[i]);
+		int32 load = atomic_get(const_cast<int32 volatile*>(&fCoreLoads[i]));
 		if (minEntry == NULL || load < minLoad) {
 			minLoad = load;
 			minEntry = candidate;
@@ -1809,8 +1809,8 @@ PackageEntry::PeekMaximumLoadCore(CPUEntry* cpu, const CPUSet* mask,
 		// sizeof(native_cpu_mask_t)*8 == 64 on 64-bit and 32 on 32-bit,
 		// so every possible index i < kMaxCoresPerPackage fits within the
 		// bitmask on all supported platforms.  No overflow is possible.
-		// static_assert replaced by comment for GCC 2.95
-		// kMaxCoresPerPackage <= (int32)(sizeof(sampledCores) * 8)
+		static_assert(kMaxCoresPerPackage <= (int32)(sizeof(sampledCores) * 8),
+			"sampledCores too narrow for kMaxCoresPerPackage");
 		int32 attempts = 0;
 		int32 registeredCores = fRegisteredCoreCount;
 		if (registeredCores <= 0)
@@ -1838,7 +1838,7 @@ PackageEntry::PeekMaximumLoadCore(CPUEntry* cpu, const CPUSet* mask,
 			if (type != CORE_TYPE_UNKNOWN && candidate->Type() != type)
 				continue;
 
-			int32 load = atomic_get(&fCoreLoads[i]);
+			int32 load = atomic_get(const_cast<int32 volatile*>(&fCoreLoads[i]));
 
 			// Track the best core across all attempts (Power-of-N-Choices).
 			if (maxEntry == NULL || load > maxLoad
@@ -1905,7 +1905,7 @@ PackageEntry::PeekMaximumLoadCore(CPUEntry* cpu, const CPUSet* mask,
 			if (type != CORE_TYPE_UNKNOWN && candidate->Type() != type)
 				continue;
 
-			int32 load = atomic_get(&fCoreLoads[i]);
+			int32 load = atomic_get(const_cast<int32 volatile*>(&fCoreLoads[i]));
 			if (maxEntry == NULL || load > maxLoad
 					// Issue 55 fix: tie-break by higher PackageIndex (within
 					// the package) rather than lower core ID to spread across
@@ -2044,7 +2044,7 @@ static int
 dump_idle_cores(int /* argc */, char** /* argv */)
 {
 	kprintf("Idle packages:\n");
-	uint64 nodeMask = atomic_get64((int64*)&gIdleNodeMask);
+	uint64 nodeMask = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&gIdleNodeMask)));
 
 	if (nodeMask != 0) {
 		kprintf("node package cores\n");

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -61,9 +61,8 @@ const int32 kMaxCoresPerPackage = sizeof(native_cpu_mask_t) * 8;
 // assert compared kMaxCoresPerPackage to itself (tautological). This one
 // checks that kMaxCoresPerPackage does not exceed a hard platform ceiling
 // and that native_cpu_mask_t is wide enough to represent all core bits.
-// static_assert replaced by comment for GCC 2.95
-// kMaxCoresPerPackage <= 64
-// kMaxCoresPerPackage <= (int32)(sizeof(native_cpu_mask_t) * 8)
+static_assert(kMaxCoresPerPackage <= 64, "kMaxCoresPerPackage exceeds platform ceiling");
+static_assert(kMaxCoresPerPackage <= (int32)(sizeof(native_cpu_mask_t) * 8), "native_cpu_mask_t too narrow");
 
 // The run queues. Holds the threads ready to run ordered by priority.
 // One queue per schedulable target per core. Additionally, each
@@ -146,12 +145,12 @@ public:
 						uint32			GetRandom();
 
 	inline				int32			ThreadCount() const
-											{ return atomic_get(const_cast<int32*>(&fThreadCount)); }
+											{ return atomic_get(const_cast<int32 volatile*>(&fThreadCount)); }
 
 						bool			SetReschedulePending()
-											{ return atomic_set(&fReschedulePending, 1) == 0; }
+											{ return atomic_set(reinterpret_cast<int32 volatile*>(&fReschedulePending), 1) == 0; }
 						void			ClearReschedulePending()
-											{ atomic_set(&fReschedulePending, 0); }
+											{ atomic_set(reinterpret_cast<int32 volatile*>(&fReschedulePending), 0); }
 
 	static inline		CPUEntry*		GetCPU(int32 cpu);
 
@@ -221,7 +220,7 @@ public:
 	inline				int32			PackageIndex() const
 											{ return fPackageIndex; }
 	inline				int32			CPUCount() const
-											{ return atomic_get(const_cast<int32*>(&fCPUCount)); }
+											{ return atomic_get(const_cast<int32 volatile*>(&fCPUCount)); }
 	inline				const CPUSet&	CPUMask() const
 											{ return fCPUSet; }
 
@@ -237,20 +236,20 @@ public:
 	inline				CPUPriorityHeap*	CPUHeap();
 
 	inline				int32			ThreadCount() const
-											{ return atomic_get(const_cast<int32*>(&fTotalThreadCount)); }
+											{ return atomic_get(const_cast<int32 volatile*>(&fTotalThreadCount)); }
 	inline				void			IncrementTotalThreadCount()
-											{ atomic_add(&fTotalThreadCount, 1); }
+											{ atomic_add(reinterpret_cast<int32 volatile*>(&fTotalThreadCount), 1); }
 	inline				void			DecrementTotalThreadCount()
-											{ atomic_add(&fTotalThreadCount, -1); }
+											{ atomic_add(reinterpret_cast<int32 volatile*>(&fTotalThreadCount), -1); }
 
 	inline				int32			DisplayThreadCount() const
-											{ return atomic_get(const_cast<int32*>(&fDisplayThreadCount)); }
+											{ return atomic_get(const_cast<int32 volatile*>(&fDisplayThreadCount)); }
 	inline				void			IncrementDisplayThreadCount()
-											{ atomic_add(&fDisplayThreadCount, 1); }
+											{ atomic_add(reinterpret_cast<int32 volatile*>(&fDisplayThreadCount), 1); }
 	inline				void			DecrementDisplayThreadCount()
-											{ atomic_add(&fDisplayThreadCount, -1); }
+											{ atomic_add(reinterpret_cast<int32 volatile*>(&fDisplayThreadCount), -1); }
 	inline				int32			CoreRunQueueThreadCount() const
-											{ return atomic_get(const_cast<int32*>(&fThreadCount)); }
+											{ return atomic_get(const_cast<int32 volatile*>(&fThreadCount)); }
 
 	inline				void			LockRunQueue();
 	inline				bool			TryLockRunQueue();
@@ -288,9 +287,9 @@ public:
 	inline				uint32			ScoreFactor() const { return fScoreFactor; }
 						bigtime_t		GetMinVirtualRuntime() const;
 	inline				uint32			LoadMeasurementEpoch() const
-											{ return (uint32)atomic_get64((int64*)&fCombinedLoad); }
+											{ return (uint32)atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fCombinedLoad))); }
 	inline				int32			CurrentLoad() const
-											{ return (int32)(atomic_get64((int64*)&fCombinedLoad) >> 32); }
+											{ return (int32)(atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fCombinedLoad))) >> 32); }
 
 	inline				void			AddLoad(int32 load, uint32 epoch,
 											bool updateLoad, bigtime_t now = 0);
@@ -541,7 +540,7 @@ CPUEntry::GetCPU(int32 cpu)
 inline int32
 CPUEntry::GetLoad() const
 {
-	int32 load = atomic_get(const_cast<int32*>(&fLoad));
+	int32 load = atomic_get(const_cast<int32 volatile*>(&fLoad));
 
 	// Penalize SMT siblings to prefer physical cores
 	CoreEntry* core = atomic_pointer_get<CoreEntry>(
@@ -624,21 +623,21 @@ inline void
 CoreEntry::IncreaseActiveTime(bigtime_t activeTime)
 {
 	SCHEDULER_ENTER_FUNCTION();
-	atomic_add64((int64*)&fActiveTime, activeTime);
+	atomic_add64(reinterpret_cast<int64 volatile*>(&fActiveTime), activeTime);
 }
 
 
 inline bigtime_t
 CoreEntry::GetActiveTime() const
 {
-	return atomic_get64((int64*)&fActiveTime);
+	return atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fActiveTime)));
 }
 
 
 inline int32
 CoreEntry::GetLoad() const
 {
-	return atomic_get(const_cast<int32*>(&fLoad));
+	return atomic_get(const_cast<int32 volatile*>(&fLoad));
 }
 
 
@@ -657,9 +656,9 @@ CoreEntry::AddLoad(int32 load, uint32 epoch, bool updateLoad, bigtime_t now)
 	ASSERT(gTrackCoreLoad);
 	ASSERT(load >= 0 && load <= kMaxLoad);
 
-	int64 oldCombined = atomic_add64(&fCombinedLoad, (int64)load << 32);
+	int64 oldCombined = atomic_add64(reinterpret_cast<int64 volatile*>(&fCombinedLoad), (int64)load << 32);
 	if ((uint32)oldCombined != epoch)
-		atomic_add(&fLoad, load);
+		atomic_add(reinterpret_cast<int32 volatile*>(&fLoad), load);
 
 	if (updateLoad)
 		_UpdateLoad(true, now);
@@ -674,9 +673,9 @@ CoreEntry::RemoveLoad(int32 load, bool force, bigtime_t now)
 	ASSERT(gTrackCoreLoad);
 	ASSERT(load >= 0 && load <= kMaxLoad);
 
-	int64 oldCombined = atomic_add64(&fCombinedLoad, (int64)(-load) << 32);
+	int64 oldCombined = atomic_add64(reinterpret_cast<int64 volatile*>(&fCombinedLoad), (int64)(-load) << 32);
 	if (force) {
-		atomic_add(&fLoad, -load);
+		atomic_add(reinterpret_cast<int32 volatile*>(&fLoad), -load);
 
 		_UpdateLoad(true, now);
 	}
@@ -696,8 +695,8 @@ CoreEntry::ChangeLoad(int32 delta, bigtime_t now)
 	ASSERT(delta >= -kMaxLoad && delta <= kMaxLoad);
 
 	if (delta != 0) {
-		atomic_add64(&fCombinedLoad, (int64)delta << 32);
-		atomic_add(&fLoad, delta);
+		atomic_add64(reinterpret_cast<int64 volatile*>(&fCombinedLoad), (int64)delta << 32);
+		atomic_add(reinterpret_cast<int32 volatile*>(&fLoad), delta);
 	}
 
 	_UpdateLoad(false, now);
@@ -717,7 +716,7 @@ PackageEntry::CoreGoesIdle(CoreEntry* core)
 	WriteSpinLocker coreLocker(fCoreLock);
 	native_cpu_mask_t oldMask = scheduler_atomic_or(&fIdleCoreMask,
 		(native_cpu_mask_t)1 << core->PackageIndex());
-	atomic_add(&fIdleCoreCount, 1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fIdleCoreCount), 1);
 
 	if (oldMask == 0) {
 		// Issue 89 fix: Added explicit serialization via fCoreLock to ensure
@@ -741,7 +740,7 @@ PackageEntry::CoreWakesUp(CoreEntry* core)
 	native_cpu_mask_t clearBit = (native_cpu_mask_t)1 << core->PackageIndex();
 	native_cpu_mask_t oldMask = scheduler_atomic_and(&fIdleCoreMask, ~clearBit);
 
-	atomic_add(&fIdleCoreCount, -1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&fIdleCoreCount), -1);
 
 	// Detect the transition from fully-idle to partially-active:
 	// the package wakes up when the *last* idle core becomes active, i.e.
@@ -770,7 +769,7 @@ SchedulerNode::PackageGoesIdle(PackageEntry* package)
 		(native_cpu_mask_t)1 << package->NodeIndex());
 
 	if (oldMask == 0 && fNodeID < 64) {
-		scheduler_atomic_or64(&gIdleNodeMask, 1ULL << fNodeID);
+		scheduler_atomic_or64(reinterpret_cast<uint64 volatile*>(&gIdleNodeMask), 1ULL << fNodeID);
 	}
 }
 
@@ -815,7 +814,7 @@ SchedulerNode::PackageWakesUp(PackageEntry* package)
 			const int kMaxWakeupRetries = 64;
 			int wakeupRetries = 0;
 			while (true) {
-				nodeMask = atomic_get64((int64*)&gIdleNodeMask);
+				nodeMask = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&gIdleNodeMask)));
 				if (!(nodeMask & nodeBit))
 					break; // already cleared by a concurrent PackageWakesUp
 
@@ -826,14 +825,14 @@ SchedulerNode::PackageWakesUp(PackageEntry* package)
 					break;
 				}
 
-				if (atomic_test_and_set64((int64*)&gIdleNodeMask,
+				if (atomic_test_and_set64(reinterpret_cast<int64 volatile*>(&gIdleNodeMask),
 						nodeMask & ~nodeBit, nodeMask) == nodeMask) {
 					// Successfully cleared. Re-check for safety to catch the
 					// race where a package went idle between our last check
 					// and the CAS.
 					if (scheduler_atomic_get(&fIdlePackageMask)
 							!= (native_cpu_mask_t)0) {
-						atomic_or64((int64*)&gIdleNodeMask, nodeBit);
+						atomic_or64(reinterpret_cast<int64 volatile*>(&gIdleNodeMask), nodeBit);
 					}
 					break;
 				}
@@ -873,9 +872,9 @@ CoreEntry::CPUGoesIdle(CPUEntry* cpu)
 	// barrier between atomic_add(fIdleCPUCount) and atomic_get(fCPUCount),
 	// the CPU could observe fCPUCount before fIdleCPUCount increment is
 	// globally visible, causing a spurious PackageGoesIdle call.
-	int32 newIdleCount = atomic_add(&fIdleCPUCount, 1) + 1;
+	int32 newIdleCount = atomic_add(reinterpret_cast<int32 volatile*>(&fIdleCPUCount), 1) + 1;
 	memory_read_barrier();
-	int32 cpuCount = atomic_get(&fCPUCount);
+	int32 cpuCount = atomic_get(const_cast<int32 volatile*>(&fCPUCount));
 	if (cpuCount > 0 && newIdleCount >= cpuCount)
 		fPackage->CoreGoesIdle(this);
 }
@@ -889,7 +888,7 @@ CoreEntry::CPUWakesUp(CPUEntry* cpu)
 
 	ClearCPUIDle(gIdleMask, cpu->ID());
 
-	ASSERT(atomic_get(&fIdleCPUCount) > 0);
+	ASSERT(atomic_get(const_cast<int32 volatile*>(&fIdleCPUCount)) > 0);
 
 	IncrementTotalThreadCount();
 	// Issue 70 fix: read fCPUCount AFTER IncrementTotalThreadCount and
@@ -897,8 +896,8 @@ CoreEntry::CPUWakesUp(CPUEntry* cpu)
 	// fIdleCPUCount; by inserting the barrier we ensure we see the latest
 	// fCPUCount before comparing with the old fIdleCPUCount.
 	memory_read_barrier();
-	int32 cpuCount = atomic_get(&fCPUCount);
-	if (atomic_add(&fIdleCPUCount, -1) == cpuCount)
+	int32 cpuCount = atomic_get(const_cast<int32 volatile*>(&fCPUCount));
+	if (atomic_add(reinterpret_cast<int32 volatile*>(&fIdleCPUCount), -1) == cpuCount)
 		fPackage->CoreWakesUp(this);
 }
 
@@ -920,8 +919,8 @@ PackageEntry::IdleCoreMask() const
 	// on all supported platforms (32 on 32-bit, 64 on 64-bit).  This
 	// comment documents the assumption so it is verified if kMaxCoresPerPackage
 	// is ever changed to a non-power-of-2 value.
-	// static_assert replaced by comment for GCC 2.95
-	// (kMaxCoresPerPackage & (kMaxCoresPerPackage - 1)) == 0
+	static_assert((kMaxCoresPerPackage & (kMaxCoresPerPackage - 1)) == 0,
+		"kMaxCoresPerPackage must be a power of 2");
 	SCHEDULER_ENTER_FUNCTION();
 	return scheduler_atomic_get(&fIdleCoreMask);
 }
@@ -964,7 +963,7 @@ PackageEntry::GetLeastIdlePackage()
 			// callers dereference Package()->Node()->ID() on the result.
 			if (current->fNode == NULL)
 				continue;
-			int32 count = atomic_get((int32*)&current->fIdleCoreCount);
+			int32 count = atomic_get(const_cast<int32 volatile*>(reinterpret_cast<const int32*>(&current->fIdleCoreCount)));
 			if (count != 0 && (package == NULL || count < bestIdleCount)) {
 				package = current;
 				bestIdleCount = count;
@@ -981,7 +980,7 @@ PackageEntry::GetLeastIdlePackage()
 			// package, but we document it explicitly here.
 			if (current->fNode == NULL)
 				continue;
-			int32 count = atomic_get((int32*)&current->fIdleCoreCount);
+			int32 count = atomic_get(const_cast<int32 volatile*>(reinterpret_cast<const int32*>(&current->fIdleCoreCount)));
 			if (count != 0 && (package == NULL || count < bestIdleCount)) {
 				package = current;
 				bestIdleCount = count;
@@ -1015,7 +1014,7 @@ CoreEntry::HasHighPriorityThread() const
 	// the next reschedule corrects it - acceptable for this hint.
 	const uint32* bitmap = fRunQueue.GetBitmap();
 	for (int i = ThreadRunQueue::kBitmapSize - 1; i >= 0; i--) {
-		uint32 val = (uint32)atomic_get((int32*)&bitmap[i]);
+		uint32 val = (uint32)atomic_get(const_cast<int32 volatile*>(reinterpret_cast<const int32*>(&bitmap[i])));
 		if (i == ThreadRunQueue::kBitmapSize - 1)
 			val &= (uint32)((2ULL << (THREAD_MAX_SET_PRIORITY % 32)) - 1);
 		if (val != 0) {

--- a/src/system/kernel/scheduler/scheduler_load.cpp
+++ b/src/system/kernel/scheduler/scheduler_load.cpp
@@ -67,7 +67,7 @@ _LoadavgUpdate(void *data, int iteration)
 	// If sub-second load visibility is required in the future, the daemon
 	// period must be reduced and sCExp recalibrated accordingly.
 	// Optimization: Use global atomic counter instead of O(N) core scan.
-	int32 threadCount = atomic_get(&gTotalRunnableThreads);
+	int32 threadCount = atomic_get(const_cast<int32 volatile*>(&gTotalRunnableThreads));
 	if (threadCount < 0)
 		threadCount = 0;
 
@@ -79,7 +79,7 @@ _LoadavgUpdate(void *data, int iteration)
 		// Clamp the result to B_INT32_MAX (a sane upper bound: no system has
 		// 2^31 runnable threads).  The FreeBSD algorithm assumes the same
 		// practical bound.
-		// GCC 2.95 compatibility: use uint64; intermediate fits in 64 bits.
+		// Modern GCC optimization: use uint64; intermediate fits in 64 bits.
 		uint64 acc =
 			(uint64)sCExp[i] * sAverageRunnable.ldavg[i]
 			+ (uint64)threadCount * (kFScale - sCExp[i]) * kFScale;

--- a/src/system/kernel/scheduler/scheduler_profiler.cpp
+++ b/src/system/kernel/scheduler/scheduler_profiler.cpp
@@ -107,7 +107,7 @@ Profiler::EnterFunction(int32 cpu, const char* functionName)
 		return false;
 
 	// Only count the call after we know we can successfully profile it.
-	atomic_add(&function->fCalled, 1);
+	atomic_add(reinterpret_cast<int32 volatile*>(&function->fCalled), 1);
 	fFunctionStackPointers[cpu]++;
 	FunctionEntry* stackEntry = &fFunctionStacks[cpu][stackDepth];
 
@@ -149,8 +149,8 @@ Profiler::ExitFunction(int32 cpu, const char* functionName)
 
 	// Optimization: Store in nanoseconds to maintain precision for low-latency tasks.
 	// Division by 1000 moved to the _Dump function.
-	atomic_add64(&stackEntry->fFunction->fTimeInclusive, timeSpent);
-	atomic_add64(&stackEntry->fFunction->fTimeExclusive,
+	atomic_add64(reinterpret_cast<int64 volatile*>(&stackEntry->fFunction->fTimeInclusive), timeSpent);
+	atomic_add64(reinterpret_cast<int64 volatile*>(&stackEntry->fFunction->fTimeExclusive),
 		(timeSpent - stackEntry->fOthersTime));
 
 	nanotime_t profilerTime = stackEntry->fProfilerTime;

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -34,12 +34,12 @@ bigtime_t ThreadData::sMaxLatency __attribute__((aligned(8)));
 void
 ThreadData::_InitBase()
 {
-	atomic_set64((int64*)&fStolenTime, 0);
-	atomic_set64((int64*)&fQuantumStart, 0);
-	atomic_set64((int64*)&fLastInterruptTime, 0);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fStolenTime), 0);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fQuantumStart), 0);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fLastInterruptTime), 0);
 
-	atomic_set64((int64*)&fWentSleep, 0);
-	atomic_set64((int64*)&fWentSleepActive, 0);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fWentSleep), 0);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fWentSleepActive), 0);
 
 	fEnqueued = false;
 	fEnqueuedInCPURunQueue = false;
@@ -49,18 +49,18 @@ ThreadData::_InitBase()
 	fHomePackage = -1;
 
 	fEffectivePriority = GetPriority();
-	atomic_set64((int64*)&fBaseQuantum,
-		atomic_get64(&sQuantumLengths[min_c(GetEffectivePriority(),
-			THREAD_MAX_SET_PRIORITY)]));
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fBaseQuantum),
+		atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&sQuantumLengths[min_c(GetEffectivePriority(),
+			THREAD_MAX_SET_PRIORITY)]))));
 
-	atomic_set64((int64*)&fTimeUsed, 0);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fTimeUsed), 0);
 
-	atomic_set64((int64*)&fMeasureAvailableActiveTime, 0);
-	atomic_set64((int64*)&fLastMeasureAvailableTime, 0);
-	atomic_set64((int64*)&fMeasureAvailableTime, 0);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fMeasureAvailableActiveTime), 0);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fLastMeasureAvailableTime), 0);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fMeasureAvailableTime), 0);
 
-	atomic_set64((int64*)&fVirtualRuntime, 0);
-	atomic_set64((int64*)&fVirtualDeadline, 0);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fVirtualRuntime), 0);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fVirtualDeadline), 0);
 
 	fInteractivityScore = 500;
 
@@ -170,11 +170,11 @@ ThreadData::Init(bigtime_t now)
 		bigtime_t vrt __attribute__((aligned(8)));
 		int retries = 0;
 		do {
-			homeA = atomic_get(&currentThreadData->fHomePackage);
+			homeA = atomic_get(const_cast<int32 volatile*>(&currentThreadData->fHomePackage));
 			memory_read_barrier();
-			vrt = atomic_get64((int64*)&currentThreadData->fVirtualRuntime);
+			vrt = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&currentThreadData->fVirtualRuntime)));
 			memory_read_barrier();
-			homeB = atomic_get(&currentThreadData->fHomePackage);
+			homeB = atomic_get(const_cast<int32 volatile*>(&currentThreadData->fHomePackage));
 		} while (homeA != homeB && ++retries < 8);
 
 		if (homeA != homeB) {
@@ -183,12 +183,12 @@ ThreadData::Init(bigtime_t now)
 			homeB = -1;
 		}
 
-		atomic_set64((int64*)&fVirtualRuntime, vrt);
-		atomic_set(&fHomePackage, homeB);
+		atomic_set64(reinterpret_cast<int64 volatile*>(&fVirtualRuntime), vrt);
+		atomic_set(reinterpret_cast<int32 volatile*>(&fHomePackage), homeB);
 	} else {
 		fNeededLoad = 0;
-		atomic_set64((int64*)&fVirtualRuntime, 0);
-		atomic_set(&fHomePackage, -1);
+		atomic_set64(reinterpret_cast<int64 volatile*>(&fVirtualRuntime), 0);
+		atomic_set(reinterpret_cast<int32 volatile*>(&fHomePackage), -1);
 	}
 
 	if (!IsRealTime()) {
@@ -217,16 +217,16 @@ ThreadData::Dump() const
 	kprintf("\teffective_priority:\t%" B_PRId32 "\n", GetEffectivePriority());
 
 	kprintf("\ttime_used:\t\t%" B_PRId64 " us (quantum: %" B_PRId64 " us)\n",
-		atomic_get64((int64*)&fTimeUsed), ComputeQuantum());
+		atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fTimeUsed))), ComputeQuantum());
 	kprintf("\tstolen_time:\t\t%" B_PRId64 " us\n",
-		atomic_get64((int64*)&fStolenTime));
+		atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fStolenTime))));
 	kprintf("\tquantum_start:\t\t%" B_PRId64 " us\n",
-		atomic_get64((int64*)&fQuantumStart));
+		atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fQuantumStart))));
 	kprintf("\tneeded_load:\t\t%" B_PRId32 "%%\n", fNeededLoad / 10);
 	kprintf("\twent_sleep:\t\t%" B_PRId64 "\n",
-		atomic_get64((int64*)&fWentSleep));
+		atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fWentSleep))));
 	kprintf("\twent_sleep_active:\t%" B_PRId64 "\n",
-		atomic_get64((int64*)&fWentSleepActive));
+		atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fWentSleepActive))));
 	kprintf("\tinteractivity_score:\t%" B_PRId32 "\n", fInteractivityScore);
 
 	CoreEntry* core = Core();
@@ -360,7 +360,7 @@ ThreadData::ComputeQuantum() const
 	SCHEDULER_ENTER_FUNCTION();
 
 	if (IsRealTime())
-		return atomic_get64((int64*)&fBaseQuantum);
+		return atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fBaseQuantum)));
 
 	// Issue 11 fix: ComputeQuantum is only called while the caller holds
 	// SchedulerModeLocker (a read lock on CPUEntry::fSchedulerModeLock).
@@ -504,9 +504,9 @@ ThreadData::ComputeQuantumLengths()
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	atomic_set64(&sMaxLatency, Scheduler::MaximumLatency());
+	atomic_set64(reinterpret_cast<int64 volatile*>(&sMaxLatency), Scheduler::MaximumLatency());
 
-	const bigtime_t kBaseSlice = atomic_get64(&Scheduler::gDeadlineBucketSize);
+	const bigtime_t kBaseSlice = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&Scheduler::gDeadlineBucketSize)));
 	const bigtime_t kQuantum0 = Scheduler::BaseQuantum();
 	const bigtime_t kQuantum1 = kQuantum0 * Scheduler::QuantumMultiplier(0);
 	const bigtime_t kQuantum2 = kQuantum0 * Scheduler::QuantumMultiplier(1);
@@ -515,17 +515,17 @@ ThreadData::ComputeQuantumLengths()
 		const int32 kBaseWeight = 10;
 		int32 taskWeight = max_c(1, priority);
 
-		atomic_set64(&sVirtualDeadlineSlices[priority],
+		atomic_set64(reinterpret_cast<int64 volatile*>(&sVirtualDeadlineSlices[priority]),
 			kBaseSlice * kBaseWeight / taskWeight);
 
 		if (priority >= B_URGENT_DISPLAY_PRIORITY) {
-			atomic_set64(&sQuantumLengths[priority], kQuantum0);
+			atomic_set64(reinterpret_cast<int64 volatile*>(&sQuantumLengths[priority]), kQuantum0);
 		} else if (priority > B_NORMAL_PRIORITY) {
-			atomic_set64(&sQuantumLengths[priority],
+			atomic_set64(reinterpret_cast<int64 volatile*>(&sQuantumLengths[priority]),
 				_ScaleQuantum(kQuantum1, kQuantum0, B_URGENT_DISPLAY_PRIORITY,
 					B_NORMAL_PRIORITY, priority));
 		} else {
-			atomic_set64(&sQuantumLengths[priority],
+			atomic_set64(reinterpret_cast<int64 volatile*>(&sQuantumLengths[priority]),
 				_ScaleQuantum(kQuantum2, kQuantum1, B_NORMAL_PRIORITY,
 					B_IDLE_PRIORITY, priority));
 		}
@@ -547,12 +547,12 @@ ThreadData::DonateTimesliceTo(Thread* beneficiary, bigtime_t now)
 	if (now == 0)
 		now = system_time();
 
-	bigtime_t timeUsed = now - atomic_get64((int64*)&fQuantumStart);
+	bigtime_t timeUsed = now - atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fQuantumStart)));
 	ASSERT(timeUsed >= 0);
-	atomic_add64((int64*)&fTimeUsed, timeUsed);
+	atomic_add64(reinterpret_cast<int64 volatile*>(&fTimeUsed), timeUsed);
 
 	bigtime_t quantum = ComputeQuantum();
-	bigtime_t timeLeft = quantum - atomic_get64((int64*)&fTimeUsed);
+	bigtime_t timeLeft = quantum - atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fTimeUsed)));
 	if (timeLeft > 0) {
 		// Donate remaining slice to the beneficiary.
 		// Callers MUST NOT hold any run-queue spinlock when invoking this
@@ -566,13 +566,13 @@ ThreadData::DonateTimesliceTo(Thread* beneficiary, bigtime_t now)
 		// are already disabled by the caller's contract.
 		ASSERT(!are_interrupts_enabled());
 		SpinLocker locker(beneficiary->scheduler_lock);
-		atomic_add64((int64*)&beneficiaryData->fStolenTime, timeLeft);
+		atomic_add64(reinterpret_cast<int64 volatile*>(&beneficiaryData->fStolenTime), timeLeft);
 	}
 
 	// Exhaust donor slice: we expect the donor to yield or be descheduled
 	// immediately after this call to prevent double-dipping.
-	atomic_set64((int64*)&fQuantumStart, now);
-	atomic_set64((int64*)&fTimeUsed, quantum);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fQuantumStart), now);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fTimeUsed), quantum);
 }
 
 void
@@ -587,16 +587,16 @@ ThreadData::_ComputeNeededLoad(bigtime_t now)
 	bigtime_t measureActiveTime __attribute__((aligned(8)));
 	int32 oldLoad;
 	do {
-		bigtime_t lastMeasureTime = atomic_get64((int64*)&fLastMeasureAvailableTime);
-		measureActiveTime = atomic_get64((int64*)&fMeasureAvailableActiveTime);
+		bigtime_t lastMeasureTime = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fLastMeasureAvailableTime)));
+		measureActiveTime = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fMeasureAvailableActiveTime)));
 		bigtime_t tempLastMeasureTime = lastMeasureTime;
 		bigtime_t tempMeasureActiveTime = measureActiveTime;
 		oldLoad = compute_load(tempLastMeasureTime, tempMeasureActiveTime, fNeededLoad,
 			now);
 		if (oldLoad < 0)
 			break;
-		if (atomic_test_and_set64((int64*)&fMeasureAvailableActiveTime, tempMeasureActiveTime, measureActiveTime) == measureActiveTime) {
-			atomic_set64((int64*)&fLastMeasureAvailableTime, tempLastMeasureTime);
+		if (atomic_test_and_set64(reinterpret_cast<int64 volatile*>(&fMeasureAvailableActiveTime), tempMeasureActiveTime, measureActiveTime) == measureActiveTime) {
+			atomic_set64(reinterpret_cast<int64 volatile*>(&fLastMeasureAvailableTime), tempLastMeasureTime);
 			break;
 		}
 	} while (true);
@@ -647,7 +647,7 @@ ThreadData::_UpdateDeadline(bigtime_t now)
 	if (priority > THREAD_MAX_SET_PRIORITY)
 		priority = THREAD_MAX_SET_PRIORITY;
 
-	bigtime_t slice = atomic_get64(&sVirtualDeadlineSlices[priority]);
+	bigtime_t slice = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&sVirtualDeadlineSlices[priority])));
 
 	// Scale virtual deadline slice by interactivity (bursty threads get shorter slices)
 	// Fast integer approximation of / 1000 (1049 / 2^20 ~= 0.0010004)
@@ -677,7 +677,7 @@ ThreadData::_UpdateDeadline(bigtime_t now)
 			slice = kMinSlice;
 	}
 
-	atomic_set64((int64*)&fVirtualDeadline, now + slice);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fVirtualDeadline), now + slice);
 
 	_ComputeEffectivePriority(now);
 }
@@ -689,14 +689,14 @@ ThreadData::_ComputeEffectivePriority(bigtime_t now) const
 
 	// Cache bucket size: avoids redundant atomic reads on this hot path.
 	// The value is effectively constant within a scheduling decision.
-	const bigtime_t bucketSize = atomic_get64(&Scheduler::gDeadlineBucketSize);
+	const bigtime_t bucketSize = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&Scheduler::gDeadlineBucketSize)));
 
 	// Issue 14 fix: guard against division-by-zero if bucketSize is 0.
 	// This can occur transiently during mode initialisation before
 	// ComputeQuantumLengths() sets gDeadlineBucketSize to a positive value.
 	if (bucketSize <= 0) {
 		fEffectivePriority = GetPriority();
-		atomic_set64((int64*)&fBaseQuantum, Scheduler::MinimalQuantum());
+		atomic_set64(reinterpret_cast<int64 volatile*>(&fBaseQuantum), Scheduler::MinimalQuantum());
 		return;
 	}
 
@@ -710,7 +710,7 @@ ThreadData::_ComputeEffectivePriority(bigtime_t now) const
 		// If Deadline is Now (or passed), Urgency is Max.
 		// If Deadline is far, Urgency is 0.
 
-		bigtime_t diff = atomic_get64((int64*)&fVirtualDeadline) - now;
+		bigtime_t diff = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fVirtualDeadline))) - now;
 
 		// Adaptive Urgency Boost: give bursty threads higher urgency.
 		bigtime_t urgencyBoost = (fInteractivityScore * bucketSize) / 1000;
@@ -744,8 +744,8 @@ ThreadData::_ComputeEffectivePriority(bigtime_t now) const
 		}
 
 		const int32 kMaxDynamicPriority = B_FIRST_REAL_TIME_PRIORITY - 1;
-		// static_assert replaced by comment for GCC 2.95
-		// kMaxDynamicPriority <= THREAD_MAX_SET_PRIORITY
+		static_assert(kMaxDynamicPriority <= THREAD_MAX_SET_PRIORITY,
+			"kMaxDynamicPriority exceeds maximum thread priority");
 
 		bigtime_t urgency = kMaxDynamicPriority - diff / bucketSize;
 		if (urgency < 0) urgency = 0;
@@ -760,8 +760,8 @@ ThreadData::_ComputeEffectivePriority(bigtime_t now) const
 		fEffectivePriority = (int32)urgency;
 	}
 
-	atomic_set64((int64*)&fBaseQuantum,
-		atomic_get64(&sQuantumLengths[GetEffectivePriority()]));
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fBaseQuantum),
+		atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&sQuantumLengths[GetEffectivePriority()]))));
 }
 
 /* static */ bigtime_t

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -100,7 +100,7 @@ public:
 							CPUEntry*& targetCPU, bigtime_t now = 0);
 
 	SCHEDULER_INLINE	void		SetLastInterruptTime(bigtime_t interruptTime)
-							{ atomic_set64((int64*)&fLastInterruptTime, interruptTime); }
+							{ atomic_set64(reinterpret_cast<int64 volatile*>(&fLastInterruptTime), interruptTime); }
 	SCHEDULER_INLINE	void		SetStolenInterruptTime(bigtime_t interruptTime);
 
 			bigtime_t	ComputeQuantum() const;
@@ -120,12 +120,12 @@ public:
 
 	SCHEDULER_INLINE	bigtime_t	WentSleep() const
 	{
-		return atomic_get64((int64*)&fWentSleep);
+		return atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fWentSleep)));
 	}
 
 	SCHEDULER_INLINE	bigtime_t	WentSleepActive() const
 	{
-		return atomic_get64((int64*)&fWentSleepActive);
+		return atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fWentSleepActive)));
 	}
 
 	// PutBack() and Enqueue() accept an optional 'now' timestamp for
@@ -150,12 +150,12 @@ public:
 
 	SCHEDULER_INLINE	bigtime_t	GetVirtualRuntime() const
 	{
-		return atomic_get64((int64*)&fVirtualRuntime);
+		return atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&fVirtualRuntime)));
 	}
 
 	SCHEDULER_INLINE	void		SetQuantum(bigtime_t quantum)
 	{
-		atomic_set64((int64*)&fBaseQuantum, quantum);
+		atomic_set64(reinterpret_cast<int64 volatile*>(&fBaseQuantum), quantum);
 	}
 
 	SCHEDULER_INLINE	bool		IsEnqueued() const	{ return fEnqueued; }
@@ -231,7 +231,7 @@ private:
 
 			int32		fInteractivityScore;
 
-			CoreEntry*	fCore;
+			CoreEntry*	fCore __attribute__((aligned(8)));
 };
 
 class ThreadProcessing {
@@ -396,14 +396,14 @@ ThreadData::SetStolenInterruptTime(bigtime_t interruptTime)
 {
 	SCHEDULER_ENTER_FUNCTION();
 
-	bigtime_t delta = interruptTime - atomic_get64((int64*)&fLastInterruptTime);
+	bigtime_t delta = interruptTime - atomic_get64(reinterpret_cast<int64 volatile*>(&fLastInterruptTime));
 	// Issue 94 fix: if interrupt_time goes backward (e.g. CPU accounting
 	// reset or wrap), delta is negative and fLastInterruptTime must be
 	// reset to the current interruptTime to restore correct accounting.
 	// Otherwise fLastInterruptTime stays at a "future" value permanently
 	// suppressing all stolen-time accounting for this thread.
 	if (delta > 0) {
-		atomic_add64((int64*)&fStolenTime, delta);
+		atomic_add64(reinterpret_cast<int64 volatile*>(&fStolenTime), delta);
 	} else if (delta < 0) {
 		// Clock went backward; reset baseline to avoid permanent suppression.
 		// Do not add the negative delta - the time is simply unaccountable.
@@ -423,10 +423,10 @@ ThreadData::GetQuantumLeft()
 
 	bigtime_t stolenTime __attribute__((aligned(8)));
 	do {
-		stolenTime = atomic_get64((int64*)&fStolenTime);
-	} while (atomic_test_and_set64((int64*)&fStolenTime, 0, stolenTime) != stolenTime);
+		stolenTime = atomic_get64(reinterpret_cast<int64 volatile*>(&fStolenTime));
+	} while (atomic_test_and_set64(reinterpret_cast<int64 volatile*>(&fStolenTime), 0, stolenTime) != stolenTime);
 
-	bigtime_t quantum = ComputeQuantum() - atomic_get64((int64*)&fTimeUsed);
+	bigtime_t quantum = ComputeQuantum() - atomic_get64(reinterpret_cast<int64 volatile*>(&fTimeUsed));
 	quantum += stolenTime;
 	quantum = max_c(quantum, Scheduler::MinimalQuantum());
 	if (quantum > Scheduler::MaximumLatency())
@@ -440,7 +440,7 @@ inline void
 ThreadData::StartQuantum(bigtime_t now)
 {
 	SCHEDULER_ENTER_FUNCTION();
-	atomic_set64((int64*)&fQuantumStart, now);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fQuantumStart), now);
 }
 
 
@@ -452,23 +452,23 @@ ThreadData::HasQuantumEnded(bool wasPreempted, bool hasYielded, bigtime_t now)
 	if (now == 0)
 		now = system_time();
 
-	bigtime_t timeUsed = now - atomic_get64((int64*)&fQuantumStart);
+	bigtime_t timeUsed = now - atomic_get64(reinterpret_cast<int64 volatile*>(&fQuantumStart));
 	ASSERT(timeUsed >= 0);
 	// Issue 68 fix: cap fTimeUsed accumulation. Under extremely rapid
 	// rescheduling, fTimeUsed can accumulate to near B_INT64_MAX before the
 	// quantum-end check fires. When that happens, quantum - fTimeUsed
 	// underflows to a large positive, granting an unintended stolen-time
 	// bonus. Cap at 2 * MaximumLatency() as a generous but safe upper bound.
-	bigtime_t timeUsedTotal = atomic_add64((int64*)&fTimeUsed, timeUsed) + timeUsed;
+	bigtime_t timeUsedTotal = atomic_add64(reinterpret_cast<int64 volatile*>(&fTimeUsed), timeUsed) + timeUsed;
 	const bigtime_t kMaxTimeUsed = Scheduler::MaximumLatency() * 2;
 	if (timeUsedTotal > kMaxTimeUsed) {
 		timeUsedTotal = kMaxTimeUsed;
-		atomic_set64((int64*)&fTimeUsed, kMaxTimeUsed);
+		atomic_set64(reinterpret_cast<int64 volatile*>(&fTimeUsed), kMaxTimeUsed);
 	}
 
 	bigtime_t quantum = ComputeQuantum();
 	if (timeUsedTotal >= quantum) {
-		atomic_set64((int64*)&fTimeUsed, 0);
+		atomic_set64(reinterpret_cast<int64 volatile*>(&fTimeUsed), 0);
 		_UpdateDeadline(now);
 		return true;
 	}
@@ -482,7 +482,7 @@ ThreadData::HasQuantumEnded(bool wasPreempted, bool hasYielded, bigtime_t now)
 		timeLeft = 0;
 		fInteractivityScore = min_c(fInteractivityScore + 20, 1000);
 	} else if (wasPreempted || timeLeft <= skipTime) {
-		atomic_add64((int64*)&fStolenTime, timeLeft);
+		atomic_add64(reinterpret_cast<int64 volatile*>(&fStolenTime), timeLeft);
 		timeLeft = 0;
 
 		if (!wasPreempted) {
@@ -492,7 +492,7 @@ ThreadData::HasQuantumEnded(bool wasPreempted, bool hasYielded, bigtime_t now)
 	}
 
 	if (timeLeft == 0) {
-		atomic_set64((int64*)&fTimeUsed, 0);
+		atomic_set64(reinterpret_cast<int64 volatile*>(&fTimeUsed), 0);
 		_UpdateDeadline(now);
 		return true;
 	}
@@ -533,15 +533,15 @@ ThreadData::GoesAway(bigtime_t now)
 		now = system_time();
 
 	if (!IsIdle()) {
-		int32 prev = atomic_add(&gTotalRunnableThreads, -1);
+		int32 prev = atomic_add(reinterpret_cast<int32 volatile*>(&gTotalRunnableThreads), -1);
 		if (prev <= 0) {
-			int32 cur = atomic_get(&gTotalRunnableThreads);
+			int32 cur = atomic_get(reinterpret_cast<int32 volatile*>(&gTotalRunnableThreads));
 			for (int32 i = 0; i < 100 && cur < 0; i++) {
 				int32 was = cur;
-				if (atomic_test_and_set(&gTotalRunnableThreads, 0, was) == was) {
+				if (atomic_test_and_set(reinterpret_cast<int32 volatile*>(&gTotalRunnableThreads), 0, was) == was) {
 					break;
 				}
-				cur = atomic_get(&gTotalRunnableThreads);
+				cur = atomic_get(reinterpret_cast<int32 volatile*>(&gTotalRunnableThreads));
 				memory_read_barrier();
 			}
 		}
@@ -558,9 +558,9 @@ ThreadData::GoesAway(bigtime_t now)
 		fInteractivityScore = min_c(fInteractivityScore + 10, 1000);
 	}
 
-	atomic_set64((int64*)&fLastInterruptTime, 0);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fLastInterruptTime), 0);
 
-	atomic_set64((int64*)&fWentSleep, now);
+	atomic_set64(reinterpret_cast<int64 volatile*>(&fWentSleep), now);
 	// Issue 7 fix: fCore can be set to NULL by a concurrent MigrateTo() call.
 	// The original code checked for NULL once then called GetActiveTime() and
 	// RemoveLoad() in separate statements - if fCore became NULL between the
@@ -571,8 +571,8 @@ ThreadData::GoesAway(bigtime_t now)
 	// SchedulerModeLocker (read). These are different locks, so the race
 	// is real. The snapshot approach is the minimal safe fix.
 	{
-		CoreEntry* const snap = atomic_pointer_get<CoreEntry>(&fCore);
-		atomic_set64((int64*)&fWentSleepActive, (snap != NULL) ? snap->GetActiveTime() : 0);
+		CoreEntry* const snap = atomic_pointer_get<CoreEntry>(const_cast<CoreEntry* volatile*>(&fCore));
+		atomic_set64(reinterpret_cast<int64 volatile*>(&fWentSleepActive), (snap != NULL) ? snap->GetActiveTime() : 0);
 		if (gTrackCoreLoad && snap != NULL)
 			fLoadMeasurementEpoch = snap->RemoveLoad(fNeededLoad, false, now);
 	}
@@ -591,15 +591,15 @@ ThreadData::Dies(bigtime_t now)
 		now = system_time();
 
 	if (!IsIdle()) {
-		int32 prev = atomic_add(&gTotalRunnableThreads, -1);
+		int32 prev = atomic_add(reinterpret_cast<int32 volatile*>(&gTotalRunnableThreads), -1);
 		if (prev <= 0) {
-			int32 cur = atomic_get(&gTotalRunnableThreads);
+			int32 cur = atomic_get(reinterpret_cast<int32 volatile*>(&gTotalRunnableThreads));
 			for (int32 i = 0; i < 100 && cur < 0; i++) {
 				int32 was = cur;
-				if (atomic_test_and_set(&gTotalRunnableThreads, 0, was) == was) {
+				if (atomic_test_and_set(reinterpret_cast<int32 volatile*>(&gTotalRunnableThreads), 0, was) == was) {
 					break;
 				}
-				cur = atomic_get(&gTotalRunnableThreads);
+				cur = atomic_get(reinterpret_cast<int32 volatile*>(&gTotalRunnableThreads));
 				memory_read_barrier();
 			}
 		}
@@ -686,7 +686,7 @@ ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption,
 			// CPUCount guard in the non-pinned path (see below).  For the pinned
 			// path the CPU liveness check happens under CPURunQueueLocker.
 			if (!wasReady && !IsIdle())
-				atomic_add(&gTotalRunnableThreads, 1);
+				atomic_add(reinterpret_cast<int32 volatile*>(&gTotalRunnableThreads), 1);
 
 			fReady = true;
 			fThread->state = B_THREAD_READY;
@@ -746,12 +746,12 @@ ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption,
 			}
 			// Issue 41 fix: AddLoad happens here, after all early-return guards.
 			if (gTrackCoreLoad && !wasReady) {
-				bigtime_t timeSlept = now - atomic_get64((int64*)&fWentSleep);
+				bigtime_t timeSlept = now - atomic_get64(reinterpret_cast<int64 volatile*>(&fWentSleep));
 				bool updateLoad = timeSlept > 0;
 				core->AddLoad(fNeededLoad, fLoadMeasurementEpoch, !updateLoad,
 					now);
 				if (updateLoad) {
-					atomic_add64((int64*)&fMeasureAvailableTime, timeSlept);
+					atomic_add64(reinterpret_cast<int64 volatile*>(&fMeasureAvailableTime), timeSlept);
 					_ComputeNeededLoad(now);
 				}
 			}
@@ -762,11 +762,11 @@ ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption,
 		} else if (!wasReady && gTrackCoreLoad) {
 			// Issue 41 fix: for non-stolen threads, AddLoad after CPUCount guard.
 			// Issue 99: ensure AddLoad captures the full sleep time when a thread is woken up.
-			bigtime_t timeSlept = now - atomic_get64((int64*)&fWentSleep);
+			bigtime_t timeSlept = now - atomic_get64(reinterpret_cast<int64 volatile*>(&fWentSleep));
 			bool updateLoad = timeSlept > 0;
 			core->AddLoad(fNeededLoad, fLoadMeasurementEpoch, !updateLoad, now);
 			if (updateLoad) {
-				atomic_add64((int64*)&fMeasureAvailableTime, timeSlept);
+				atomic_add64(reinterpret_cast<int64 volatile*>(&fMeasureAvailableTime), timeSlept);
 				_ComputeNeededLoad(now);
 			}
 		}
@@ -777,7 +777,7 @@ ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption,
 		// defer the gTotalRunnableThreads increment until after the
 		// CPUCount guard in the non-pinned path.
 		if (!wasReady && !IsIdle())
-			atomic_add(&gTotalRunnableThreads, 1);
+			atomic_add(reinterpret_cast<int32 volatile*>(&gTotalRunnableThreads), 1);
 
 		fReady = true;
 		fThread->state = B_THREAD_READY;
@@ -855,7 +855,7 @@ ThreadData::UpdateVirtualRuntime(bigtime_t delta, bigtime_t now,
 
 	// Optimization: Pre-calculate lookahead horizon
 	if (maxLatency == 0)
-		maxLatency = atomic_get64(&sMaxLatency);
+		maxLatency = atomic_get64(const_cast<int64 volatile*>(reinterpret_cast<const int64*>(&sMaxLatency)));
 	const bigtime_t kLookahead = maxLatency * 1000LL;
 
 	if (now == 0) {
@@ -868,7 +868,7 @@ ThreadData::UpdateVirtualRuntime(bigtime_t delta, bigtime_t now,
 		? B_INT64_MAX : now + kLookahead;
 
 	const bigtime_t threshold = ceiling - delta;
-	bigtime_t vRuntime = atomic_get64((int64*)&fVirtualRuntime);
+	bigtime_t vRuntime = atomic_get64(reinterpret_cast<int64 volatile*>(&fVirtualRuntime));
 
 	while (true) {
 		bigtime_t next;
@@ -880,7 +880,7 @@ ThreadData::UpdateVirtualRuntime(bigtime_t delta, bigtime_t now,
 			break;
 
 		// Optimization: Reuse the value returned by the CAS if it fails
-		bigtime_t old = atomic_test_and_set64((int64*)&fVirtualRuntime,
+		bigtime_t old = atomic_test_and_set64(reinterpret_cast<int64 volatile*>(&fVirtualRuntime),
 			next, vRuntime);
 		if (old == vRuntime)
 			break;
@@ -904,8 +904,8 @@ ThreadData::UpdateActivity(bigtime_t active, bigtime_t now)
 	if (!gTrackCoreLoad)
 		return;
 
-	atomic_add64((int64*)&fMeasureAvailableTime, active);
-	atomic_add64((int64*)&fMeasureAvailableActiveTime, active);
+	atomic_add64(reinterpret_cast<int64 volatile*>(&fMeasureAvailableTime), active);
+	atomic_add64(reinterpret_cast<int64 volatile*>(&fMeasureAvailableActiveTime), active);
 }
 
 

--- a/src/system/kernel/scheduler/scheduling_analysis.cpp
+++ b/src/system/kernel/scheduler/scheduling_analysis.cpp
@@ -310,25 +310,25 @@ public:
 		size = (size + 7) & ~(size_t)7;
 		for (int32 i = 0; i < 1000; i++) {
 #if B_HAIKU_64_BIT
-			int64 current = (int64)atomic_get64((int64*)&fNextAllocation);
+			int64 current = (int64)atomic_get64(reinterpret_cast<int64 volatile*>(&fNextAllocation));
 			int64 newAlloc = current + (int64)size;
 			int64 hashTableAddr = (int64)(uintptr_t)fHashTable;
 			if (newAlloc > hashTableAddr)
 				return NULL;
-			if (atomic_test_and_set64((int64*)&fNextAllocation, newAlloc, current)
+			if (atomic_test_and_set64(reinterpret_cast<int64 volatile*>(&fNextAllocation), newAlloc, current)
 					== current) {
-				atomic_add64((int64*)&fRemainingBytes, -(int64)size);
+				atomic_add64(reinterpret_cast<int64 volatile*>(&fRemainingBytes), -(int64)size);
 				return (void*)(uintptr_t)current;
 			}
 #else
-			int32 current32 = atomic_get((int32*)&fNextAllocation);
+			int32 current32 = atomic_get(reinterpret_cast<int32 volatile*>(&fNextAllocation));
 			int32 newAlloc32 = current32 + (int32)size;
 			int32 hashTableAddr32 = (int32)(uintptr_t)fHashTable;
 			if (size > (size_t)B_INT32_MAX || newAlloc32 > hashTableAddr32)
 				return NULL;
-			if (atomic_test_and_set((int32*)&fNextAllocation, newAlloc32, current32)
+			if (atomic_test_and_set(reinterpret_cast<int32 volatile*>(&fNextAllocation), newAlloc32, current32)
 					== current32) {
-				atomic_add((int32*)&fRemainingBytes, -(int32)size);
+				atomic_add(reinterpret_cast<int32 volatile*>(&fRemainingBytes), -(int32)size);
 				return (void*)(uintptr_t)current32;
 			}
 #endif


### PR DESCRIPTION
Extensive audit and modernization of the Haiku scheduler for GCC 13 and architecture independence.

Key changes:
1. **GCC 13 & Atomic Safety**: Replaced fragile C-style casts in atomic operations with explicit `reinterpret_cast<T volatile*>` and `const_cast`. This ensures the compiler correctly handles shared state and complies with strict pointer conversion rules in modern GCC.
2. **Modern Built-ins**: Replaced manual bit manipulation loops and legacy GCC 2.95 workarounds with efficient GCC intrinsics like `__builtin_popcountll`, `__builtin_ctzll`, and `__builtin_ffsll`.
3. **32/64-bit Portability**: Enforced 8-byte alignment (`__attribute__((aligned(8)))`) for all 64-bit variables used in atomic operations (e.g., `fStolenTime`, `fCombinedLoad`, `gIdleMask`), ensuring stability on 32-bit architectures.
4. **Static Asserts**: Replaced legacy comments with standard C++ `static_assert` to catch configuration and invariant violations at compile time.
5. **Logic Improvements**: Updated `ThreadDataVRuntimeCompare` to use standard signed subtraction for virtual runtime comparisons, providing robust wrap-around handling.

This patch improves the performance, safety, and maintainability of the scheduler across all supported Haiku architectures.

---
*PR created automatically by Jules for task [17303432264408592385](https://jules.google.com/task/17303432264408592385) started by @tonestone57*