### PR TITLE
Improve scheduler boost scalability and RunQueue efficiency

### DIFF
--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -103,6 +103,10 @@ public:
 
 	void Remove(Element* element);
 
+private:
+	void _PushPriority(Element* element, unsigned int priority, bool front);
+	void _RemovePriority(Element* element, unsigned int priority);
+
 	inline int32 Count() const { return LoadAcquire(fTotalCount); }
 
 	class ConstIterator {
@@ -233,24 +237,8 @@ void RUN_QUEUE_CLASS_NAME::PushBack(Element* element, unsigned int priority, big
 	RunQueueLink<Element>* link = sGetLink(element);
 	link->fPriority = priority;
 
-	if (priority <= MaxPriority) {
-		if (fPriorityCounts[priority]++ == 0) {
-			fBitmap[priority / 32] |= (1U << (priority % 32));
-			fPriorityHeads[priority] = element;
-			link->fNext = element;
-			link->fPrev = element;
-		} else {
-			Element* head = fPriorityHeads[priority];
-			RunQueueLink<Element>* headLink = sGetLink(head);
-			Element* tail = headLink->fPrev;
-			RunQueueLink<Element>* tailLink = sGetLink(tail);
-
-			link->fNext = head;
-			link->fPrev = tail;
-			tailLink->fNext = element;
-			headLink->fPrev = element;
-		}
-	}
+	if (priority <= MaxPriority)
+		_PushPriority(element, priority, false);
 
 	Traits::SetInRunQueue(element, true);
 
@@ -279,7 +267,37 @@ void RUN_QUEUE_CLASS_NAME::PushBack(Element* element, unsigned int priority, big
 
 RUN_QUEUE_TEMPLATE_LIST
 void RUN_QUEUE_CLASS_NAME::PushFront(Element* element, unsigned int priority, bigtime_t svt) {
-	PushBack(element, priority, svt);
+	SCHEDULER_ENTER_FUNCTION();
+
+	RunQueueLink<Element>* link = sGetLink(element);
+	link->fPriority = priority;
+
+	if (priority <= MaxPriority)
+		_PushPriority(element, priority, true);
+
+	Traits::SetInRunQueue(element, true);
+
+	if (element->IsRealTime() || element->IsIdle() || element->IsEligible(svt)) {
+		if (fEligibleCount >= kMaxThreadsPerCore) {
+			panic("scheduler: eligible heap overflow (count=%d)", fEligibleCount);
+		}
+		AddAcquireRelease(fTotalCount, 1);
+		int32 idx = fEligibleCount;
+		fEligibleHeap[idx] = element;
+		link->fIndex = idx;
+		_BubbleUp(fEligibleHeap, idx + 1, idx, true);
+		StoreRelease(fEligibleCount, idx + 1);
+	} else {
+		if (fIneligibleCount >= kMaxThreadsPerCore) {
+			panic("scheduler: ineligible heap overflow (count=%d)", fIneligibleCount);
+		}
+		AddAcquireRelease(fTotalCount, 1);
+		int32 idx = fIneligibleCount;
+		fIneligibleHeap[idx] = element;
+		link->fIndex = -idx - 1;
+		_BubbleUp(fIneligibleHeap, idx + 1, idx, false);
+		StoreRelease(fIneligibleCount, idx + 1);
+	}
 }
 
 RUN_QUEUE_TEMPLATE_LIST
@@ -291,23 +309,6 @@ void RUN_QUEUE_CLASS_NAME::Remove(Element* element) {
 
 	if (rawIndex == 0x7FFFFFFF) return;
 
-	unsigned int priority = link->fPriority;
-	if (priority <= MaxPriority) {
-		if (--fPriorityCounts[priority] == 0) {
-			fBitmap[priority / 32] &= ~(1U << (priority % 32));
-			fPriorityHeads[priority] = NULL;
-		} else {
-			Element* next = link->fNext;
-			Element* prev = link->fPrev;
-			sGetLink(next)->fPrev = prev;
-			sGetLink(prev)->fNext = next;
-			if (fPriorityHeads[priority] == element)
-				fPriorityHeads[priority] = next;
-		}
-		link->fNext = NULL;
-		link->fPrev = NULL;
-	}
-
 	bool eligible = (rawIndex >= 0);
 	int32 index = eligible ? rawIndex : (-rawIndex - 1);
 	Element** heap = eligible ? fEligibleHeap : fIneligibleHeap;
@@ -315,6 +316,10 @@ void RUN_QUEUE_CLASS_NAME::Remove(Element* element) {
 
 	if (index < 0 || index >= count || heap[index] != element)
 		return;
+
+	unsigned int priority = link->fPriority;
+	if (priority <= MaxPriority)
+		_RemovePriority(element, priority);
 
 	int32 lastIndex = count - 1;
 	Element* last = heap[lastIndex];
@@ -335,6 +340,48 @@ void RUN_QUEUE_CLASS_NAME::Remove(Element* element) {
 	link->fIndex = 0x7FFFFFFF;
 	Traits::SetInRunQueue(element, false);
 	SubAcquireRelease(fTotalCount, 1);
+}
+
+RUN_QUEUE_TEMPLATE_LIST
+void RUN_QUEUE_CLASS_NAME::_PushPriority(Element* element, unsigned int priority, bool front) {
+	RunQueueLink<Element>* link = sGetLink(element);
+	if (fPriorityCounts[priority]++ == 0) {
+		fBitmap[priority / 32] |= (1U << (priority % 32));
+		fPriorityHeads[priority] = element;
+		link->fNext = element;
+		link->fPrev = element;
+	} else {
+		Element* head = fPriorityHeads[priority];
+		RunQueueLink<Element>* headLink = sGetLink(head);
+		Element* tail = headLink->fPrev;
+		RunQueueLink<Element>* tailLink = sGetLink(tail);
+
+		link->fNext = head;
+		link->fPrev = tail;
+		tailLink->fNext = element;
+		headLink->fPrev = element;
+
+		if (front)
+			fPriorityHeads[priority] = element;
+	}
+}
+
+RUN_QUEUE_TEMPLATE_LIST
+void RUN_QUEUE_CLASS_NAME::_RemovePriority(Element* element, unsigned int priority) {
+	RunQueueLink<Element>* link = sGetLink(element);
+	if (--fPriorityCounts[priority] == 0) {
+		fBitmap[priority / 32] &= ~(1U << (priority % 32));
+		fPriorityHeads[priority] = NULL;
+	} else {
+		Element* next = link->fNext;
+		Element* prev = link->fPrev;
+		sGetLink(next)->fPrev = prev;
+		sGetLink(prev)->fNext = next;
+		if (fPriorityHeads[priority] == element)
+			fPriorityHeads[priority] = next;
+	}
+	link->fNext = NULL;
+	link->fPrev = NULL;
 }
 
 RUN_QUEUE_TEMPLATE_LIST

--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -209,13 +209,13 @@ void RUN_QUEUE_CLASS_NAME::CheckEligibility(bigtime_t svt) {
 
 			// Remove from Ineligible
 			int32 lastIdx = fIneligibleCount - 1;
-			StoreRelease(fIneligibleCount, lastIdx);
 			Element* last = fIneligibleHeap[lastIdx];
 			if (0 != lastIdx) {
 				fIneligibleHeap[0] = last;
 				sGetLink(last)->fIndex = -1; // Temp index for bubble
-				_BubbleDown(fIneligibleHeap, fIneligibleCount, 0, false);
+				_BubbleDown(fIneligibleHeap, lastIdx, 0, false);
 			}
+			StoreRelease(fIneligibleCount, lastIdx);
 			sGetLink(root)->fIndex = 0x7FFFFFFF;
 
 			// Add to Eligible

--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -20,6 +20,9 @@ struct RunQueueLink {
 
 	int32 fIndex; // Positive for Eligible, Negative for Ineligible (-idx-1)
 	unsigned int fPriority;
+
+	Element* fNext;
+	Element* fPrev;
 } __attribute__((aligned(8)));
 
 template <typename Element>
@@ -69,11 +72,15 @@ class RunQueue {
 	typedef Scheduler::RunQueueTraits<Element> Traits;
 
 public:
+	static const int32 kBitmapSize = (MaxPriority + 31) / 32;
+
 	inline bool IsEmpty() const { return LoadAcquire(fTotalCount) == 0; }
 
 	RunQueue();
 
 	inline status_t GetInitStatus() { return fInitStatus; }
+
+	inline const uint32* GetBitmap() const { return fBitmap; }
 
 	// Ensure the heap array has enough space.
 	// Fixed-size avoids unsafe realloc in kernel hotpath.
@@ -143,6 +150,10 @@ private:
 
 	int32 fTotalCount __attribute__((aligned(8)));
 
+	uint32 fBitmap[kBitmapSize];
+	int32 fPriorityCounts[MaxPriority + 1];
+	Element* fPriorityHeads[MaxPriority + 1];
+
 	// Prevent false sharing
 	char _pad0[64] __attribute__((aligned(64)));
 
@@ -152,7 +163,7 @@ private:
 
 template <typename Element>
 RunQueueLink<Element>::RunQueueLink()
-	: fIndex(0x7FFFFFFF), fPriority(0) {}
+	: fIndex(0x7FFFFFFF), fPriority(0), fNext(NULL), fPrev(NULL) {}
 
 template <typename Element>
 RunQueueLink<Element>* RunQueueLinkImpl<Element>::GetRunQueueLink() {
@@ -176,6 +187,9 @@ RUN_QUEUE_CLASS_NAME::RunQueue()
 	: fInitStatus(B_OK), fEligibleCount(0), fIneligibleCount(0), fTotalCount(0) {
 	memset(fEligibleHeap, 0, sizeof(fEligibleHeap));
 	memset(fIneligibleHeap, 0, sizeof(fIneligibleHeap));
+	memset(fBitmap, 0, sizeof(fBitmap));
+	memset(fPriorityCounts, 0, sizeof(fPriorityCounts));
+	memset(fPriorityHeads, 0, sizeof(fPriorityHeads));
 }
 
 RUN_QUEUE_TEMPLATE_LIST
@@ -219,6 +233,25 @@ void RUN_QUEUE_CLASS_NAME::PushBack(Element* element, unsigned int priority, big
 	RunQueueLink<Element>* link = sGetLink(element);
 	link->fPriority = priority;
 
+	if (priority <= MaxPriority) {
+		if (fPriorityCounts[priority]++ == 0) {
+			fBitmap[priority / 32] |= (1U << (priority % 32));
+			fPriorityHeads[priority] = element;
+			link->fNext = element;
+			link->fPrev = element;
+		} else {
+			Element* head = fPriorityHeads[priority];
+			RunQueueLink<Element>* headLink = sGetLink(head);
+			Element* tail = headLink->fPrev;
+			RunQueueLink<Element>* tailLink = sGetLink(tail);
+
+			link->fNext = head;
+			link->fPrev = tail;
+			tailLink->fNext = element;
+			headLink->fPrev = element;
+		}
+	}
+
 	Traits::SetInRunQueue(element, true);
 
 	if (element->IsRealTime() || element->IsIdle() || element->IsEligible(svt)) {
@@ -257,6 +290,23 @@ void RUN_QUEUE_CLASS_NAME::Remove(Element* element) {
 	int32 rawIndex = link->fIndex;
 
 	if (rawIndex == 0x7FFFFFFF) return;
+
+	unsigned int priority = link->fPriority;
+	if (priority <= MaxPriority) {
+		if (--fPriorityCounts[priority] == 0) {
+			fBitmap[priority / 32] &= ~(1U << (priority % 32));
+			fPriorityHeads[priority] = NULL;
+		} else {
+			Element* next = link->fNext;
+			Element* prev = link->fPrev;
+			sGetLink(next)->fPrev = prev;
+			sGetLink(prev)->fNext = next;
+			if (fPriorityHeads[priority] == element)
+				fPriorityHeads[priority] = next;
+		}
+		link->fNext = NULL;
+		link->fPrev = NULL;
+	}
 
 	bool eligible = (rawIndex >= 0);
 	int32 index = eligible ? rawIndex : (-rawIndex - 1);
@@ -349,14 +399,8 @@ Element* RUN_QUEUE_CLASS_NAME::ConstIterator::Next() {
 
 RUN_QUEUE_TEMPLATE_LIST
 Element* RUN_QUEUE_CLASS_NAME::GetHead(unsigned int priority) const {
-	for (int32 i = 0; i < fEligibleCount; i++) {
-		if (fEligibleHeap[i]->GetEffectivePriority() == (int32)priority)
-			return fEligibleHeap[i];
-	}
-	for (int32 i = 0; i < fIneligibleCount; i++) {
-		if (fIneligibleHeap[i]->GetEffectivePriority() == (int32)priority)
-			return fIneligibleHeap[i];
-	}
+	if (priority <= MaxPriority)
+		return fPriorityHeads[priority];
 	return NULL;
 }
 

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -281,7 +281,6 @@ void scheduler_update_interaction_state(bigtime_t now) {
 			// path) but the timer is not armed, so gDeadlineBucketSize stays
 			// at the wrong resolution until the next DPC queue drain.
 			// sTimerArmed is set below; if Add() fails we must NOT set it.
-			StoreRelease(sTimerArmed, 0);
 			return;
 		}
 	}

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -281,6 +281,7 @@ void scheduler_update_interaction_state(bigtime_t now) {
 			// path) but the timer is not armed, so gDeadlineBucketSize stays
 			// at the wrong resolution until the next DPC queue drain.
 			// sTimerArmed is set below; if Add() fails we must NOT set it.
+			StoreRelease(sTimerArmed, 0);
 			return;
 		}
 	}

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -203,7 +203,7 @@ static status_t interaction_timer_hook(struct timer* timer) {
 void scheduler_update_interaction_state(bigtime_t now) {
 	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
 
-	if (cpu->fInteractionUpdateCounter++ % 32 != 0)
+	if (cpu->fInteractionUpdateCounter++ % 32 != 0) {
 		// fInteractionUpdateCounter is a
 		// plain uint32 incremented without atomics.  This is safe because:
 		// (a) it is a per-CPU field - only the current CPU accesses it here
@@ -212,6 +212,7 @@ void scheduler_update_interaction_state(bigtime_t now) {
 		//     merely shifts the phase of the 32-call window, which is
 		//     harmless.  No code change required.
 		return;
+	}
 
 	// Note: Deadline bucket caching. Cache gDeadlineBucketSize once - it is
 	// read twice below and the two reads could observe different values if a
@@ -221,6 +222,7 @@ void scheduler_update_interaction_state(bigtime_t now) {
 
 	if (now == 0)
 		now = system_time();
+
 	bigtime_t lastTime = (bigtime_t)LoadAcquire64(sLastInteractionTime);
 	// Note: Scheduler::MinimalQuantum() reads sCurrentMode->minimal_quantum
 	// in two separate memory accesses (pointer load + field read). On 32-bit
@@ -234,8 +236,8 @@ void scheduler_update_interaction_state(bigtime_t now) {
 							  : 1200;  // fallback: 1.2ms minimal quantum
 
 	while (now - lastTime >= threshold) {
-		if ((bigtime_t)TestAndSet64(sLastInteractionTime,
-				(int64)now, (int64)lastTime) == lastTime) {
+		if ((bigtime_t)TestAndSet64(sLastInteractionTime, (int64)now,
+				(int64)lastTime) == lastTime) {
 			lastTime = now;
 			break;
 		}
@@ -447,17 +449,19 @@ static void UpdatePriorityBoostScalable(CoreEntry* core, CPUEntry* cpu,
 	// only the CPU whose (boost_epoch % cpuCount) matches its modular index
 	// within the core performs the scan.
 	int32 coreCPUCount = max_c(1, core->CPUCount());
+
 	// Note: Counter wrap-around safety. when fRescheduleCount wraps UINT32_MAX
-	// → 0, the post- increment is 0, so (0 % 10 == 0) fires and preCount
+	// → 0, the post-increment is 0, so (0 % 10 == 0) fires and preCount
 	// becomes UINT32_MAX, making boostEpoch ≈ 429M.  This causes all CPUs to
 	// satisfy the modular ownership check simultaneously, producing a
 	// correlated scan burst. Treat the wrap as a normal epoch boundary by
 	// clamping preCount.
 	uint32 preCount = cpu->fRescheduleCount - 1;
 	// Note: Use a non-zero epoch at wrap boundary to avoid bias.
-	if (cpu->fRescheduleCount == 0)
+	if (cpu->fRescheduleCount == 0) {
 		preCount =
 			THREAD_MAX_SET_PRIORITY;  // Arbitrary but stable non-zero value
+	}
 
 	uint32 boostEpoch = preCount / 10;
 

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -296,16 +296,20 @@ void scheduler_update_interaction_state(bigtime_t now) {
 
 struct RunQueueScanner {
 	uint32 kTopWordMask;
-	int kMaxThreadsToCheckPerQueue;
+	int kMaxPrioritiesToCheckPerQueue;
 	bigtime_t now;
 
-	RunQueueScanner(uint32 topWordMask, int maxThreads, bigtime_t now)
+	RunQueueScanner(uint32 topWordMask, int maxPriorities, bigtime_t now)
 		: kTopWordMask(topWordMask),
-		  kMaxThreadsToCheckPerQueue(maxThreads),
+		  kMaxPrioritiesToCheckPerQueue(maxPriorities),
 		  now(now) {}
 
 	void operator()(const ThreadRunQueue* runQueue) const {
+		if (kMaxPrioritiesToCheckPerQueue <= 0)
+			return;
+
 		const uint32* bitmap = runQueue->GetBitmap();
+		int checked = 0;
 
 		for (int i = ThreadRunQueue::kBitmapSize - 1; i >= 0; i--) {
 			uint32 val = bitmap[i];
@@ -323,11 +327,16 @@ struct RunQueueScanner {
 				// For priority boosting we update the most urgent thread
 				// in the requested priority bucket.
 				ThreadData* thread = runQueue->GetHead(priority);
+				// Count each visited priority slot toward the budget, even if
+				// the queue head is transiently NULL (e.g. concurrent dequeue or
+				// stale bitmap bit). This keeps scan work strictly bounded.
 				if (thread != NULL) {
 					thread->_UpdatePriorityBoost(now);
 				}
+				if (++checked >= kMaxPrioritiesToCheckPerQueue)
+					return;
 
-				val &= ~(1UL << bit);
+				val &= ~(1U << bit);
 				if (val == 0)
 					break;
 				bit = fls(val) - 1;
@@ -424,9 +433,12 @@ static void UpdatePriorityBoostScalable(CoreEntry* core, CPUEntry* cpu,
 	// We verify if the longest-waiting thread in each queue is starving.
 	// This maintains O(1) complexity regardless of the number of threads.
 
-	const int kMaxThreadsToCheckPerQueue = 5;
+	// Budget is the number of priority buckets examined per run queue,
+	// not the number of threads.
+	const int kMaxPrioritiesToCheckPerQueue = 5;
 
-	RunQueueScanner scanRunQueue(kTopWordMask, kMaxThreadsToCheckPerQueue, now);
+	RunQueueScanner scanRunQueue(kTopWordMask, kMaxPrioritiesToCheckPerQueue,
+								 now);
 
 	// Check Core RunQueue first to maintain Core -> CPU lock ordering
 	// On an N-way SMT core, all N CPUs previously scanned the shared
@@ -453,8 +465,22 @@ static void UpdatePriorityBoostScalable(CoreEntry* core, CPUEntry* cpu,
 	// This ensures fair round-robin ownership even if there are holes
 	// in the assigned local indices.
 	native_cpu_mask_t localMask = cpu_mask_get_atomic(&core->fLocalIndices);
-	int32 denseLocalIndex = scheduler_popcount(
-		localMask & (((native_cpu_mask_t)1 << cpu->fCoreLocalIndex) - 1));
+	const int32 maskBitCount = (int32)(sizeof(native_cpu_mask_t) * 8);
+	// 32/64-bit safety: shifting by the type width is undefined behavior.
+	// Clamp the shift domain so this remains valid on both 32-bit and 64-bit.
+	int32 localIndex = cpu->fCoreLocalIndex;
+	if (localIndex < 0)
+		localIndex = 0;
+	if (localIndex > maskBitCount)
+		localIndex = maskBitCount;
+
+	native_cpu_mask_t lowerMask = 0;
+	if (localIndex == maskBitCount)
+		lowerMask = localMask;
+	else if (localIndex > 0)
+		lowerMask = localMask & (((native_cpu_mask_t)1 << localIndex) - 1);
+
+	int32 denseLocalIndex = scheduler_popcount(lowerMask);
 
 	bool ownsCoreQueueScan = ((int32)(boostEpoch % (uint32)coreCPUCount) ==
 							  (int32)(denseLocalIndex % (uint32)coreCPUCount));

--- a/src/system/kernel/scheduler/scheduler_audit_report_2025.md
+++ b/src/system/kernel/scheduler/scheduler_audit_report_2025.md
@@ -10,12 +10,18 @@
 - **Native Masking**: Utilized `native_cpu_mask_t` and portable bit manipulation intrinsics (`scheduler_ctz`, `scheduler_ffs64`, `scheduler_popcount`) to handle varying CPU mask widths and topologies.
 
 ## 3. Performance Optimizations
+- **Hybrid RunQueue Structure**: Refactored `ThreadRunQueue` to a hybrid data structure combining dual array-based binary min-heaps for EEVDF deadline sorting with per-priority circular doubly-linked lists and a priority bitmap. This enables $O(1)$ retrieval of threads by priority while maintaining $O(\log N)$ heap complexity for deadline-based scheduling.
+- **Scalable Priority Boosting**: Optimized the starvation scanner to utilize the hybrid RunQueue's priority bitmap. Implemented a per-priority work budget (`kMaxPrioritiesToCheckPerQueue`) to strictly bound scan overhead, replacing the previous $O(N)$ linear scan of heaps with $O(1)$ lookup per priority level.
+- **Modular Core Ownership**: Implemented a round-robin ownership model for core-level starvation scans using a modular index calculation (`boostEpoch % coreCPUCount`). This prevents multiple CPUs on an SMT core from contending on the shared Core RunQueue lock simultaneously.
 - **Deep Timestamp Propagation**: Refactored the scheduling hot path (`reschedule()`) to capture `system_time()` once and propagate the `now` timestamp through accounting, load tracking, and quantum calculation. This eliminates redundant hardware timer reads in the kernel's most frequent execution path.
 - **Thread Coloring Refinement**: Optimized core selection logic in `low_latency.cpp` and `power_saving.cpp` to skip redundant type-filtered searches on homogeneous systems, reducing overhead.
 - **Lockless Hints**: Implemented `CoreEntry::HasHighPriorityThread()` using lockless run-queue bitmap reads, improving quantum calculation performance by avoiding `TryLockRunQueue` contention.
 - **Bounded CAS Loops**: Hardened E-core selection loops in `power_saving.cpp` with a retry limit (16) and `cpu_pause()` to prevent indefinite spinning under high contention.
 
 ## 4. Bug Fixes & Robustness
+- **32/64-bit Shift Domain Safety**: Hardened bitwise modular calculations in `UpdatePriorityBoostScalable` by explicitly clamping shift domains to the bit width of `native_cpu_mask_t`, preventing undefined behavior on 32-bit and 64-bit platforms.
+- **Interaction State Reliability**: Resolved a race condition in `scheduler_update_interaction_state` by ensuring the interaction timer is only armed if the DPC is successfully queued. Implemented explicit recovery paths (clearing `sDPCPending`) for DPC queue saturation to prevent permanent loss of timer resolution.
+- **fRescheduleCount Wrap-around Protection**: Implemented wrap-around safety for the reschedule counter used in starvation scanning, ensuring stable non-zero epoch boundaries at the `UINT32_MAX -> 0` transition to prevent correlated scan bursts across all CPUs.
 - **RunQueue Hardening**: Implemented stale pointer detection for the `fBest` cache in `RunQueue.h`. Added an authoritative rescan in `PeekBest()` to guarantee finding a thread if the queue is non-empty, even under high contention.
 - **Hot-Unplug Safety**: Added explicit `NULL` guards for `Core()`, `Package()`, and `Node()` dereferences throughout the scheduler and load balancer to prevent kernel panics during CPU hot-unplug events.
 - **Counter Consistency**: Verified and corrected various atomic counter updates (e.g., `fThreadCount`, `gTotalRunnableThreads`) to ensure symmetric increments/decrements and avoid leaks.


### PR DESCRIPTION
Improved the Haiku scheduler by implementing a hybrid Heap+MLFQ RunQueue and optimizing the priority boosting mechanism.

Key changes:
1. **RunQueue.h**: Refactored to a hybrid structure. Binary heaps (fEligibleHeap/fIneligibleHeap) still handle deadline-based selection (EEVDF), but each priority level now also maintains a doubly-linked list (MLFQ) anchored by `fPriorityHeads`. A priority bitmap (`fBitmap`) enables O(P/32) scanning of non-empty levels.
2. **scheduler.cpp**: Updated `RunQueueScanner` to use priority-based budgeting, ensuring the starvation-prevention scan remains O(1) relative to thread count. Fixed potential undefined behavior in `UpdatePriorityBoostScalable` related to shifting `native_cpu_mask_t`.

These changes ensure that priority-based interactivity heuristics do not regress under the new heap-based EEVDF implementation.

---
*PR created automatically by Jules for task [10218915675367339300](https://jules.google.com/task/10218915675367339300) started by @tonestone57*