### PR TITLE
Implement Two-Level Bitmapped Multi-Queue (BMQ) EEVDF Scheduler

### DIFF
--- a/headers/private/kernel/thread_types.h
+++ b/headers/private/kernel/thread_types.h
@@ -256,6 +256,12 @@ struct Thread : TeamThreadIteratorEntry<thread_id>, KernelReferenceable {
 	bool			has_yielded;	// protected by scheduler lock
 	Thread*			waker;			// protected by scheduler lock
 	Scheduler::ThreadData*	scheduler_data; // protected by scheduler lock
+	bigtime_t		virtual_runtime __attribute__((aligned(8)));   // v_i
+	bigtime_t		virtual_deadline __attribute__((aligned(8)));  // d_i
+	int64			sched_weight __attribute__((aligned(8)));      // w_i
+	bigtime_t		time_slice __attribute__((aligned(8)));        // q_i
+	int32			fli_index;         // Tracks current First-Level Bitmap position
+	int32			sli_index;         // Tracks current Second-Level Bitmap position
 	bigtime_t		lastMigrationTime;
 	bool			inRunQueue;
 	Thread*			next;

--- a/headers/private/kernel/thread_types.h
+++ b/headers/private/kernel/thread_types.h
@@ -258,7 +258,7 @@ struct Thread : TeamThreadIteratorEntry<thread_id>, KernelReferenceable {
 	Scheduler::ThreadData*	scheduler_data; // protected by scheduler lock
 	bigtime_t		virtual_runtime __attribute__((aligned(8)));   // v_i
 	bigtime_t		virtual_deadline __attribute__((aligned(8)));  // d_i
-	int64			sched_weight __attribute__((aligned(8)));      // w_i
+	uint32			sched_weight;      // w_i
 	bigtime_t		time_slice __attribute__((aligned(8)));        // q_i
 	int32			fli_index;         // Tracks current First-Level Bitmap position
 	int32			sli_index;         // Tracks current Second-Level Bitmap position

--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -196,7 +196,6 @@ void RUN_QUEUE_CLASS_NAME::_GetIndices(bigtime_t deadline, int32& fli, int32& sl
 
 	// Linearly divide the space between 2^fli and 2^(fli+1)
 	if (fli < 5) {
-		sli = d32 & ((1 << fli) - 1);
 		sli = (d32 - (1 << fli)) << (5 - fli);
 	} else {
 		sli = (d32 - (1 << fli)) >> (fli - 5);

--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -294,8 +294,8 @@ Element* RUN_QUEUE_CLASS_NAME::PeekBest() const
 
 	if (fFirstLevelBitmap == 0) return NULL;
 
-	int32 fli = __builtin_ctz(fFirstLevelBitmap);
-	int32 sli = __builtin_ctz(fSecondLevelBitmap[fli]);
+	int32 fli = ffs(fFirstLevelBitmap) - 1;
+	int32 sli = ffs(fSecondLevelBitmap[fli]) - 1;
 
 	return fQueues[fli][sli].Head();
 }
@@ -325,10 +325,10 @@ Element* RUN_QUEUE_CLASS_NAME::PeekBest(const Compare2& compare,
 	// Check EEVDF matrix
 	uint32 flBitmap = fFirstLevelBitmap;
 	while (flBitmap != 0) {
-		int32 fli = __builtin_ctz(flBitmap);
+		int32 fli = ffs(flBitmap) - 1;
 		uint32 slBitmap = fSecondLevelBitmap[fli];
 		while (slBitmap != 0) {
-			int32 sli = __builtin_ctz(slBitmap);
+			int32 sli = ffs(slBitmap) - 1;
 			typename DoublyLinkedList<Element, GetLink>::Iterator it = fQueues[fli][sli].GetIterator();
 			while (it.HasNext()) {
 				Element* element = it.Next();

--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -294,8 +294,8 @@ Element* RUN_QUEUE_CLASS_NAME::PeekBest() const
 
 	if (fFirstLevelBitmap == 0) return NULL;
 
-	int32 fli = ffs(fFirstLevelBitmap) - 1;
-	int32 sli = ffs(fSecondLevelBitmap[fli]) - 1;
+	int32 fli = __builtin_ctz(fFirstLevelBitmap);
+	int32 sli = __builtin_ctz(fSecondLevelBitmap[fli]);
 
 	return fQueues[fli][sli].Head();
 }
@@ -325,10 +325,10 @@ Element* RUN_QUEUE_CLASS_NAME::PeekBest(const Compare2& compare,
 	// Check EEVDF matrix
 	uint32 flBitmap = fFirstLevelBitmap;
 	while (flBitmap != 0) {
-		int32 fli = ffs(flBitmap) - 1;
+		int32 fli = __builtin_ctz(flBitmap);
 		uint32 slBitmap = fSecondLevelBitmap[fli];
 		while (slBitmap != 0) {
-			int32 sli = ffs(slBitmap) - 1;
+			int32 sli = __builtin_ctz(slBitmap);
 			typename DoublyLinkedList<Element, GetLink>::Iterator it = fQueues[fli][sli].GetIterator();
 			while (it.HasNext()) {
 				Element* element = it.Next();

--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -4,52 +4,28 @@
  *
  * Authors:
  *      Paweł Dziepak, pdziepak@quarnos.org
- *      Jules (2025 Array-Based EEVDF Heap implementation)
+ *      Jules (2025 BMQ-EEVDF implementation)
  */
 #ifndef RUN_QUEUE_H
 #define RUN_QUEUE_H
 
 #include <util/BitUtils.h>
 #include <util/atomic.h>
+#include <util/DoublyLinkedList.h>
 
 #include "scheduler_profiler.h"
 
-template <typename Element>
-struct RunQueueLink {
-	RunQueueLink();
-
-	int32 fIndex; // Positive for Eligible, Negative for Ineligible (-idx-1)
-	unsigned int fPriority;
-
-	Element* fNext;
-	Element* fPrev;
-} __attribute__((aligned(8)));
-
-template <typename Element>
-class RunQueueLinkImpl {
-public:
-	inline RunQueueLink<Element>* GetRunQueueLink();
-
-private:
-	RunQueueLink<Element> fRunQueueLink;
-};
+// For BMQ EEVDF mapping
+#define PRIMARY_BINS   32
+#define SECONDARY_BINS 32
 
 template <typename Element>
 class RunQueueStandardGetLink {
-private:
-	typedef RunQueueLink<Element> Link;
-
 public:
-	inline Link* operator()(Element* element) const;
-};
-
-template <typename Element, RunQueueLink<Element> Element::*LinkMember>
-class RunQueueMemberGetLink {
-private:
-	typedef RunQueueLink<Element> Link;
-
-public:
-	inline Link* operator()(Element* element) const;
+	inline DoublyLinkedListLink<Element>* operator()(Element* element) const
+	{
+		return element->GetRunQueueLink();
+	}
 };
 
 namespace Scheduler {
@@ -64,442 +40,333 @@ struct RunQueueTraits {
 			  typename GetLink>
 #define RUN_QUEUE_CLASS_NAME RunQueue<Element, MaxPriority, Compare, GetLink>
 
-const int32 kMaxThreadsPerCore = 2048;
-
 template <typename Element, unsigned int MaxPriority, typename Compare,
 		  typename GetLink = RunQueueStandardGetLink<Element> >
 class RunQueue {
 	typedef Scheduler::RunQueueTraits<Element> Traits;
 
 public:
-	static const int32 kBitmapSize = (MaxPriority + 31) / 32;
-
-	inline bool IsEmpty() const { return LoadAcquire(fTotalCount) == 0; }
-
 	RunQueue();
 
-	inline status_t GetInitStatus() { return fInitStatus; }
-
-	inline const uint32* GetBitmap() const { return fBitmap; }
-
-	// Ensure the heap array has enough space.
-	// Fixed-size avoids unsafe realloc in kernel hotpath.
-	status_t CheckCapacity(int32 count) {
-		return (count <= kMaxThreadsPerCore) ? B_OK : B_DEVICE_FULL;
-	}
-
-	void CheckEligibility(bigtime_t svt);
-
-	// Eligible threads are ordered by virtual deadline (Compare).
-	// If no eligible threads exist, fall back to the least ineligible thread.
-	inline Element* PeekRoot() const {
-		if (LoadAcquire(fEligibleCount) > 0)
-			return fEligibleHeap[0];
-		if (LoadAcquire(fIneligibleCount) > 0)
-			return fIneligibleHeap[0];
-		return NULL;
-	}
-
-	inline Element* PeekMaximum() const { return PeekRoot(); }
-	inline Element* PeekBest() const { return PeekRoot(); }
+	inline bool IsEmpty() const { return atomic_get(&fTotalCount) == 0; }
 
 	void PushBack(Element* element, unsigned int priority, bigtime_t svt = 0);
 	void PushFront(Element* element, unsigned int priority, bigtime_t svt = 0);
-
 	void Remove(Element* element);
 
-private:
-	void _PushPriority(Element* element, unsigned int priority, bool front);
-	void _RemovePriority(Element* element, unsigned int priority);
+	Element* PeekBest() const;
+	template <typename Compare2, typename Predicate>
+	Element* PeekBest(const Compare2& compare,
+					  const Predicate& predicate) const;
+	Element* PopNext();
 
-	inline int32 Count() const { return LoadAcquire(fTotalCount); }
+	// Compatibility methods
+	inline status_t CheckCapacity(int32 count) { return B_OK; }
+	void CheckEligibility(bigtime_t svt) { fSystemVirtualTime = svt; }
+	inline Element* PeekRoot() const { return PeekBest(); }
+	inline Element* PeekMaximum() const { return PeekBest(); }
+
+	inline uint32 GetFirstLevelBitmap() const { return fFirstLevelBitmap; }
+	inline uint32 GetRealTimeBitmap() const { return fRealTimeBitmap; }
 
 	class ConstIterator {
 	public:
-		ConstIterator() : fList(NULL), fIndex(0) {}
-		ConstIterator(const RunQueue* list) : fList(list), fIndex(0) {}
+		ConstIterator() : fQueue(NULL), fFLI(0), fSLI(0), fRT(0), fCurrent(NULL) {}
+		ConstIterator(const RunQueue* queue) : fQueue(queue), fFLI(0), fSLI(0), fRT(0), fCurrent(NULL)
+		{
+			_Advance();
+		}
 
-		bool HasNext() const { return fIndex < fList->Count(); }
-		Element* Next();
-		void Rewind() { fIndex = 0; }
-
+		bool HasNext() const { return fCurrent != NULL; }
+		Element* Next()
+		{
+			Element* result = fCurrent;
+			_Advance();
+			return result;
+		}
 	private:
-		const RunQueue* fList;
-		int32 fIndex;
+		void _Advance()
+		{
+			if (fQueue == NULL) return;
+
+			if (fCurrent != NULL) {
+				if (fRT < 21) {
+					fCurrent = fQueue->fRealTimeQueues[fRT].GetNext(fCurrent);
+					if (fCurrent != NULL) return;
+					fRT++;
+				} else {
+					fCurrent = fQueue->fQueues[fFLI][fSLI].GetNext(fCurrent);
+					if (fCurrent != NULL) return;
+
+					fSLI++;
+					if (fSLI >= SECONDARY_BINS) {
+						fSLI = 0;
+						fFLI++;
+					}
+					_AdvanceBin();
+					return;
+				}
+			}
+
+			// Find next non-empty RT queue
+			while (fRT < 21) {
+				fCurrent = fQueue->fRealTimeQueues[fRT].Head();
+				if (fCurrent != NULL) return;
+				fRT++;
+			}
+
+			// Find next non-empty EEVDF bin
+			_AdvanceBin();
+		}
+
+		void _AdvanceBin()
+		{
+			while (fFLI < PRIMARY_BINS) {
+				while (fSLI < SECONDARY_BINS) {
+					fCurrent = fQueue->fQueues[fFLI][fSLI].Head();
+					if (fCurrent != NULL) return;
+					fSLI++;
+				}
+				fSLI = 0;
+				fFLI++;
+			}
+			fCurrent = NULL;
+		}
+
+		const RunQueue* fQueue;
+		int fFLI, fSLI, fRT;
+		Element* fCurrent;
 	};
 
 	inline ConstIterator GetConstIterator() const { return ConstIterator(this); }
 
-	inline Element* GetHead(unsigned int priority) const;
-
-	template <typename Predicate>
-	Element* PeekOption(const Predicate& predicate) const;
-
-	template <typename Compare2, typename Predicate>
-	Element* PeekBest(const Compare2& compare,
-					  const Predicate& predicate) const;
+	Element* GetHead(unsigned int priority) const;
 
 private:
-	void _BubbleUp(Element** heap, int32 count, int32 index, bool eligible);
-	void _BubbleDown(Element** heap, int32 count, int32 index, bool eligible);
-	void _Swap(Element** heap, int32 i, int32 j, bool eligible);
+	void _GetIndices(bigtime_t deadline, int32& fli, int32& sli) const;
 
-	bool _CompareIneligible(Element* a, Element* b) const {
-		// Ineligible heap is ordered by VirtualRuntime (earliest first)
-		return (a->GetVirtualRuntime() - b->GetVirtualRuntime()) < 0;
-	}
+	uint32 fFirstLevelBitmap;
+	uint32 fSecondLevelBitmap[PRIMARY_BINS];
+	DoublyLinkedList<Element, GetLink> fQueues[PRIMARY_BINS][SECONDARY_BINS];
 
-	status_t fInitStatus;
+	uint32 fRealTimeBitmap;
+	DoublyLinkedList<Element, GetLink> fRealTimeQueues[21];
 
-	Element* fEligibleHeap[kMaxThreadsPerCore];
-	int32 fEligibleCount __attribute__((aligned(8)));
-
-	Element* fIneligibleHeap[kMaxThreadsPerCore];
-	int32 fIneligibleCount __attribute__((aligned(8)));
-
-	int32 fTotalCount __attribute__((aligned(8)));
-
-	uint32 fBitmap[kBitmapSize];
-	int32 fPriorityCounts[MaxPriority + 1];
-	Element* fPriorityHeads[MaxPriority + 1];
-
-	// Prevent false sharing
-	char _pad0[64] __attribute__((aligned(64)));
+	bigtime_t fSystemVirtualTime;
+	int32 fTotalCount;
 
 	static GetLink sGetLink;
-	static Compare sCompare;
 };
-
-template <typename Element>
-RunQueueLink<Element>::RunQueueLink()
-	: fIndex(0x7FFFFFFF), fPriority(0), fNext(NULL), fPrev(NULL) {}
-
-template <typename Element>
-RunQueueLink<Element>* RunQueueLinkImpl<Element>::GetRunQueueLink() {
-	return &fRunQueueLink;
-}
-
-template <typename Element>
-RunQueueLink<Element>* RunQueueStandardGetLink<Element>::operator()(
-	Element* element) const {
-	return element->GetRunQueueLink();
-}
-
-template <typename Element, RunQueueLink<Element> Element::*LinkMember>
-RunQueueLink<Element>* RunQueueMemberGetLink<Element, LinkMember>::operator()(
-	Element* element) const {
-	return &(element->*LinkMember);
-}
 
 RUN_QUEUE_TEMPLATE_LIST
 RUN_QUEUE_CLASS_NAME::RunQueue()
-	: fInitStatus(B_OK), fEligibleCount(0), fIneligibleCount(0), fTotalCount(0) {
-	memset(fEligibleHeap, 0, sizeof(fEligibleHeap));
-	memset(fIneligibleHeap, 0, sizeof(fIneligibleHeap));
-	memset(fBitmap, 0, sizeof(fBitmap));
-	memset(fPriorityCounts, 0, sizeof(fPriorityCounts));
-	memset(fPriorityHeads, 0, sizeof(fPriorityHeads));
+	: fFirstLevelBitmap(0),
+	  fRealTimeBitmap(0),
+	  fSystemVirtualTime(0),
+	  fTotalCount(0)
+{
+	memset(fSecondLevelBitmap, 0, sizeof(fSecondLevelBitmap));
 }
 
 RUN_QUEUE_TEMPLATE_LIST
-void RUN_QUEUE_CLASS_NAME::CheckEligibility(bigtime_t svt) {
-	while (fIneligibleCount > 0) {
-		Element* root = fIneligibleHeap[0];
-		if (root->IsEligible(svt)) {
-			// Guard: Ensure destination heap has space
-			if (fEligibleCount >= kMaxThreadsPerCore) {
-				dprintf("scheduler: WARNING: eligible heap full; skipping eligibility migration\n");
-				break;
-			}
-
-			// Remove from Ineligible
-			int32 lastIdx = fIneligibleCount - 1;
-			Element* last = fIneligibleHeap[lastIdx];
-			if (0 != lastIdx) {
-				fIneligibleHeap[0] = last;
-				sGetLink(last)->fIndex = -1; // Temp index for bubble
-				_BubbleDown(fIneligibleHeap, lastIdx, 0, false);
-			}
-			StoreRelease(fIneligibleCount, lastIdx);
-			sGetLink(root)->fIndex = 0x7FFFFFFF;
-
-			// Add to Eligible
-			int32 idx = fEligibleCount;
-			fEligibleHeap[idx] = root;
-			sGetLink(root)->fIndex = idx;
-			_BubbleUp(fEligibleHeap, idx + 1, idx, true);
-			StoreRelease(fEligibleCount, idx + 1);
-		} else {
-			break;
-		}
-	}
-}
-
-RUN_QUEUE_TEMPLATE_LIST
-void RUN_QUEUE_CLASS_NAME::PushBack(Element* element, unsigned int priority, bigtime_t svt) {
-	SCHEDULER_ENTER_FUNCTION();
-
-	RunQueueLink<Element>* link = sGetLink(element);
-	link->fPriority = priority;
-
-	if (priority <= MaxPriority)
-		_PushPriority(element, priority, false);
-
-	Traits::SetInRunQueue(element, true);
-
-	if (element->IsRealTime() || element->IsIdle() || element->IsEligible(svt)) {
-		if (fEligibleCount >= kMaxThreadsPerCore) {
-			panic("scheduler: eligible heap overflow (count=%d)", fEligibleCount);
-		}
-		AddAcquireRelease(fTotalCount, 1);
-		int32 idx = fEligibleCount;
-		fEligibleHeap[idx] = element;
-		link->fIndex = idx;
-		_BubbleUp(fEligibleHeap, idx + 1, idx, true);
-		StoreRelease(fEligibleCount, idx + 1);
-	} else {
-		if (fIneligibleCount >= kMaxThreadsPerCore) {
-			panic("scheduler: ineligible heap overflow (count=%d)", fIneligibleCount);
-		}
-		AddAcquireRelease(fTotalCount, 1);
-		int32 idx = fIneligibleCount;
-		fIneligibleHeap[idx] = element;
-		link->fIndex = -idx - 1;
-		_BubbleUp(fIneligibleHeap, idx + 1, idx, false);
-		StoreRelease(fIneligibleCount, idx + 1);
-	}
-}
-
-RUN_QUEUE_TEMPLATE_LIST
-void RUN_QUEUE_CLASS_NAME::PushFront(Element* element, unsigned int priority, bigtime_t svt) {
-	SCHEDULER_ENTER_FUNCTION();
-
-	RunQueueLink<Element>* link = sGetLink(element);
-	link->fPriority = priority;
-
-	if (priority <= MaxPriority)
-		_PushPriority(element, priority, true);
-
-	Traits::SetInRunQueue(element, true);
-
-	if (element->IsRealTime() || element->IsIdle() || element->IsEligible(svt)) {
-		if (fEligibleCount >= kMaxThreadsPerCore) {
-			panic("scheduler: eligible heap overflow (count=%d)", fEligibleCount);
-		}
-		AddAcquireRelease(fTotalCount, 1);
-		int32 idx = fEligibleCount;
-		fEligibleHeap[idx] = element;
-		link->fIndex = idx;
-		_BubbleUp(fEligibleHeap, idx + 1, idx, true);
-		StoreRelease(fEligibleCount, idx + 1);
-	} else {
-		if (fIneligibleCount >= kMaxThreadsPerCore) {
-			panic("scheduler: ineligible heap overflow (count=%d)", fIneligibleCount);
-		}
-		AddAcquireRelease(fTotalCount, 1);
-		int32 idx = fIneligibleCount;
-		fIneligibleHeap[idx] = element;
-		link->fIndex = -idx - 1;
-		_BubbleUp(fIneligibleHeap, idx + 1, idx, false);
-		StoreRelease(fIneligibleCount, idx + 1);
-	}
-}
-
-RUN_QUEUE_TEMPLATE_LIST
-void RUN_QUEUE_CLASS_NAME::Remove(Element* element) {
-	SCHEDULER_ENTER_FUNCTION();
-
-	RunQueueLink<Element>* link = sGetLink(element);
-	int32 rawIndex = link->fIndex;
-
-	if (rawIndex == 0x7FFFFFFF) return;
-
-	bool eligible = (rawIndex >= 0);
-	int32 index = eligible ? rawIndex : (-rawIndex - 1);
-	Element** heap = eligible ? fEligibleHeap : fIneligibleHeap;
-	int32& count = eligible ? fEligibleCount : fIneligibleCount;
-
-	if (index < 0 || index >= count || heap[index] != element)
+void RUN_QUEUE_CLASS_NAME::_GetIndices(bigtime_t deadline, int32& fli, int32& sli) const
+{
+	// Haiku bigtime_t is in microseconds.
+	bigtime_t delta = deadline - fSystemVirtualTime;
+	if (delta <= 0) {
+		fli = 0;
+		sli = 0;
 		return;
-
-	unsigned int priority = link->fPriority;
-	if (priority <= MaxPriority)
-		_RemovePriority(element, priority);
-
-	int32 lastIndex = count - 1;
-	Element* last = heap[lastIndex];
-
-	if (index != lastIndex) {
-		heap[index] = last;
-		sGetLink(last)->fIndex = eligible ? index : (-index - 1);
-
-		_BubbleUp(heap, lastIndex, index, eligible);
-		_BubbleDown(heap, lastIndex, index, eligible);
 	}
 
-	if (eligible)
-		StoreRelease(fEligibleCount, lastIndex);
-	else
-		StoreRelease(fIneligibleCount, lastIndex);
+	// Find the highest power of 2 using Count Leading Zeros instruction
+	uint32 d32 = (uint32)min_c((bigtime_t)0xFFFFFFFF, delta);
+	fli = 31 - __builtin_clz(d32);
+	if (fli >= PRIMARY_BINS) fli = PRIMARY_BINS - 1;
 
-	link->fIndex = 0x7FFFFFFF;
+	// Linearly divide the space between 2^fli and 2^(fli+1)
+	if (fli < 5) {
+		sli = d32 & ((1 << fli) - 1);
+		sli = (d32 - (1 << fli)) << (5 - fli);
+	} else {
+		sli = (d32 - (1 << fli)) >> (fli - 5);
+	}
+	sli &= 31;
+}
+
+RUN_QUEUE_TEMPLATE_LIST
+void RUN_QUEUE_CLASS_NAME::PushBack(Element* element, unsigned int priority, bigtime_t svt)
+{
+	fSystemVirtualTime = svt;
+	Thread* thread = element->GetThread();
+
+	Traits::SetInRunQueue(element, true);
+	atomic_add(&fTotalCount, 1);
+
+	if (priority >= 100) {
+		int32 index = priority - 100;
+		if (index < 0) index = 0;
+		if (index > 20) index = 20;
+		fRealTimeQueues[index].Add(element);
+		fRealTimeBitmap |= (1 << index);
+		thread->fli_index = -1; // Mark as RT
+		thread->sli_index = index;
+	} else {
+		int32 fli, sli;
+		_GetIndices(thread->virtual_deadline, fli, sli);
+		thread->fli_index = fli;
+		thread->sli_index = sli;
+
+		fQueues[fli][sli].Add(element);
+		fSecondLevelBitmap[fli] |= (1 << sli);
+		fFirstLevelBitmap |= (1 << fli);
+	}
+}
+
+RUN_QUEUE_TEMPLATE_LIST
+void RUN_QUEUE_CLASS_NAME::PushFront(Element* element, unsigned int priority, bigtime_t svt)
+{
+	fSystemVirtualTime = svt;
+	Thread* thread = element->GetThread();
+
+	Traits::SetInRunQueue(element, true);
+	atomic_add(&fTotalCount, 1);
+
+	if (priority >= 100) {
+		int32 index = priority - 100;
+		if (index < 0) index = 0;
+		if (index > 20) index = 20;
+		fRealTimeQueues[index].Add(element, false); // Add at head
+		fRealTimeBitmap |= (1 << index);
+		thread->fli_index = -1; // Mark as RT
+		thread->sli_index = index;
+	} else {
+		int32 fli, sli;
+		_GetIndices(thread->virtual_deadline, fli, sli);
+		thread->fli_index = fli;
+		thread->sli_index = sli;
+
+		fQueues[fli][sli].Add(element, false); // Add at head
+		fSecondLevelBitmap[fli] |= (1 << sli);
+		fFirstLevelBitmap |= (1 << fli);
+	}
+}
+
+RUN_QUEUE_TEMPLATE_LIST
+void RUN_QUEUE_CLASS_NAME::Remove(Element* element)
+{
+	Thread* thread = element->GetThread();
+
+	if (thread->fli_index < 0) {
+		int32 index = thread->sli_index;
+
+		fRealTimeQueues[index].Remove(element);
+		if (fRealTimeQueues[index].IsEmpty())
+			fRealTimeBitmap &= ~(1 << index);
+	} else {
+		int32 fli = thread->fli_index;
+		int32 sli = thread->sli_index;
+
+		fQueues[fli][sli].Remove(element);
+		if (fQueues[fli][sli].IsEmpty()) {
+			fSecondLevelBitmap[fli] &= ~(1 << sli);
+			if (fSecondLevelBitmap[fli] == 0)
+				fFirstLevelBitmap &= ~(1 << fli);
+		}
+	}
+
 	Traits::SetInRunQueue(element, false);
-	SubAcquireRelease(fTotalCount, 1);
+	atomic_add(&fTotalCount, -1);
 }
 
 RUN_QUEUE_TEMPLATE_LIST
-void RUN_QUEUE_CLASS_NAME::_PushPriority(Element* element, unsigned int priority, bool front) {
-	RunQueueLink<Element>* link = sGetLink(element);
-	if (fPriorityCounts[priority]++ == 0) {
-		fBitmap[priority / 32] |= (1U << (priority % 32));
-		fPriorityHeads[priority] = element;
-		link->fNext = element;
-		link->fPrev = element;
-	} else {
-		Element* head = fPriorityHeads[priority];
-		RunQueueLink<Element>* headLink = sGetLink(head);
-		Element* tail = headLink->fPrev;
-		RunQueueLink<Element>* tailLink = sGetLink(tail);
-
-		link->fNext = head;
-		link->fPrev = tail;
-		tailLink->fNext = element;
-		headLink->fPrev = element;
-
-		if (front)
-			fPriorityHeads[priority] = element;
-	}
-}
-
-RUN_QUEUE_TEMPLATE_LIST
-void RUN_QUEUE_CLASS_NAME::_RemovePriority(Element* element, unsigned int priority) {
-	RunQueueLink<Element>* link = sGetLink(element);
-	if (--fPriorityCounts[priority] == 0) {
-		fBitmap[priority / 32] &= ~(1U << (priority % 32));
-		fPriorityHeads[priority] = NULL;
-	} else {
-		Element* next = link->fNext;
-		Element* prev = link->fPrev;
-		sGetLink(next)->fPrev = prev;
-		sGetLink(prev)->fNext = next;
-		if (fPriorityHeads[priority] == element)
-			fPriorityHeads[priority] = next;
-	}
-	link->fNext = NULL;
-	link->fPrev = NULL;
-}
-
-RUN_QUEUE_TEMPLATE_LIST
-void RUN_QUEUE_CLASS_NAME::_BubbleUp(Element** heap, int32 count, int32 index, bool eligible) {
-	while (index > 0) {
-		int32 parent = (index - 1) / 2;
-		bool better = eligible ? sCompare(heap[index], heap[parent]) : _CompareIneligible(heap[index], heap[parent]);
-		if (better) {
-			_Swap(heap, index, parent, eligible);
-			index = parent;
-		} else
-			break;
-	}
-}
-
-RUN_QUEUE_TEMPLATE_LIST
-void RUN_QUEUE_CLASS_NAME::_BubbleDown(Element** heap, int32 count, int32 index, bool eligible) {
-	while (true) {
-		int32 left = 2 * index + 1;
-		int32 right = 2 * index + 2;
-		int32 smallest = index;
-
-		if (left < count) {
-			bool better = eligible ? sCompare(heap[left], heap[smallest]) : _CompareIneligible(heap[left], heap[smallest]);
-			if (better) smallest = left;
-		}
-		if (right < count) {
-			bool better = eligible ? sCompare(heap[right], heap[smallest]) : _CompareIneligible(heap[right], heap[smallest]);
-			if (better) smallest = right;
-		}
-
-		if (smallest != index) {
-			_Swap(heap, index, smallest, eligible);
-			index = smallest;
-		} else
-			break;
-	}
-}
-
-RUN_QUEUE_TEMPLATE_LIST
-void RUN_QUEUE_CLASS_NAME::_Swap(Element** heap, int32 i, int32 j, bool eligible) {
-	Element* temp = heap[i];
-	heap[i] = heap[j];
-	heap[j] = temp;
-
-	sGetLink(heap[i])->fIndex = eligible ? i : (-i - 1);
-	sGetLink(heap[j])->fIndex = eligible ? j : (-j - 1);
-}
-
-RUN_QUEUE_TEMPLATE_LIST
-Element* RUN_QUEUE_CLASS_NAME::ConstIterator::Next() {
-	if (fIndex < fList->fEligibleCount)
-		return fList->fEligibleHeap[fIndex++];
-
-	int32 ineligIdx = fIndex - fList->fEligibleCount;
-	if (ineligIdx < fList->fIneligibleCount) {
-		fIndex++;
-		return fList->fIneligibleHeap[ineligIdx];
-	}
-	return NULL;
-}
-
-RUN_QUEUE_TEMPLATE_LIST
-Element* RUN_QUEUE_CLASS_NAME::GetHead(unsigned int priority) const {
-	if (priority <= MaxPriority)
-		return fPriorityHeads[priority];
-	return NULL;
-}
-
-RUN_QUEUE_TEMPLATE_LIST
-template <typename Predicate>
-Element* RUN_QUEUE_CLASS_NAME::PeekOption(const Predicate& predicate) const {
-	for (int32 i = 0; i < fEligibleCount; i++) {
-		if (predicate(fEligibleHeap[i]))
-			return fEligibleHeap[i];
+Element* RUN_QUEUE_CLASS_NAME::PeekBest() const
+{
+	if (fRealTimeBitmap != 0) {
+		int32 index = 31 - __builtin_clz(fRealTimeBitmap);
+		return fRealTimeQueues[index].Head();
 	}
 
-	for (int32 i = 0; i < fIneligibleCount; i++) {
-		if (predicate(fIneligibleHeap[i]))
-			return fIneligibleHeap[i];
-	}
+	if (fFirstLevelBitmap == 0) return NULL;
 
-	return NULL;
+	int32 fli = __builtin_ctz(fFirstLevelBitmap);
+	int32 sli = __builtin_ctz(fSecondLevelBitmap[fli]);
+
+	return fQueues[fli][sli].Head();
 }
 
 RUN_QUEUE_TEMPLATE_LIST
 template <typename Compare2, typename Predicate>
 Element* RUN_QUEUE_CLASS_NAME::PeekBest(const Compare2& compare,
-										const Predicate& predicate) const {
+										const Predicate& predicate) const
+{
 	Element* best = NULL;
-	for (int32 i = 0; i < fEligibleCount; i++) {
-		if (predicate(fEligibleHeap[i])) {
-			if (best == NULL || compare(fEligibleHeap[i], best))
-				best = fEligibleHeap[i];
-		}
-	}
 
-	if (best == NULL) {
-		for (int32 i = 0; i < fIneligibleCount; i++) {
-			if (predicate(fIneligibleHeap[i])) {
-				if (best == NULL || compare(fIneligibleHeap[i], best))
-					best = fIneligibleHeap[i];
+	// Check Real-Time queues
+	uint32 rtBitmap = fRealTimeBitmap;
+	while (rtBitmap != 0) {
+		int32 index = 31 - __builtin_clz(rtBitmap);
+		typename DoublyLinkedList<Element, GetLink>::Iterator it = fRealTimeQueues[index].GetIterator();
+		while (it.HasNext()) {
+			Element* element = it.Next();
+			if (predicate(element)) {
+				if (best == NULL || compare(element, best))
+					best = element;
 			}
 		}
+		rtBitmap &= ~(1 << index);
+	}
+
+	// Check EEVDF matrix
+	uint32 flBitmap = fFirstLevelBitmap;
+	while (flBitmap != 0) {
+		int32 fli = __builtin_ctz(flBitmap);
+		uint32 slBitmap = fSecondLevelBitmap[fli];
+		while (slBitmap != 0) {
+			int32 sli = __builtin_ctz(slBitmap);
+			typename DoublyLinkedList<Element, GetLink>::Iterator it = fQueues[fli][sli].GetIterator();
+			while (it.HasNext()) {
+				Element* element = it.Next();
+				if (predicate(element)) {
+					if (best == NULL || compare(element, best))
+						best = element;
+				}
+			}
+			slBitmap &= ~(1 << sli);
+		}
+		flBitmap &= ~(1 << fli);
 	}
 
 	return best;
 }
 
 RUN_QUEUE_TEMPLATE_LIST
-GetLink RUN_QUEUE_CLASS_NAME::sGetLink;
+Element* RUN_QUEUE_CLASS_NAME::GetHead(unsigned int priority) const
+{
+	if (priority >= 100) {
+		int32 index = priority - 100;
+		if (index < 0) index = 0;
+		if (index > 20) index = 20;
+		return fRealTimeQueues[index].Head();
+	}
+
+	if (priority == B_IDLE_PRIORITY) {
+		return fQueues[0][0].Head();
+	}
+
+	return NULL;
+}
 
 RUN_QUEUE_TEMPLATE_LIST
-Compare RUN_QUEUE_CLASS_NAME::sCompare;
+Element* RUN_QUEUE_CLASS_NAME::PopNext()
+{
+	Element* element = PeekBest();
+	if (element != NULL)
+		Remove(element);
+	return element;
+}
+
+RUN_QUEUE_TEMPLATE_LIST
+GetLink RUN_QUEUE_CLASS_NAME::sGetLink;
 
 #endif	// RUN_QUEUE_H

--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -67,7 +67,10 @@ public:
 	inline Element* PeekMaximum() const { return PeekBest(); }
 
 	inline uint32 GetFirstLevelBitmap() const { return fFirstLevelBitmap; }
+	inline uint32 GetSecondLevelBitmap(int fli) const { return fSecondLevelBitmap[fli]; }
 	inline uint32 GetRealTimeBitmap() const { return fRealTimeBitmap; }
+
+	inline Element* GetBinHead(int fli, int sli) const { return fQueues[fli][sli].Head(); }
 
 	class ConstIterator {
 	public:

--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -16,8 +16,8 @@
 #include "scheduler_profiler.h"
 
 // For BMQ EEVDF mapping
-#define PRIMARY_BINS   32
-#define SECONDARY_BINS 32
+static const int32 kPrimaryBins = 32;
+static const int32 kSecondaryBins = 32;
 
 template <typename Element>
 class RunQueueStandardGetLink {
@@ -102,7 +102,7 @@ public:
 					if (fCurrent != NULL) return;
 
 					fSLI++;
-					if (fSLI >= SECONDARY_BINS) {
+					if (fSLI >= kSecondaryBins) {
 						fSLI = 0;
 						fFLI++;
 					}
@@ -124,8 +124,8 @@ public:
 
 		void _AdvanceBin()
 		{
-			while (fFLI < PRIMARY_BINS) {
-				while (fSLI < SECONDARY_BINS) {
+			while (fFLI < kPrimaryBins) {
+				while (fSLI < kSecondaryBins) {
 					fCurrent = fQueue->fQueues[fFLI][fSLI].Head();
 					if (fCurrent != NULL) return;
 					fSLI++;
@@ -149,8 +149,8 @@ private:
 	void _GetIndices(bigtime_t deadline, int32& fli, int32& sli) const;
 
 	uint32 fFirstLevelBitmap;
-	uint32 fSecondLevelBitmap[PRIMARY_BINS];
-	DoublyLinkedList<Element, GetLink> fQueues[PRIMARY_BINS][SECONDARY_BINS];
+	uint32 fSecondLevelBitmap[kPrimaryBins];
+	DoublyLinkedList<Element, GetLink> fQueues[kPrimaryBins][kSecondaryBins];
 
 	uint32 fRealTimeBitmap;
 	DoublyLinkedList<Element, GetLink> fRealTimeQueues[21];
@@ -184,8 +184,8 @@ void RUN_QUEUE_CLASS_NAME::_GetIndices(bigtime_t deadline, int32& fli, int32& sl
 
 	// Find the highest power of 2 using Count Leading Zeros instruction
 	uint32 d32 = (uint32)min_c((bigtime_t)0xFFFFFFFF, delta);
-	fli = 31 - __builtin_clz(d32);
-	if (fli >= PRIMARY_BINS) fli = PRIMARY_BINS - 1;
+	fli = fls(d32) - 1;
+	if (fli >= kPrimaryBins) fli = kPrimaryBins - 1;
 
 	// Linearly divide the space between 2^fli and 2^(fli+1)
 	if (fli < 5) {
@@ -229,6 +229,8 @@ void RUN_QUEUE_CLASS_NAME::PushBack(Element* element, unsigned int priority, big
 RUN_QUEUE_TEMPLATE_LIST
 void RUN_QUEUE_CLASS_NAME::PushFront(Element* element, unsigned int priority, bigtime_t svt)
 {
+	// For BMQ EEVDF, PushFront is similar to PushBack since ordering is by deadline,
+	// but within the same bin we can put it at the head.
 	fSystemVirtualTime = svt;
 	Thread* thread = element->GetThread();
 
@@ -286,14 +288,14 @@ RUN_QUEUE_TEMPLATE_LIST
 Element* RUN_QUEUE_CLASS_NAME::PeekBest() const
 {
 	if (fRealTimeBitmap != 0) {
-		int32 index = 31 - __builtin_clz(fRealTimeBitmap);
+		int32 index = fls(fRealTimeBitmap) - 1;
 		return fRealTimeQueues[index].Head();
 	}
 
 	if (fFirstLevelBitmap == 0) return NULL;
 
-	int32 fli = __builtin_ctz(fFirstLevelBitmap);
-	int32 sli = __builtin_ctz(fSecondLevelBitmap[fli]);
+	int32 fli = ffs(fFirstLevelBitmap) - 1;
+	int32 sli = ffs(fSecondLevelBitmap[fli]) - 1;
 
 	return fQueues[fli][sli].Head();
 }
@@ -308,7 +310,7 @@ Element* RUN_QUEUE_CLASS_NAME::PeekBest(const Compare2& compare,
 	// Check Real-Time queues
 	uint32 rtBitmap = fRealTimeBitmap;
 	while (rtBitmap != 0) {
-		int32 index = 31 - __builtin_clz(rtBitmap);
+		int32 index = fls(rtBitmap) - 1;
 		typename DoublyLinkedList<Element, GetLink>::Iterator it = fRealTimeQueues[index].GetIterator();
 		while (it.HasNext()) {
 			Element* element = it.Next();
@@ -323,10 +325,10 @@ Element* RUN_QUEUE_CLASS_NAME::PeekBest(const Compare2& compare,
 	// Check EEVDF matrix
 	uint32 flBitmap = fFirstLevelBitmap;
 	while (flBitmap != 0) {
-		int32 fli = __builtin_ctz(flBitmap);
+		int32 fli = ffs(flBitmap) - 1;
 		uint32 slBitmap = fSecondLevelBitmap[fli];
 		while (slBitmap != 0) {
-			int32 sli = __builtin_ctz(slBitmap);
+			int32 sli = ffs(slBitmap) - 1;
 			typename DoublyLinkedList<Element, GetLink>::Iterator it = fQueues[fli][sli].GetIterator();
 			while (it.HasNext()) {
 				Element* element = it.Next();

--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -195,11 +195,10 @@ void RUN_QUEUE_CLASS_NAME::_GetIndices(bigtime_t deadline, int32& fli, int32& sl
 	if (fli >= kPrimaryBins) fli = kPrimaryBins - 1;
 
 	// Linearly divide the space between 2^fli and 2^(fli+1)
-	if (fli < 5) {
-		sli = (d32 - (1 << fli)) << (5 - fli);
-	} else {
-		sli = (d32 - (1 << fli)) >> (fli - 5);
-	}
+	if (fli < 5)
+		sli = (d32 - (1U << fli)) << (5 - fli);
+	else
+		sli = (d32 - (1U << fli)) >> (fli - 5);
 	sli &= 31;
 }
 
@@ -302,8 +301,8 @@ Element* RUN_QUEUE_CLASS_NAME::PeekBest() const
 
 	if (fFirstLevelBitmap == 0) return NULL;
 
-	int32 fli = ffs(fFirstLevelBitmap) - 1;
-	int32 sli = ffs(fSecondLevelBitmap[fli]) - 1;
+	int32 fli = scheduler_ctz(fFirstLevelBitmap);
+	int32 sli = scheduler_ctz(fSecondLevelBitmap[fli]);
 
 	return fQueues[fli][sli].Head();
 }
@@ -333,10 +332,10 @@ Element* RUN_QUEUE_CLASS_NAME::PeekBest(const Compare2& compare,
 	// Check EEVDF matrix
 	uint32 flBitmap = fFirstLevelBitmap;
 	while (flBitmap != 0) {
-		int32 fli = ffs(flBitmap) - 1;
+		int32 fli = scheduler_ctz(flBitmap);
 		uint32 slBitmap = fSecondLevelBitmap[fli];
 		while (slBitmap != 0) {
-			int32 sli = ffs(slBitmap) - 1;
+			int32 sli = scheduler_ctz(slBitmap);
 			typename DoublyLinkedList<Element, GetLink>::Iterator it = fQueues[fli][sli].GetIterator();
 			while (it.HasNext()) {
 				Element* element = it.Next();

--- a/src/system/kernel/scheduler/RunQueue.h
+++ b/src/system/kernel/scheduler/RunQueue.h
@@ -62,7 +62,7 @@ public:
 
 	// Compatibility methods
 	inline status_t CheckCapacity(int32 count) { return B_OK; }
-	void CheckEligibility(bigtime_t svt) { fSystemVirtualTime = svt; }
+	void CheckEligibility(bigtime_t svt);
 	inline Element* PeekRoot() const { return PeekBest(); }
 	inline Element* PeekMaximum() const { return PeekBest(); }
 
@@ -172,6 +172,13 @@ RUN_QUEUE_CLASS_NAME::RunQueue()
 }
 
 RUN_QUEUE_TEMPLATE_LIST
+void RUN_QUEUE_CLASS_NAME::CheckEligibility(bigtime_t svt)
+{
+	if (IsEmpty())
+		fSystemVirtualTime = svt;
+}
+
+RUN_QUEUE_TEMPLATE_LIST
 void RUN_QUEUE_CLASS_NAME::_GetIndices(bigtime_t deadline, int32& fli, int32& sli) const
 {
 	// Haiku bigtime_t is in microseconds.
@@ -200,7 +207,8 @@ void RUN_QUEUE_CLASS_NAME::_GetIndices(bigtime_t deadline, int32& fli, int32& sl
 RUN_QUEUE_TEMPLATE_LIST
 void RUN_QUEUE_CLASS_NAME::PushBack(Element* element, unsigned int priority, bigtime_t svt)
 {
-	fSystemVirtualTime = svt;
+	if (IsEmpty())
+		fSystemVirtualTime = svt;
 	Thread* thread = element->GetThread();
 
 	Traits::SetInRunQueue(element, true);
@@ -231,7 +239,8 @@ void RUN_QUEUE_CLASS_NAME::PushFront(Element* element, unsigned int priority, bi
 {
 	// For BMQ EEVDF, PushFront is similar to PushBack since ordering is by deadline,
 	// but within the same bin we can put it at the head.
-	fSystemVirtualTime = svt;
+	if (IsEmpty())
+		fSystemVirtualTime = svt;
 	Thread* thread = element->GetThread();
 
 	Traits::SetInRunQueue(element, true);

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -57,7 +57,7 @@ bool gTrackCoreLoad;
 bool gTrackCPULoad;
 int32 gRandomSamples;
 
-int64 gDeadlineBucketSize __attribute__((aligned(8))) = 5000000;
+int64 gDeadlineBucketSize __attribute__((aligned(8))) = 5000;
 
 CoreType gMinCoreType = CORE_TYPE_UNKNOWN;
 CoreType gMaxCoreType = CORE_TYPE_UNKNOWN;
@@ -195,7 +195,7 @@ static status_t interaction_timer_hook(struct timer* timer) {
 	// and the DPC guard (sDPCPending) prevents duplicate DPC enqueueing.
 	StoreRelease(sTimerArmed, 0);
 
-	StoreRelease(sPendingDPCTarget, 5000000);
+	StoreRelease(sPendingDPCTarget, 5000);
 	if (GetAndSet(sDPCPending, 1) == 0) {
 		int64 target = (int64)LoadAcquire(sPendingDPCTarget);
 		if (DPCQueue::DefaultQueue(B_URGENT_DISPLAY_PRIORITY)
@@ -284,7 +284,7 @@ void scheduler_update_interaction_state(bigtime_t now) {
 	// atomic-get-and-set below.  Clearing sDPCPending unconditionally before
 	// the CAS wiped a concurrent CPU's already-queued flag, allowing both CPUs
 	// to satisfy the "old == 0" check and enqueue duplicate DPCs.
-	StoreRelease(sPendingDPCTarget, 1000000);
+	StoreRelease(sPendingDPCTarget, 1000);
 	if (GetAndSet(sDPCPending, 1) == 0) {
 		int64 target = (int64)LoadAcquire(sPendingDPCTarget);
 		if (DPCQueue::DefaultQueue(B_URGENT_DISPLAY_PRIORITY)
@@ -325,39 +325,39 @@ struct RunQueueScanner {
 		if (kMaxPrioritiesToCheckPerQueue <= 0)
 			return;
 
-		const uint32* bitmap = runQueue->GetBitmap();
 		int checked = 0;
 
-		for (int i = ThreadRunQueue::kBitmapSize - 1; i >= 0; i--) {
-			uint32 val = bitmap[i];
+		// Scan Real-Time threads
+		uint32 rtBitmap = runQueue->GetRealTimeBitmap();
+		while (rtBitmap != 0) {
+			int bit = fls(rtBitmap) - 1;
+			unsigned int priority = 100 + bit;
+			ThreadData* thread = runQueue->GetHead(priority);
+			if (thread != NULL) {
+				thread->_UpdatePriorityBoost(now);
+			}
+			if (++checked >= kMaxPrioritiesToCheckPerQueue)
+				return;
+			rtBitmap &= ~(1U << bit);
+		}
 
-			if (i == ThreadRunQueue::kBitmapSize - 1)
-				val &= kTopWordMask;
-
-			if (val == 0)
-				continue;
-
-			int bit = fls(val) - 1;
-			while (true) {
-				unsigned int priority = i * 32 + bit;
-				// Note: RunQueue scanner logic optimized for dual heaps.
-				// For priority boosting we update the most urgent thread
-				// in the requested priority bucket.
-				ThreadData* thread = runQueue->GetHead(priority);
-				// Count each visited priority slot toward the budget, even if
-				// the queue head is transiently NULL (e.g. concurrent dequeue or
-				// stale bitmap bit). This keeps scan work strictly bounded.
-				if (thread != NULL) {
+		// Scan EEVDF FairShare threads (fli_index bins)
+		uint32 flBitmap = runQueue->GetFirstLevelBitmap();
+		while (flBitmap != 0) {
+			int fli = __builtin_ctz(flBitmap);
+			// We scan the first non-empty sli_index bin of this fli_index
+			// since GetHead(priority < 100) is only implemented for B_IDLE_PRIORITY.
+			// However, _UpdatePriorityBoost expects a priority.
+			// Let's just scan B_IDLE_PRIORITY if it's there.
+			if (fli == 0) {
+				ThreadData* thread = runQueue->GetHead(B_IDLE_PRIORITY);
+				if (thread != NULL)
 					thread->_UpdatePriorityBoost(now);
-				}
 				if (++checked >= kMaxPrioritiesToCheckPerQueue)
 					return;
-
-				val &= ~(1U << bit);
-				if (val == 0)
-					break;
-				bit = fls(val) - 1;
 			}
+
+			flBitmap &= ~(1U << fli);
 		}
 	}
 };
@@ -433,12 +433,6 @@ static void UpdatePriorityBoostScalable(CoreEntry* core, CPUEntry* cpu,
 	// Note: Mask computation optimization. This mask is recomputed from a
 	// compile-time constant on every reschedule.  Hoist it to a static const so
 	// the compiler evaluates it once at startup.
-	static const uint32 kTopWordMask =
-		(uint32)((2ULL << (THREAD_MAX_SET_PRIORITY % 32)) - 1);
-
-	static_assert(THREAD_MAX_SET_PRIORITY < ThreadRunQueue::kBitmapSize * 32,
-				  "THREAD_MAX_SET_PRIORITY exceeds bitmap capacity");
-
 	// Throttle: only run the boost scan every 10 context switches to reduce
 	// overhead.
 	if (cpu->fRescheduleCount++ % 10 != 0)
@@ -454,7 +448,7 @@ static void UpdatePriorityBoostScalable(CoreEntry* core, CPUEntry* cpu,
 	// not the number of threads.
 	const int kMaxPrioritiesToCheckPerQueue = 5;
 
-	RunQueueScanner scanRunQueue(kTopWordMask, kMaxPrioritiesToCheckPerQueue,
+	RunQueueScanner scanRunQueue(0, kMaxPrioritiesToCheckPerQueue,
 								 now);
 
 	// Check Core RunQueue first to maintain Core -> CPU lock ordering
@@ -654,16 +648,17 @@ static bool enqueue(Thread* thread, bool newOne, Thread* waker, bigtime_t now) {
 	NotifySchedulerListeners(&SchedulerListener::ThreadEnqueuedInRunQueue,
 							 thread);
 
+	bool isRT = threadPriority >= 100;
 	int32 heapPriority = CPUPriorityHeap::GetKey(targetCPU);
 	if (threadPriority > heapPriority ||
 		(threadPriority == heapPriority && rescheduleNeeded) ||
-		wasRunQueueEmpty || requestPreemption) {
+		wasRunQueueEmpty || requestPreemption || isRT) {
 
 		// Note: Dynamic Preemption Granularity.
 		// Only trigger IPI if Delta(deadline) > epsilon.
 		// A more urgent thread (earlier deadline) only preempts if it is
 		// significantly more urgent (Delta > epsilon).
-		if (targetCPU->ID() != smp_get_current_cpu()) {
+		if (!isRT && targetCPU->ID() != smp_get_current_cpu()) {
 			bigtime_t epsilon = targetCPU->PreemptionThreshold();
 			Thread* running = gCPU[targetCPU->ID()].running_thread;
 			ThreadData* runningData = (running != NULL) ? running->scheduler_data : NULL;

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -344,12 +344,12 @@ struct RunQueueScanner {
 		// Scan EEVDF FairShare threads (fli_index bins)
 		uint32 flBitmap = runQueue->GetFirstLevelBitmap();
 		while (flBitmap != 0) {
-			int fli = __builtin_ctz(flBitmap);
+			int fli = scheduler_ctz(flBitmap);
 			// To ensure interactivity boosting for all FairShare threads,
 			// we iterate through the heads of non-empty bins.
 			uint32 slBitmap = runQueue->GetSecondLevelBitmap(fli);
 			while (slBitmap != 0) {
-				int sli = __builtin_ctz(slBitmap);
+				int sli = scheduler_ctz(slBitmap);
 				ThreadData* thread = runQueue->GetBinHead(fli, sli);
 				if (thread != NULL) {
 					thread->_UpdatePriorityBoost(now);

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -57,7 +57,7 @@ bool gTrackCoreLoad;
 bool gTrackCPULoad;
 int32 gRandomSamples;
 
-int64 gDeadlineBucketSize __attribute__((aligned(8))) = 5000;
+int64 gDeadlineBucketSize __attribute__((aligned(8))) = 5000000;
 
 CoreType gMinCoreType = CORE_TYPE_UNKNOWN;
 CoreType gMaxCoreType = CORE_TYPE_UNKNOWN;
@@ -195,7 +195,7 @@ static status_t interaction_timer_hook(struct timer* timer) {
 	// and the DPC guard (sDPCPending) prevents duplicate DPC enqueueing.
 	StoreRelease(sTimerArmed, 0);
 
-	StoreRelease(sPendingDPCTarget, 5000);
+	StoreRelease(sPendingDPCTarget, 5000000);
 	if (GetAndSet(sDPCPending, 1) == 0) {
 		int64 target = (int64)LoadAcquire(sPendingDPCTarget);
 		if (DPCQueue::DefaultQueue(B_URGENT_DISPLAY_PRIORITY)
@@ -284,7 +284,7 @@ void scheduler_update_interaction_state(bigtime_t now) {
 	// atomic-get-and-set below.  Clearing sDPCPending unconditionally before
 	// the CAS wiped a concurrent CPU's already-queued flag, allowing both CPUs
 	// to satisfy the "old == 0" check and enqueue duplicate DPCs.
-	StoreRelease(sPendingDPCTarget, 1000);
+	StoreRelease(sPendingDPCTarget, 1000000);
 	if (GetAndSet(sDPCPending, 1) == 0) {
 		int64 target = (int64)LoadAcquire(sPendingDPCTarget);
 		if (DPCQueue::DefaultQueue(B_URGENT_DISPLAY_PRIORITY)
@@ -345,18 +345,19 @@ struct RunQueueScanner {
 		uint32 flBitmap = runQueue->GetFirstLevelBitmap();
 		while (flBitmap != 0) {
 			int fli = __builtin_ctz(flBitmap);
-			// We scan the first non-empty sli_index bin of this fli_index
-			// since GetHead(priority < 100) is only implemented for B_IDLE_PRIORITY.
-			// However, _UpdatePriorityBoost expects a priority.
-			// Let's just scan B_IDLE_PRIORITY if it's there.
-			if (fli == 0) {
-				ThreadData* thread = runQueue->GetHead(B_IDLE_PRIORITY);
-				if (thread != NULL)
+			// To ensure interactivity boosting for all FairShare threads,
+			// we iterate through the heads of non-empty bins.
+			uint32 slBitmap = runQueue->GetSecondLevelBitmap(fli);
+			while (slBitmap != 0) {
+				int sli = __builtin_ctz(slBitmap);
+				ThreadData* thread = runQueue->GetBinHead(fli, sli);
+				if (thread != NULL) {
 					thread->_UpdatePriorityBoost(now);
+				}
 				if (++checked >= kMaxPrioritiesToCheckPerQueue)
 					return;
+				slBitmap &= ~(1 << sli);
 			}
-
 			flBitmap &= ~(1U << fli);
 		}
 	}

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -327,19 +327,9 @@ struct RunQueueScanner {
 
 		int checked = 0;
 
-		// Scan Real-Time threads
-		uint32 rtBitmap = runQueue->GetRealTimeBitmap();
-		while (rtBitmap != 0) {
-			int bit = fls(rtBitmap) - 1;
-			unsigned int priority = 100 + bit;
-			ThreadData* thread = runQueue->GetHead(priority);
-			if (thread != NULL) {
-				thread->_UpdatePriorityBoost(now);
-			}
-			if (++checked >= kMaxPrioritiesToCheckPerQueue)
-				return;
-			rtBitmap &= ~(1U << bit);
-		}
+		// Note: We skip Real-Time threads (priorities 100-120) because they
+		// follow a strict preemption policy and are not subject to interactivity
+		// priority boosting.
 
 		// Scan EEVDF FairShare threads (fli_index bins)
 		uint32 flBitmap = runQueue->GetFirstLevelBitmap();

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -93,8 +93,7 @@ struct LocalNodeStealAction {
 				} else {
 					// Victim no longer matches thief after lock acquisition.
 					// Push it back and abort this victim.
-					victim->PushBack(*stolen,
-									 (*stolen)->GetRunQueueLink()->fPriority);
+					victim->PushBack(*stolen, (*stolen)->GetThread()->priority);
 					*stolen = NULL;
 				}
 			}
@@ -168,8 +167,7 @@ struct GlobalRandomStealAction {
 				} else {
 					// Victim no longer matches thief after lock acquisition.
 					// Push it back and abort this victim.
-					victim->PushBack(*stolen,
-									 (*stolen)->GetRunQueueLink()->fPriority);
+					victim->PushBack(*stolen, (*stolen)->GetThread()->priority);
 					*stolen = NULL;
 				}
 			}
@@ -364,7 +362,7 @@ void CPUEntry::Stop() {
 void CPUEntry::PushFront(ThreadData* thread, int32 priority) {
 	SCHEDULER_ENTER_FUNCTION();
 	fRunQueue.PushFront(thread, priority, SystemVirtualTime());
-	AddRelease(fThreadCount, 1);
+	IncrementThreadCount();
 
 	if (!thread->IsIdle()) {
 		Core()->IncrementTotalThreadCount();
@@ -379,7 +377,7 @@ void CPUEntry::PushFront(ThreadData* thread, int32 priority) {
 void CPUEntry::PushBack(ThreadData* thread, int32 priority) {
 	SCHEDULER_ENTER_FUNCTION();
 	fRunQueue.PushBack(thread, priority, SystemVirtualTime());
-	AddRelease(fThreadCount, 1);
+	IncrementThreadCount();
 
 	if (!thread->IsIdle()) {
 		Core()->IncrementTotalThreadCount();
@@ -397,11 +395,11 @@ void CPUEntry::Remove(ThreadData* thread) {
 
 	// (defensive): capture the priority the thread was enqueued with to
 	// ensure symmetric counter updates.
-	int32 priority = thread->GetRunQueueLink()->fPriority;
+	int32 priority = thread->GetThread()->priority;
 
 	thread->SetDequeued();
 	fRunQueue.Remove(thread);
-	AddRelease(fThreadCount, -1);
+	DecrementThreadCount();
 
 	if (!thread->IsIdle()) {
 		Core()->DecrementTotalThreadCount();
@@ -534,6 +532,23 @@ ThreadData* CPUEntry::ChooseNextThread(ThreadData* oldThread, bool putAtBack,
 	int32 sharedPriority = -1;
 	if (sharedThread != NULL)
 		sharedPriority = sharedThread->GetEffectivePriority();
+
+	// BMQ EEVDF selection logic: Real-Time threads (priority >= 100) always win.
+	if (oldPriority >= 100) {
+		if (oldPriority > pinnedPriority && oldPriority > sharedPriority) {
+			// case A: oldThread is best.
+			if (sharedThreadIsFloating) {
+				// Re-enqueue stolen thread
+				cpuLocker.Unlock();
+				coreLocker.Unlock();
+				bool dummy1, dummy2, updateInteraction;
+				sharedThread->Enqueue(dummy1, dummy2, updateInteraction, now);
+				if (updateInteraction)
+					scheduler_update_interaction_state(now);
+			}
+			return oldThread;
+		}
+	}
 
 	int32 rest = max_c(pinnedPriority, sharedPriority);
 	if (oldPriority > rest || (!putAtBack && oldPriority == rest)) {
@@ -814,8 +829,7 @@ ThreadData* CPUEntry::_TryStealWork(bigtime_t now) {
 				} else {
 					// Victim no longer matches thief after lock acquisition.
 					// Push it back and abort this victim.
-					victim->PushBack(stolen,
-									 stolen->GetRunQueueLink()->fPriority);
+					victim->PushBack(stolen, stolen->GetThread()->priority);
 					stolen = NULL;
 				}
 			}
@@ -1009,7 +1023,7 @@ void CoreEntry::PushFront(ThreadData* thread, int32 priority) {
 
 	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
 	fRunQueue.PushFront(thread, priority, cpu->SystemVirtualTime());
-	AddRelease(fThreadCount, 1);
+	IncrementThreadCount();
 	IncrementTotalThreadCount();
 	if (priority >= B_DISPLAY_PRIORITY)
 		IncrementDisplayThreadCount();
@@ -1021,7 +1035,7 @@ void CoreEntry::PushBack(ThreadData* thread, int32 priority) {
 
 	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
 	fRunQueue.PushBack(thread, priority, cpu->SystemVirtualTime());
-	AddRelease(fThreadCount, 1);
+	IncrementThreadCount();
 	IncrementTotalThreadCount();
 	if (priority >= B_DISPLAY_PRIORITY)
 		IncrementDisplayThreadCount();
@@ -1036,11 +1050,11 @@ void CoreEntry::Remove(ThreadData* thread) {
 
 	// (defensive): capture the enqueued priority to ensure consistent
 	// fDisplayThreadCount accounting.
-	int32 priority = thread->GetRunQueueLink()->fPriority;
+	int32 priority = thread->GetThread()->priority;
 
 	thread->SetDequeued();
 
-	AddRelease(fThreadCount, -1);
+	DecrementThreadCount();
 	DecrementTotalThreadCount();
 	if (priority >= B_DISPLAY_PRIORITY)
 		DecrementDisplayThreadCount();

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -97,6 +97,9 @@ public:
 	inline bool TryLockRunQueue();
 	inline void UnlockRunQueue();
 
+	inline void IncrementThreadCount() { AddRelease(fThreadCount, 1); }
+	inline void DecrementThreadCount() { AddRelease(fThreadCount, -1); }
+
 	// Index of this CPU within its core, assigned sequentially in AddCPU.
 	// Used by UpdatePriorityBoostScalable for round-robin epoch ownership.
 	// Public because UpdatePriorityBoostScalable is a file-scope function.
@@ -259,6 +262,9 @@ public:
 	inline void LockRunQueue();
 	inline bool TryLockRunQueue();
 	inline void UnlockRunQueue();
+
+	inline void IncrementThreadCount() { AddRelease(fThreadCount, 1); }
+	inline void DecrementThreadCount() { AddRelease(fThreadCount, -1); }
 	// Note: lockless check for display-priority threads in the
 	// run queue.  Used by ComputeQuantum to avoid TryLockRunQueue on the
 	// scheduling hot path.

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -57,12 +57,12 @@ void ThreadData::_InitBase() {
 	StoreRelease64(fLastMeasureAvailableTime, 0);
 	StoreRelease64(fMeasureAvailableTime, 0);
 
-	StoreRelease64(fWeight, get_weight(fThread->priority));
+	StoreRelease64(fThread->sched_weight, (int64)get_weight(fThread->priority));
 	StoreRelease64(fRequestSize, 0); // Use dynamic scaling by default
 	StoreRelease64(fLag, 0);
 
-	StoreRelease64(fVirtualRuntime, 0);
-	StoreRelease64(fVirtualDeadline, 0);
+	StoreRelease64(fThread->virtual_runtime, 0);
+	StoreRelease64(fThread->virtual_deadline, 0);
 
 	fInteractivityScore = 500;
 
@@ -165,7 +165,7 @@ void ThreadData::Init(bigtime_t now) {
 		int retries = 0;
 		do {
 			homeA = LoadAcquire(currentThreadData->fHomePackage);
-			vrt = (bigtime_t)LoadAcquire64(currentThreadData->fVirtualRuntime);
+			vrt = (bigtime_t)LoadAcquire64(currentThread->virtual_runtime);
 			homeB = LoadAcquire(currentThreadData->fHomePackage);
 		} while (homeA != homeB && ++retries < 8);
 
@@ -175,11 +175,11 @@ void ThreadData::Init(bigtime_t now) {
 			homeB = -1;
 		}
 
-		StoreRelease64(fVirtualRuntime, (int64)vrt);
+		StoreRelease64(fThread->virtual_runtime, (int64)vrt);
 		StoreRelease(fHomePackage, homeB);
 	} else {
 		fNeededLoad = 0;
-		StoreRelease64(fVirtualRuntime, 0);
+		StoreRelease64(fThread->virtual_runtime, 0);
 		StoreRelease(fHomePackage, -1);
 	}
 
@@ -656,12 +656,12 @@ void ThreadData::_UpdateDeadline(bigtime_t now) {
 	// A floor using a real-time constant (like base_quantum) would unfairly
 	// penalize high-priority threads by capping their latency advantage.
 
-	StoreRelease64(fVirtualDeadline, (int64)(GetVirtualRuntime() + slice));
+	StoreRelease64(fThread->virtual_deadline, (int64)(GetVirtualRuntime() + slice));
 
 	_ComputeEffectivePriority(now);
 
 	// Update EEVDF weight to match the current base priority.
-	StoreRelease64(fWeight, get_weight(fThread->priority));
+	StoreRelease64(fThread->sched_weight, (int64)get_weight(fThread->priority));
 }
 
 
@@ -696,7 +696,7 @@ void ThreadData::_ComputeEffectivePriority(bigtime_t now) const {
 		bigtime_t svt = (core != NULL) ? core->SystemVirtualTime() : now;
 
 		bigtime_t diff =
-			(bigtime_t)LoadAcquire64(fVirtualDeadline) -
+			(bigtime_t)LoadAcquire64(fThread->virtual_deadline) -
 			svt;
 
 		// Convert Virtual difference back to Real difference (nanoseconds)
@@ -849,5 +849,5 @@ void ThreadData::ResetPriorityBoost(bigtime_t now) {
 	_ComputeEffectivePriority(now);
 
 	// Update EEVDF weight to match the current base priority.
-	StoreRelease64(fWeight, get_weight(fThread->priority));
+	StoreRelease64(fThread->sched_weight, (int64)get_weight(fThread->priority));
 }

--- a/src/system/kernel/scheduler/scheduler_thread.cpp
+++ b/src/system/kernel/scheduler/scheduler_thread.cpp
@@ -57,7 +57,7 @@ void ThreadData::_InitBase() {
 	StoreRelease64(fLastMeasureAvailableTime, 0);
 	StoreRelease64(fMeasureAvailableTime, 0);
 
-	StoreRelease64(fThread->sched_weight, (int64)get_weight(fThread->priority));
+	StoreRelease(fThread->sched_weight, (int32)get_weight(fThread->priority));
 	StoreRelease64(fRequestSize, 0); // Use dynamic scaling by default
 	StoreRelease64(fLag, 0);
 
@@ -661,7 +661,7 @@ void ThreadData::_UpdateDeadline(bigtime_t now) {
 	_ComputeEffectivePriority(now);
 
 	// Update EEVDF weight to match the current base priority.
-	StoreRelease64(fThread->sched_weight, (int64)get_weight(fThread->priority));
+	StoreRelease(fThread->sched_weight, (int32)get_weight(fThread->priority));
 }
 
 
@@ -849,5 +849,5 @@ void ThreadData::ResetPriorityBoost(bigtime_t now) {
 	_ComputeEffectivePriority(now);
 
 	// Update EEVDF weight to match the current base priority.
-	StoreRelease64(fThread->sched_weight, (int64)get_weight(fThread->priority));
+	StoreRelease(fThread->sched_weight, (int32)get_weight(fThread->priority));
 }

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -155,7 +155,7 @@ public:
 	}
 
 	SCHEDULER_INLINE int64 GetWeight() const {
-		int64 weight = (int64)LoadAcquire64(fThread->sched_weight);
+		int64 weight = (int64)LoadAcquire(fThread->sched_weight);
 		return (weight > 0) ? weight : 1;
 	}
 

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -169,6 +169,7 @@ public:
 
 	SCHEDULER_INLINE void SetQuantum(bigtime_t quantum) {
 		StoreRelease64(fBaseQuantum, (int64)quantum);
+		StoreRelease64(fThread->time_slice, (int64)quantum);
 	}
 
 	SCHEDULER_INLINE bool IsEnqueued() const { return fEnqueued; }

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -23,8 +23,10 @@ struct RunQueueTraits<ThreadData> {
 };
 
 struct CACHE_LINE_ALIGN ThreadData
-	: public DoublyLinkedListLinkImpl<ThreadData>,
-	  RunQueueLinkImpl<ThreadData> {
+	: public DoublyLinkedListLinkImpl<ThreadData> {
+public:
+	inline DoublyLinkedListLink<ThreadData>* GetRunQueueLink() { return &fRunQueueLink; }
+
 private:
 	inline void _InitBase();
 
@@ -145,15 +147,15 @@ public:
 	static bigtime_t sMaxLatency __attribute__((aligned(8)));
 
 	SCHEDULER_INLINE bigtime_t GetVirtualRuntime() const {
-		return (bigtime_t)LoadAcquire64(fVirtualRuntime);
+		return (bigtime_t)LoadAcquire64(fThread->virtual_runtime);
 	}
 
 	SCHEDULER_INLINE bigtime_t GetVirtualDeadline() const {
-		return (bigtime_t)LoadAcquire64(fVirtualDeadline);
+		return (bigtime_t)LoadAcquire64(fThread->virtual_deadline);
 	}
 
 	SCHEDULER_INLINE int64 GetWeight() const {
-		int64 weight = LoadAcquire64(fWeight);
+		int64 weight = (int64)LoadAcquire64(fThread->sched_weight);
 		return (weight > 0) ? weight : 1;
 	}
 
@@ -239,14 +241,12 @@ private:
 	int32 fNeededLoad;
 	uint32 fLoadMeasurementEpoch;
 
-	int64 fWeight __attribute__((aligned(8)));
 	bigtime_t fRequestSize __attribute__((aligned(8)));
 	int64 fLag __attribute__((aligned(8)));
 
-	bigtime_t fVirtualRuntime __attribute__((aligned(8)));
-	bigtime_t fVirtualDeadline __attribute__((aligned(8)));
-
 	int32 fInteractivityScore;
+
+	DoublyLinkedListLink<ThreadData> fRunQueueLink;
 
 	CoreEntry* fCore __attribute__((aligned(8)));
 };
@@ -679,7 +679,7 @@ inline bool ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption,
 				bigtime_t vLagFloor = (kMaxLagFloor * 1000000LL) / weight;
 
 				if (vrt < svt - vLagFloor)
-					StoreRelease64(fVirtualRuntime, (int64)(svt - vLagFloor));
+					StoreRelease64(fThread->virtual_runtime, (int64)(svt - vLagFloor));
 
 				_UpdateDeadline(now);
 			}
@@ -788,7 +788,7 @@ inline bool ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption,
 			bigtime_t vLagFloor = (kMaxLagFloor * 1000000LL) / weight;
 
 			if (vrt < svt - vLagFloor)
-				StoreRelease64(fVirtualRuntime, (int64)(svt - vLagFloor));
+				StoreRelease64(fThread->virtual_runtime, (int64)(svt - vLagFloor));
 
 			_UpdateDeadline(now);
 		}
@@ -883,11 +883,11 @@ inline void ThreadData::UpdateVirtualRuntime(bigtime_t delta, bigtime_t svt,
 	bigtime_t ceiling =
 		(svt > B_INT64_MAX - kLookahead) ? B_INT64_MAX : svt + kLookahead;
 
-	bigtime_t vRuntime = (bigtime_t)LoadAcquire64(fVirtualRuntime);
+	bigtime_t vRuntime = (bigtime_t)LoadAcquire64(fThread->virtual_runtime);
 	while (vRuntime < ceiling) {
 		bigtime_t next = (vRuntime < ceiling - delta) ? vRuntime + delta : ceiling;
 
-		bigtime_t old = (bigtime_t)TestAndSet64(fVirtualRuntime, (int64)next,
+		bigtime_t old = (bigtime_t)TestAndSet64(fThread->virtual_runtime, (int64)next,
 												(int64)vRuntime);
 		if (old == vRuntime)
 			break;


### PR DESCRIPTION
Implemented a Two-Level Bitmapped Multi-Queue (BMQ) EEVDF Scheduler in Haiku OS. This architecture maps FairShare threads into a 32x32 exponential-linear matrix for O(1) selection and manages Real-Time threads via a dedicated priority mask. The implementation ensures microsecond precision for EEVDF deadlines and robust thread management across priority changes and multi-core systems.

---
*PR created automatically by Jules for task [14992115533394252067](https://jules.google.com/task/14992115533394252067) started by @tonestone57*