### PR TITLE
Implement Tiered Work-Stealing and NUMA Gating in Scheduler

### DIFF
--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -495,6 +495,7 @@ static status_t topology_validation_error(status_t strictStatus,
 
 
 static int32* sPackageToNode;
+static int32* sNodeToNUMA;
 static int32* sCPUToCluster = NULL;
 
 static void UpdatePriorityBoostScalable(CoreEntry* core, CPUEntry* cpu,
@@ -1464,6 +1465,7 @@ static status_t build_topology_mappings(int32& cpuCount, int32& coreCount,
 	delete[] sCPUToCore;
 	delete[] sCPUToCluster;
 	delete[] sPackageToNode;
+	delete[] sNodeToNUMA;
 	delete[] sCPUToPackage;
 
 	sCPUToCore = new (std::nothrow) int32[cpuCount];
@@ -1475,13 +1477,15 @@ static status_t build_topology_mappings(int32& cpuCount, int32& coreCount,
 	// write on systems where the topology detection produces packageCount ==
 	// cpuCount entries.
 	sPackageToNode = new (std::nothrow) int32[cpuCount + 1];
+	sNodeToNUMA = new (std::nothrow) int32[cpuCount + 1];
 	sCPUToPackage = new (std::nothrow) int32[cpuCount];
 
 	if (sCPUToCore == NULL || sCPUToCluster == NULL || sPackageToNode == NULL ||
-		sCPUToPackage == NULL) {
+		sNodeToNUMA == NULL || sCPUToPackage == NULL) {
 		delete[] sCPUToCore;
 		delete[] sCPUToCluster;
 		delete[] sPackageToNode;
+		delete[] sNodeToNUMA;
 		delete[] sCPUToPackage;
 		return B_NO_MEMORY;
 	}
@@ -1497,12 +1501,14 @@ static status_t build_topology_mappings(int32& cpuCount, int32& coreCount,
 
 	// Safe upper bound allocation for mapping packages to nodes
 	ArrayDeleter<int32> packageToNodeDeleter(sPackageToNode);
+	ArrayDeleter<int32> nodeToNUMADeleterMap(sNodeToNUMA);
 
-	// sPackageToNode is the only mapping array not zero-initialized.
-	// Packages that are never written (guard short-circuits) carry heap
-	// garbage, which init() then uses as a node index, mapping the package to a
-	// non-existent SchedulerNode.
+	// sPackageToNode and sNodeToNUMA are the only mapping arrays not
+	// zero-initialized. Packages that are never written (guard
+	// short-circuits) carry heap garbage, which init() then uses as a node
+	// index, mapping the package to a non-existent SchedulerNode.
 	memset(sPackageToNode, 0, sizeof(int32) * (cpuCount + 1));
+	memset(sNodeToNUMA, 0, sizeof(int32) * (cpuCount + 1));
 
 	// First pass: logical topology from ACPI/Device Tree
 	const cpu_topology_node* root = get_cpu_topology();
@@ -1600,8 +1606,10 @@ static status_t build_topology_mappings(int32& cpuCount, int32& coreCount,
 
 		if (coresInL3 > 0) {
 			// Note: ensure we don't write past cpuCount.
-			if (packageCount < cpuCount)
+			if (packageCount < cpuCount) {
 				sPackageToNode[packageCount] = currentNodeID;
+				sNodeToNUMA[currentNodeID] = sCPUToPackage[cpuList[l3Start]];
+			}
 
 			// Note: when this is the very last package that fits
 			// within the cpuCount limit AND we are at the boundary where
@@ -1624,8 +1632,11 @@ static status_t build_topology_mappings(int32& cpuCount, int32& coreCount,
 					currentNodeID = nodeCount++;
 					coresInCurrentNode = 0;
 
-					if (packageCount < cpuCount)
+					if (packageCount < cpuCount) {
 						sPackageToNode[packageCount] = currentNodeID;
+						sNodeToNUMA[currentNodeID] =
+							sCPUToPackage[cpuList[l3Start]];
+					}
 				}
 
 				int32 clusterSize =
@@ -1642,6 +1653,8 @@ static status_t build_topology_mappings(int32& cpuCount, int32& coreCount,
 						clusterIndex++;
 						packageCount++;
 						sPackageToNode[packageCount] = currentNodeID;
+						sNodeToNUMA[currentNodeID] =
+							sCPUToPackage[cpuList[l3Start]];
 					}
 					// Note: Package limit guard documentation. when the guard
 					// above prevents a new package from being created, the
@@ -1710,6 +1723,7 @@ static status_t init() {
 	ArrayDeleter<int32> cpuToPackageDeleter(sCPUToPackage);
 	ArrayDeleter<int32> cpuToClusterDeleter(sCPUToCluster);
 	ArrayDeleter<int32> packageToNodeDeleter(sPackageToNode);
+	ArrayDeleter<int32> nodeToNUMADeleter(sNodeToNUMA);
 
 	if (packageCount > 4096) {
 		dprintf("scheduler: system has too many packages (%" B_PRId32
@@ -1746,7 +1760,10 @@ static status_t init() {
 		return B_NO_MEMORY;
 	ArrayDeleter<SchedulerNode> schedulerNodesDeleter(gSchedulerNodes);
 
-	for (int32 i = 0; i < nodeCount; i++) gSchedulerNodes[i].Init(i);
+	for (int32 i = 0; i < nodeCount; i++) {
+		gSchedulerNodes[i].Init(i);
+		gSchedulerNodes[i].SetNUMAID(sNodeToNUMA[i]);
+	}
 
 	gCPUEntries = new (std::nothrow) CPUEntry[cpuCount];
 	gCoreEntries = new (std::nothrow) CoreEntry[coreCount];

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -1700,6 +1700,7 @@ static status_t build_topology_mappings(int32& cpuCount, int32& coreCount,
 	cpuToPackageDeleter.Detach();
 	cpuToClusterDeleter.Detach();
 	packageToNodeDeleter.Detach();
+	nodeToNUMADeleterMap.Detach();
 	return B_OK;
 }
 

--- a/src/system/kernel/scheduler/scheduler_common.h
+++ b/src/system/kernel/scheduler/scheduler_common.h
@@ -287,7 +287,8 @@ const bigtime_t kForegroundVRuntimeOffset = 5000000;
 
 const bigtime_t kMaxLagFloor = 200000;
 
-const int64 kNUMANodeLagThreshold = 1000000;
+const int64 kL3LagThreshold = 1000000;
+const int64 kNUMANodeLagThreshold = 2000000;
 const int64 kGlobalLagThreshold = 5000000;
 
 struct ThreadDataVRuntimeCompare {

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -52,6 +52,9 @@ struct LocalNodeStealAction {
 		if (entry == package)
 			return false;
 
+		if (entry->IdleCoreCount() == entry->CoreCount())
+			return false;
+
 		int32 victimCoreCount = entry->RegisteredCoreCount();
 		if (victimCoreCount == 0)
 			return false;
@@ -79,7 +82,7 @@ struct LocalNodeStealAction {
 		if (*stolen != NULL) {
 			// We have the victim's run-queue lock.
 			bool success = false;
-			if ((*stolen)->GetLag() >= kNUMANodeLagThreshold) {
+			if ((*stolen)->GetLag() >= kL3LagThreshold) {
 				// Re-verify affinity under the lock (mostly redundant but safe).
 				const CPUSet& threadMask = (*stolen)->GetThread()->cpumask;
 				if (threadMask.IsEmpty() || threadMask.GetBit(cpu->ID())) {
@@ -104,15 +107,15 @@ struct LocalNodeStealAction {
 	}
 };
 
-struct GlobalRandomStealAction {
+struct NUMARandomStealAction {
 	CPUEntry* cpu;
 	PackageEntry* package;
 	ThreadData** stolen;
 	const CPUSet& enabled;
 	bigtime_t now;
 
-	GlobalRandomStealAction(CPUEntry* c, PackageEntry* p, ThreadData** s,
-							const CPUSet& e, bigtime_t n)
+	NUMARandomStealAction(CPUEntry* c, PackageEntry* p, ThreadData** s,
+						  const CPUSet& e, bigtime_t n)
 		: cpu(c), package(p), stolen(s), enabled(e), now(n) {}
 
 	bool operator()(PackageEntry* entry) const {
@@ -152,7 +155,7 @@ struct GlobalRandomStealAction {
 		if (*stolen != NULL) {
 			// We have the victim's run-queue lock.
 			bool success = false;
-			if ((*stolen)->GetLag() >= kGlobalLagThreshold) {
+			if ((*stolen)->GetLag() >= kNUMANodeLagThreshold) {
 				// Re-verify affinity under the lock.
 				const CPUSet& threadMask = (*stolen)->GetThread()->cpumask;
 				if (threadMask.IsEmpty() || threadMask.GetBit(cpu->ID())) {
@@ -160,6 +163,106 @@ struct GlobalRandomStealAction {
 					(*stolen)->fStolen = true;
 					cpu->Core()->IncrementTotalThreadCount();
 					success = true;
+				}
+			}
+
+			if (!success) {
+				// Thread not under-served enough or affinity changed; restore
+				// it.
+				victim->PushBack(*stolen, stolenPriority);
+				*stolen = NULL;
+			}
+
+			victim->UnlockRunQueue();
+			return success;
+		}
+
+		return false;
+	}
+};
+
+struct GlobalRandomStealAction {
+	CPUEntry* cpu;
+	PackageEntry* package;
+	ThreadData** stolen;
+	const CPUSet& enabled;
+	bigtime_t now;
+
+	GlobalRandomStealAction(CPUEntry* c, PackageEntry* p, ThreadData** s,
+							const CPUSet& e, bigtime_t n)
+		: cpu(c), package(p), stolen(s), enabled(e), now(n) {}
+
+	bool operator()(PackageEntry* entry) const {
+		if (*stolen != NULL)
+			return true;
+
+		if (entry == package)
+			return false;
+
+		int32 victimCoreCount = entry->RegisteredCoreCount();
+		if (victimCoreCount == 0)
+			return false;
+
+		int32 coreIndex =
+			(int32)get_random_index(cpu->GetRandom(), victimCoreCount);
+		CoreEntry* victim = entry->GetCore(coreIndex);
+
+		if (victim == NULL)
+			return false;
+
+		if ((entry->IdleCoreMask() &
+			 ((native_cpu_mask_t)1 << victim->PackageIndex())) != 0)
+			return false;
+
+		// Lock-Free Bit-Stealing Phase 1: Atomic Remote Scanning
+		if (victim->RunQueue()->GetRealTimeBitmap() == 0 &&
+			victim->RunQueue()->GetFirstLevelBitmap() == 0)
+			return false;
+
+		int32 stolenPriority = -1;
+		// Lock-Free Bit-Stealing Phase 2: Atomic Steal Attempt
+		*stolen = victim->StealThreadLockless(stolenPriority, cpu->ID());
+
+		if (*stolen != NULL) {
+			// We have the victim's run-queue lock.
+			bool success = false;
+
+			int32 myNUMA = -1;
+			CoreEntry* myCore = cpu->Core();
+			if (myCore != NULL && myCore->Package() != NULL &&
+				myCore->Package()->Node() != NULL) {
+				myNUMA = myCore->Package()->Node()->NUMAID();
+			}
+
+			int32 victimNUMA = -1;
+			if (entry->Node() != NULL)
+				victimNUMA = entry->Node()->NUMAID();
+
+			bool crossNUMA =
+				(myNUMA != -1 && victimNUMA != -1 && myNUMA != victimNUMA);
+			int64 threshold =
+				crossNUMA ? kGlobalLagThreshold : kNUMANodeLagThreshold;
+
+			if ((*stolen)->GetLag() >= threshold) {
+				// Task-Type Gating: Threads with high interactivity or display
+				// priority should never be stolen across NUMA nodes.
+				bool interactive = (*stolen)->GetEffectivePriority() >=
+									   B_DISPLAY_PRIORITY ||
+								   (*stolen)->GetThread()->priority >=
+									   B_DISPLAY_PRIORITY ||
+								   (*stolen)->InteractivityScore() > 750;
+
+				if (crossNUMA && interactive) {
+					success = false;
+				} else {
+					// Re-verify affinity under the lock.
+					const CPUSet& threadMask = (*stolen)->GetThread()->cpumask;
+					if (threadMask.IsEmpty() || threadMask.GetBit(cpu->ID())) {
+						(*stolen)->MigrateTo(cpu->Core(), now);
+						(*stolen)->fStolen = true;
+						cpu->Core()->IncrementTotalThreadCount();
+						success = true;
+					}
 				}
 			}
 
@@ -522,10 +625,29 @@ ThreadData* CPUEntry::ChooseNextThread(ThreadData* oldThread, bool putAtBack,
 	if (pinnedThread != NULL)
 		pinnedPriority = pinnedThread->GetEffectivePriority();
 
-	ThreadData* sharedThread = core->PeekThread();
-	if (sharedThread == NULL && pinnedThread == NULL) {
-		// try to steal work from other cores in the same package
-		sharedThread = _TryStealWork(now);
+	// Tiered search to avoid SMT contention:
+	// 1. Pinned threads (already peeked)
+	// 2. Shared threads if core is idle (no SMT contention)
+	// 3. Work-stealing from other physical cores (Phase 1-4)
+	// 4. Shared threads if core is busy (accept SMT contention)
+	ThreadData* sharedThread = NULL;
+	if (pinnedThread == NULL) {
+		if (core->CPUCount() == 1 || core->ThreadCount() == 0)
+			sharedThread = core->PeekThread();
+
+		if (sharedThread == NULL)
+			sharedThread = _TryStealWorkL3(now);
+
+		if (sharedThread == NULL)
+			sharedThread = _TryStealWorkNUMA(now);
+
+		if (sharedThread == NULL)
+			sharedThread = _TryStealWorkGlobal(now);
+
+		if (sharedThread == NULL)
+			sharedThread = core->PeekThread();
+	} else {
+		sharedThread = core->PeekThread();
 	}
 
 	bool sharedThreadIsFloating =
@@ -754,13 +876,7 @@ uint32 CPUEntry::GetRandom() {
 	return (uint32)((x * 0x2545F4914F6CDD1DULL) >> 32);
 }
 
-ThreadData* CPUEntry::_TryStealWork(bigtime_t now) {
-	SCHEDULER_ENTER_FUNCTION();
-
-	// Note: Formal EEVDF Hierarchical Work-Stealing.
-	// Phase 1 (Sibling): Try to steal from a sibling core sharing cache.
-
-	// iterate over other cores in the package and try to steal work
+ThreadData* CPUEntry::_TryStealWorkL3(bigtime_t now) {
 	CoreEntry* core = atomic_pointer_get<CoreEntry>(&fCore);
 	PackageEntry* package = core->Package();
 
@@ -768,35 +884,10 @@ ThreadData* CPUEntry::_TryStealWork(bigtime_t now) {
 	if (registeredCores <= 1)
 		return NULL;
 
-	// (clarification): The subtraction-wrap "index -= registeredCores"
-	// is safe because startIndex < registeredCores and i < registeredCores,
-	// so startIndex + i < 2 * registeredCores, requiring at most one
-	// subtraction. (clarification): GetIdleCorePacking shift guard - when
-	// shift==0 the left-shift by kMaxCoresPerPackage is already guarded by "if
-	// (shift > 0)" in PackageEntry::GetIdleCorePacking; no undefined behavior
-	// occurs.
-
-	CPUSet enabled;
-	const int32 kWords = (SMP_MAX_CPUS + 31) / 32;
-	for (int32 i = 0; i < kWords; i++) {
-		uint32 w;
-		int retry = 0;
-		do {
-			w = gCPUEnabled.Bits(i);
-			memory_read_barrier();
-			if (w == gCPUEnabled.Bits(i) || ++retry >= 3)
-				break;
-			cpu_pause();
-		} while (true);
-		enabled.SetWord(i, w);
-	}
-
 	// Pick a random starting point to avoid convoys
-	// We use multiplicative mapping to avoid modulo.
 	int32 startIndex = (int32)get_random_index(GetRandom(), registeredCores);
 
 	for (int32 i = 0; i < registeredCores; i++) {
-		// Optimization: Use subtraction for wrapping instead of modulo
 		int32 index = startIndex + i;
 		if (index >= registeredCores)
 			index -= registeredCores;
@@ -806,108 +897,95 @@ ThreadData* CPUEntry::_TryStealWork(bigtime_t now) {
 		if (victim == NULL || victim == fCore || victim->CPUCount() == 0)
 			continue;
 
-		// Note: IdleCoreMask() is read atomically but without holding
-		// a lock. Between this read and TryLockRunQueue(), the victim core may
-		// have transitioned from idle to active. The skip is a best-effort
-		// optimization, not a guarantee. The comment "guaranteed empty" was
-		// incorrect - replace with accurate description.
-		// The TryLockRunQueue() + PeekOption() predicate below is the actual
-		// correctness barrier; this skip only avoids a redundant lock attempt.
 		if ((package->IdleCoreMask() &
 			 ((native_cpu_mask_t)1 << victim->PackageIndex())) != 0) {
 			continue;
 		}
 
-		// Lock-Free Bit-Stealing Phase 1: Atomic Remote Scanning
 		if (victim->RunQueue()->GetRealTimeBitmap() == 0 &&
 			victim->RunQueue()->GetFirstLevelBitmap() == 0)
 			continue;
 
 		int32 stolenPriority = -1;
-		// Lock-Free Bit-Stealing Phase 2: Atomic Steal Attempt
-		ThreadData* stolen = victim->StealThreadLockless(stolenPriority, fCPUNumber);
+		ThreadData* stolen =
+			victim->StealThreadLockless(stolenPriority, fCPUNumber);
 
 		if (stolen != NULL) {
-			// We have the victim's run-queue lock.
-			const CPUSet& threadMask = stolen->GetThread()->cpumask;
-			if (threadMask.IsEmpty() || threadMask.GetBit(fCPUNumber)) {
-				CoreEntry* core = atomic_pointer_get<CoreEntry>(&fCore);
-				stolen->MigrateTo(core, now);
-				stolen->fStolen = true;
-				core->IncrementTotalThreadCount();
+			bool success = false;
+			if (stolen->GetLag() >= kL3LagThreshold) {
+				const CPUSet& threadMask = stolen->GetThread()->cpumask;
+				if (threadMask.IsEmpty() || threadMask.GetBit(fCPUNumber)) {
+					stolen->MigrateTo(core, now);
+					stolen->fStolen = true;
+					core->IncrementTotalThreadCount();
+					success = true;
+				}
+			}
 
-				victim->UnlockRunQueue();
-				return stolen;
-			} else {
-				// Victim no longer matches thief after lock acquisition.
-				// Push it back and abort this victim.
-				victim->PushBack(stolen, stolen->GetThread()->priority);
+			if (!success) {
+				victim->PushBack(stolen, stolenPriority);
 				stolen = NULL;
 			}
 
 			victim->UnlockRunQueue();
-		} else {
-			// Note: if StealThreadLockless returns NULL, it either failed
-			// its atomic bit-claim OR it acquired the lock but found no
-			// suitable thread. In both cases, we must ensure the lock is
-			// released if it was acquired.
-			//
-			// StealThreadLockless follows the pattern:
-			//   if (TestAndClearAtomic) {
-			//       LockRunQueue();
-			//       ... find thread ...
-			//       if (found) return thread; // LOCK HELD
-			//       UnlockRunQueue();
-			//   }
-			//   return NULL; // LOCK NOT HELD
-			//
-			// Thus if stolen == NULL, the lock is already released or was
-			// never held. No additional UnlockRunQueue() is needed here.
+			if (success)
+				return stolen;
 		}
 	}
 
-	// Phase 2: The Local NUMA Node (Random)
-	// Target: Cores on the same physical socket/die (e.g., 64-128 cores).
-	// Method: Random Sampling
-	// Why: Stealing here is fast (local RAM). You want to exhaust reasonable
-	// options here before going across the expensive interconnect.
-
-	// Note: declare 'stolen' BEFORE the 'goto phase3' to avoid
-	// jumping over a variable initialization, which is ill-formed in C++
-	// (UB even for trivial types when an initializer is present).
 	ThreadData* stolen = NULL;
-
-	{
-		SchedulerNode* node = package->Node();
-		if (node == NULL)
-			goto phase3;
+	SchedulerNode* node = package->Node();
+	if (node != NULL) {
+		CPUSet enabled;
+		const int32 kWords = (SMP_MAX_CPUS + 31) / 32;
+		for (int32 i = 0; i < kWords; i++) {
+			enabled.SetWord(i, gCPUEnabled.Bits(i));
+		}
 
 		search_local_node(
 			node, LocalNodeStealAction(this, package, &stolen, enabled, now));
-
-		if (stolen != NULL)
-			return stolen;
 	}
 
-phase3:
-	// Note: removed the unconditional stolen = NULL reset.
-	// If Phase 2 fell through with a valid stolen thread, the reset would
-	// lose it.  If Phase 2 jumped here (node == NULL) stolen is already NULL.
-	// Phase 3 correctly checks (stolen != NULL) in its first lambda probe.
+	return stolen;
+}
 
-	// Phase 3: The Global Hail Mary (Random)
-	// Target: Any core in the system (4096 cores).
-	// Method: Logarithmic Formula
-	// Why: This is the last resort. If the local node is empty, you are willing
-	// to pay the high cost to steal from a remote socket to avoid sleeping.
+
+ThreadData* CPUEntry::_TryStealWorkNUMA(bigtime_t now) {
+	CoreEntry* core = atomic_pointer_get<CoreEntry>(&fCore);
+	PackageEntry* package = core->Package();
+	SchedulerNode* node = package->Node();
+
+	if (node == NULL)
+		return NULL;
+
+	ThreadData* stolen = NULL;
+	CPUSet enabled;
+	const int32 kWords = (SMP_MAX_CPUS + 31) / 32;
+	for (int32 i = 0; i < kWords; i++) {
+		enabled.SetWord(i, gCPUEnabled.Bits(i));
+	}
+
+	search_numa_random(node->NUMAID(), node->NodeIndex(),
+					   NUMARandomStealAction(this, package, &stolen, enabled,
+											 now));
+	return stolen;
+}
+
+
+ThreadData* CPUEntry::_TryStealWorkGlobal(bigtime_t now) {
+	CoreEntry* core = atomic_pointer_get<CoreEntry>(&fCore);
+	PackageEntry* package = core->Package();
+
+	ThreadData* stolen = NULL;
+	CPUSet enabled;
+	const int32 kWords = (SMP_MAX_CPUS + 31) / 32;
+	for (int32 i = 0; i < kWords; i++) {
+		enabled.SetWord(i, gCPUEnabled.Bits(i));
+	}
 
 	search_global_random(
 		GlobalRandomStealAction(this, package, &stolen, enabled, now));
-
-	if (stolen != NULL)
-		return stolen;
-
-	return NULL;
+	return stolen;
 }
 
 
@@ -1563,10 +1641,12 @@ void CoreEntry::_UpdateLoad(bool forceUpdate, bigtime_t now) {
 }
 
 SchedulerNode::SchedulerNode()
-	: fIdlePackageMask(0), fPackageStartIndex(0), fPackageCount(0) {}
+	: fNodeID(-1), fNUMAID(-1), fIdlePackageMask(0), fPackageStartIndex(0),
+	  fPackageCount(0) {}
 
 void SchedulerNode::Init(int32 id) {
 	fNodeID = id;
+	fNUMAID = -1;
 	cpu_mask_set_atomic(&fIdlePackageMask, 0);
 	fPackageStartIndex = 0;
 	fPackageCount = 0;

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -160,7 +160,10 @@ public:
 
 private:
 	void _RequestPerformanceLevel(ThreadData* threadData, bigtime_t now = 0);
-	ThreadData* _TryStealWork(bigtime_t now = 0);
+
+	ThreadData* _TryStealWorkL3(bigtime_t now = 0);
+	ThreadData* _TryStealWorkNUMA(bigtime_t now = 0);
+	ThreadData* _TryStealWorkGlobal(bigtime_t now = 0);
 
 	static int32 _RescheduleEvent(timer* /* unused */);
 	static int32 _UpdateLoadEvent(timer* /* unused */);
@@ -393,6 +396,9 @@ public:
 	inline native_cpu_mask_t IdlePackageMask() const;
 	inline int32 NodeIndex() const { return fNodeID; }
 
+	inline int32 NUMAID() const { return fNUMAID; }
+	inline void SetNUMAID(int32 id) { fNUMAID = id; }
+
 	inline int32 PackageStartIndex() const { return fPackageStartIndex; }
 	inline void SetPackageStartIndex(int32 start) {
 		fPackageStartIndex = start;
@@ -408,6 +414,8 @@ public:
 
 private:
 	int32 fNodeID;
+	int32 fNUMAID;
+
 	native_cpu_mask_t fIdlePackageMask __attribute__((aligned(8)));
 
 	int32 fPackageStartIndex;

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -181,6 +181,10 @@ public:
 
 	SCHEDULER_INLINE int32 GetLoad() const { return fNeededLoad; }
 
+	SCHEDULER_INLINE int32 InteractivityScore() const {
+		return fInteractivityScore;
+	}
+
 	SCHEDULER_INLINE bool IsForeground() const { return fIsForeground; }
 	SCHEDULER_INLINE void SetForeground(bool foreground) {
 		fIsForeground = foreground;

--- a/src/system/kernel/scheduler/scheduler_topology.h
+++ b/src/system/kernel/scheduler/scheduler_topology.h
@@ -146,6 +146,38 @@ static void search_local_node(SchedulerNode* node, Action action) {
 }
 
 template <typename Action>
+static void search_numa_random(int32 numaID, int32 excludeNode, Action action) {
+	const int32 nodeCount = gNodeCount;
+	if (nodeCount <= 0)
+		return;
+
+	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
+	int32 samplesToTake = min_c(gRandomSamples, nodeCount);
+	int32 samplesTaken = 0;
+	int32 attempts = 0;
+	const int32 kMaxAttempts = samplesToTake * 8;
+
+	while (samplesTaken < samplesToTake && attempts++ < kMaxAttempts) {
+		int32 i = (int32)(((uint64)cpu->GetRandom() * nodeCount) >> 32);
+		SchedulerNode* node = &gSchedulerNodes[i];
+
+		if (i == excludeNode || node->NUMAID() != numaID)
+			continue;
+
+		samplesTaken++;
+
+		int32 packagesInNode = node->PackageCount();
+		if (packagesInNode <= 0)
+			continue;
+
+		int32 pkgOffset =
+			(int32)(((uint64)cpu->GetRandom() * packagesInNode) >> 32);
+		if (action(&gPackageEntries[node->PackageStartIndex() + pkgOffset]))
+			break;
+	}
+}
+
+template <typename Action>
 static void search_global_random(Action action) {
 	// Note: snapshot gPackageCount once at the start of the function.
 	// This ensures consistency if a hot-plug event changes the global count


### PR DESCRIPTION
Optimized the Haiku scheduler for desktop responsiveness by implementing a four-tier tiered work-stealing hierarchy. The new hierarchy prioritizes migrations within the same L3 domain first, then searches remote L3 nodes on the same NUMA socket, and finally falls back to a global search with strict task-type gating. Threads with display priority or high interactivity scores are prevented from migrating across NUMA boundaries to avoid the devastating latency penalties of inter-socket memory access. Additionally, refined core selection to prioritize physical parallelism over SMT utilization when possible.

---
*PR created automatically by Jules for task [11081120224682251113](https://jules.google.com/task/11081120224682251113) started by @tonestone57*