### PR TITLE
Refine and Optimize EEVDF Scheduler Implementation

### DIFF
--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -91,8 +91,13 @@ public:
 	void CheckEligibility(bigtime_t svt);
 
 	// Eligible threads are ordered by virtual deadline (Compare).
+	// If no eligible threads exist, fall back to the least ineligible thread.
 	inline Element* PeekRoot() const {
-		return LoadAcquire(fEligibleCount) > 0 ? fEligibleHeap[0] : NULL;
+		if (LoadAcquire(fEligibleCount) > 0)
+			return fEligibleHeap[0];
+		if (LoadAcquire(fIneligibleCount) > 0)
+			return fIneligibleHeap[0];
+		return NULL;
 	}
 
 	inline Element* PeekMaximum() const { return PeekRoot(); }
@@ -472,6 +477,16 @@ Element* RUN_QUEUE_CLASS_NAME::PeekBest(const Compare2& compare,
 				best = fEligibleHeap[i];
 		}
 	}
+
+	if (best == NULL) {
+		for (int32 i = 0; i < fIneligibleCount; i++) {
+			if (predicate(fIneligibleHeap[i])) {
+				if (best == NULL || compare(fIneligibleHeap[i], best))
+					best = fIneligibleHeap[i];
+			}
+		}
+	}
+
 	return best;
 }
 

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -664,7 +664,7 @@ static bool enqueue(Thread* thread, bool newOne, Thread* waker, bigtime_t now) {
 		// A more urgent thread (earlier deadline) only preempts if it is
 		// significantly more urgent (Delta > epsilon).
 		if (targetCPU->ID() != smp_get_current_cpu()) {
-			bigtime_t epsilon = (bigtime_t)LoadAcquire64(targetCPU->fPreemptionThreshold);
+			bigtime_t epsilon = targetCPU->PreemptionThreshold();
 			ThreadData* top = targetCPU->PeekThread();
 			if (top != NULL && !top->IsIdle()) {
 				// new thread is 'threadData', running thread is 'top'.

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -175,6 +175,8 @@ namespace Scheduler {
 
 const bigtime_t kForegroundVRuntimeOffset = 5000;
 
+const bigtime_t kMaxLagFloor = 200000;
+
 const int64 kNUMANodeLagThreshold = 1000000;
 const int64 kGlobalLagThreshold = 5000000;
 
@@ -222,11 +224,24 @@ struct ThreadDataDeadlineCompare {
 };
 
 struct ThreadDataLagCompare {
+	ThreadDataLagCompare(bigtime_t svt = -1) : fSVT(svt) {}
+
 	template <typename ThreadData>
 	bool operator()(const ThreadData* a, const ThreadData* b) const {
+		int64 lagA, lagB;
+		if (fSVT == (bigtime_t)-1) {
+			lagA = a->GetLag();
+			lagB = b->GetLag();
+		} else {
+			lagA = (fSVT - a->GetVirtualRuntime()) * a->GetWeight();
+			lagB = (fSVT - b->GetVirtualRuntime()) * b->GetWeight();
+		}
 		// Highest positive lag first (most under-served)
-		return (a->GetLag() - b->GetLag()) > 0;
+		return (lagA - lagB) > 0;
 	}
+
+private:
+	bigtime_t fSVT;
 };
 
 static const int32 kWeightTable[] = {

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -519,7 +519,6 @@ ThreadData* CPUEntry::ChooseNextThread(ThreadData* oldThread, bool putAtBack,
 	if (pinnedThread != NULL)
 		pinnedPriority = pinnedThread->GetEffectivePriority();
 
-	core->CheckEligibility(core->SystemVirtualTime());
 	ThreadData* sharedThread = core->PeekThread();
 	if (sharedThread == NULL && pinnedThread == NULL) {
 		// try to steal work from other cores in the same package
@@ -1052,13 +1051,12 @@ ThreadData* CoreEntry::StealThread(int32& stolenPriority, int32 thiefCPU) {
 	// Unlike traditional schedulers, we prefer threads with the
 	// highest positive Lag (most under-served).
 
-	CPUEntry* thief = CPUEntry::GetCPU(thiefCPU);
-	const_cast<ThreadRunQueue&>(fRunQueue).CheckEligibility(thief->SystemVirtualTime());
+	const_cast<ThreadRunQueue&>(fRunQueue).CheckEligibility(SystemVirtualTime());
 
 	// Thief prefers cores with lower total weight pressure.
 	// (Target pressure comparison is handled in _TryStealWork)
 
-	bigtime_t svt = thief->SystemVirtualTime();
+	bigtime_t svt = SystemVirtualTime();
 	ThreadData* thread = fRunQueue.PeekBest(ThreadDataLagCompare(svt), StealThreadPredicate(thiefCPU));
 
 	if (thread != NULL) {

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -248,8 +248,7 @@ CPUEntry::CPUEntry()
 	  fRescheduleCount(0),
 	  fCoreLocalIndex(0),
 	  fInteractionUpdateCounter(0),
-	  fSystemVirtualTime(0),
-	  fPreemptionThreshold(0),
+
 	  fTotalWeight(0),
 	  fReschedulePending(0),
 	  fLastLocalPackageIndex(0),
@@ -415,8 +414,7 @@ void CPUEntry::Remove(ThreadData* thread) {
 
 ThreadData* CoreEntry::PeekThread() const {
 	SCHEDULER_ENTER_FUNCTION();
-	// Note: We don't have a specific SVT for the entire core here,
-	// but StealThread and ChooseNextThread handle eligibility properly.
+	const_cast<ThreadRunQueue&>(fRunQueue).CheckEligibility(SystemVirtualTime());
 	return fRunQueue.PeekBest();
 }
 
@@ -521,6 +519,7 @@ ThreadData* CPUEntry::ChooseNextThread(ThreadData* oldThread, bool putAtBack,
 	if (pinnedThread != NULL)
 		pinnedPriority = pinnedThread->GetEffectivePriority();
 
+	core->CheckEligibility(core->SystemVirtualTime());
 	ThreadData* sharedThread = core->PeekThread();
 	if (sharedThread == NULL && pinnedThread == NULL) {
 		// try to steal work from other cores in the same package
@@ -681,19 +680,22 @@ void CPUEntry::TrackLoad(ThreadData* nextThreadData, bigtime_t now) {
 	// Note: Update System Virtual Time (SVT).
 	// SVT tracks the FairShare baseline for this core.
 	if (nextThreadData != NULL) {
-		if (!nextThreadData->IsIdle() && !nextThreadData->IsRealTime()) {
-			bigtime_t vrt = nextThreadData->GetVirtualRuntime();
-			bigtime_t svt = SystemVirtualTime();
-			if (vrt > svt)
-				SetSystemVirtualTime(vrt);
+		CoreEntry* core = Core();
+		if (core != NULL) {
+			if (!nextThreadData->IsIdle() && !nextThreadData->IsRealTime()) {
+				bigtime_t vrt = nextThreadData->GetVirtualRuntime();
+				bigtime_t svt = core->SystemVirtualTime();
+				if (vrt > svt)
+					core->SetSystemVirtualTime(vrt);
 
-			// Note: Update Dynamic Preemption Threshold.
-			// Scale epsilon based on thread count to protect cache performance.
-			int32 threads = ThreadCount();
-			StoreRelease64(fPreemptionThreshold, (int64)(threads * 500)); // 500us per thread
-		} else if (nextThreadData->IsIdle()) {
-			// On an idle system, epsilon is near zero (instant response).
-			StoreRelease64(fPreemptionThreshold, 0);
+				// Note: Update Dynamic Preemption Threshold.
+				// Scale epsilon based on thread count to protect cache performance.
+				int32 threads = core->ThreadCount();
+				core->SetPreemptionThreshold((int64)(threads * 500)); // 500us per thread
+			} else if (nextThreadData->IsIdle()) {
+				// On an idle system, epsilon is near zero (instant response).
+				core->SetPreemptionThreshold(0);
+			}
 		}
 	}
 
@@ -984,6 +986,9 @@ void CoreEntry::Init(int32 id, PackageEntry* package) {
 	fCoreID = id;
 	fPackage = package;
 
+	StoreRelease64(fSystemVirtualTime, 0);
+	StoreRelease64(fPreemptionThreshold, 0);
+
 	fScoreFactor = (kDefaultCapacity << 16) / fCapacity;
 
 	fCPUHeap.~CPUPriorityHeap();
@@ -1053,11 +1058,13 @@ ThreadData* CoreEntry::StealThread(int32& stolenPriority, int32 thiefCPU) {
 	// Thief prefers cores with lower total weight pressure.
 	// (Target pressure comparison is handled in _TryStealWork)
 
-	ThreadData* thread = fRunQueue.PeekBest(ThreadDataLagCompare(), StealThreadPredicate(thiefCPU));
+	bigtime_t svt = thief->SystemVirtualTime();
+	ThreadData* thread = fRunQueue.PeekBest(ThreadDataLagCompare(svt), StealThreadPredicate(thiefCPU));
 
 	if (thread != NULL) {
 		// Only steal if thread has positive lag (under-served)
-		if (thread->GetLag() <= 0)
+		int64 lag = (svt - thread->GetVirtualRuntime()) * thread->GetWeight();
+		if (lag <= 0)
 			return NULL;
 
 		stolenPriority = thread->GetEffectivePriority();

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -117,6 +117,10 @@ public:
 		return fRunQueue.GetConstIterator();
 	}
 
+	inline void CheckEligibility(bigtime_t svt) {
+		fRunQueue.CheckEligibility(svt);
+	}
+
 	void UpdatePriority(int32 priority);
 
 	inline int32 GetLoad() const;
@@ -135,13 +139,6 @@ public:
 
 	inline int32 ThreadCount() const { return LoadAcquire(fThreadCount); }
 
-	inline bigtime_t SystemVirtualTime() const {
-		return (bigtime_t)LoadAcquire64(fSystemVirtualTime);
-	}
-
-	inline void SetSystemVirtualTime(bigtime_t time) {
-		StoreRelease64(fSystemVirtualTime, (int64)time);
-	}
 
 	inline int64 TotalWeight() const {
 		return LoadAcquire64(fTotalWeight);
@@ -190,8 +187,6 @@ private:
 	uint32 fRescheduleCount;
 	uint32 fInteractionUpdateCounter;
 
-	bigtime_t fSystemVirtualTime __attribute__((aligned(8)));
-	bigtime_t fPreemptionThreshold __attribute__((aligned(8)));
 	int64 fTotalWeight __attribute__((aligned(8)));
 
 	int32 fReschedulePending __attribute__((aligned(8)));
@@ -282,6 +277,26 @@ public:
 		return fRunQueue.GetConstIterator();
 	}
 
+	inline void CheckEligibility(bigtime_t svt) {
+		fRunQueue.CheckEligibility(svt);
+	}
+
+	inline bigtime_t SystemVirtualTime() const {
+		return (bigtime_t)LoadAcquire64(fSystemVirtualTime);
+	}
+
+	inline void SetSystemVirtualTime(bigtime_t time) {
+		StoreRelease64(fSystemVirtualTime, (int64)time);
+	}
+
+	inline bigtime_t PreemptionThreshold() const {
+		return (bigtime_t)LoadAcquire64(fPreemptionThreshold);
+	}
+
+	inline void SetPreemptionThreshold(bigtime_t threshold) {
+		StoreRelease64(fPreemptionThreshold, (int64)threshold);
+	}
+
 	inline bigtime_t GetActiveTime() const;
 	inline void IncreaseActiveTime(bigtime_t activeTime);
 
@@ -318,6 +333,9 @@ private:
 	static void _UnassignThread(Thread* thread, void* core);
 
 	bigtime_t fActiveTime __attribute__((aligned(8)));
+
+	bigtime_t fSystemVirtualTime __attribute__((aligned(8)));
+	bigtime_t fPreemptionThreshold __attribute__((aligned(8)));
 
 	// bits 32-63: Current Load, bits 0-31: Epoch
 	int64 fCombinedLoad __attribute__((aligned(8)));
@@ -480,6 +498,26 @@ inline bool CPUEntry::TryLockRunQueue() {
 inline void CPUEntry::UnlockRunQueue() {
 	SCHEDULER_ENTER_FUNCTION();
 	release_spinlock(&fQueueLock);
+}
+
+inline bigtime_t CPUEntry::SystemVirtualTime() const {
+	CoreEntry* core = Core();
+	if (core == NULL)
+		return 0;
+	return core->SystemVirtualTime();
+}
+
+inline void CPUEntry::SetSystemVirtualTime(bigtime_t time) {
+	CoreEntry* core = Core();
+	if (core != NULL)
+		core->SetSystemVirtualTime(time);
+}
+
+inline bigtime_t CPUEntry::PreemptionThreshold() const {
+	CoreEntry* core = Core();
+	if (core == NULL)
+		return 0;
+	return core->PreemptionThreshold();
 }
 
 /* static */ inline CPUEntry* CPUEntry::GetCPU(int32 cpu) {

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -288,7 +288,6 @@ public:
 	inline void SetSystemVirtualTime(bigtime_t time) {
 		StoreRelease64(fSystemVirtualTime, (int64)time);
 	}
-
 	inline bigtime_t PreemptionThreshold() const {
 		return (bigtime_t)LoadAcquire64(fPreemptionThreshold);
 	}

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -661,8 +661,14 @@ inline bool ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption,
 			locker.Unlock();
 			pinned = false;	 // float
 		} else {
-			if (!wasReady && !IsRealTime())
+			if (!wasReady && !IsRealTime()) {
+				bigtime_t svt = cpu->SystemVirtualTime();
+				bigtime_t vrt = GetVirtualRuntime();
+				if (vrt < svt - kMaxLagFloor)
+					StoreRelease64(fVirtualRuntime, (int64)(svt - kMaxLagFloor));
+
 				_UpdateDeadline(now);
+			}
 
 			// defer the gTotalRunnableThreads increment until after the
 			// CPUCount guard in the non-pinned path (see below).  For the
@@ -757,8 +763,14 @@ inline bool ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption,
 			}
 		}
 
-		if (!wasReady && !IsRealTime())
+		if (!wasReady && !IsRealTime()) {
+			bigtime_t svt = core->SystemVirtualTime();
+			bigtime_t vrt = GetVirtualRuntime();
+			if (vrt < svt - kMaxLagFloor)
+				StoreRelease64(fVirtualRuntime, (int64)(svt - kMaxLagFloor));
+
 			_UpdateDeadline(now);
+		}
 
 		// defer the gTotalRunnableThreads increment until after the
 		// CPUCount guard in the non-pinned path.
@@ -883,13 +895,9 @@ inline void ThreadData::UpdateActivity(bigtime_t active, bigtime_t now) {
 		// Lag = (SystemVirtualTime - VirtualRuntime) * Weight
 		CoreEntry* core = Core();
 		if (core != NULL) {
-			// Find a CPU in this core to get SystemVirtualTime.
-			CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
-			if (cpu->Core() == core) {
-				bigtime_t svt = cpu->SystemVirtualTime();
-				int64 lag = (svt - GetVirtualRuntime()) * weight;
-				StoreRelease64(fLag, lag);
-			}
+			bigtime_t svt = core->SystemVirtualTime();
+			int64 lag = (svt - GetVirtualRuntime()) * weight;
+			StoreRelease64(fLag, lag);
 		}
 	}
 


### PR DESCRIPTION
This update performs an extensive refinement of the EEVDF scheduling logic in the Haiku kernel. Key architectural improvements include moving fair-share baseline tracking (SVT) to the physical core level to eliminate inconsistencies between SMT siblings, implementing an ineligible thread fallback to ensure system liveness, and adding a vruntime floor to protect against long-term starvation debt. Work-stealing is now more accurate through dynamic lag calculation, and eligibility migration is more responsive due to additional proactive checks in the scheduling hot path.

---
*PR created automatically by Jules for task [4083857862461082790](https://jules.google.com/task/4083857862461082790) started by @tonestone57*