### PR TITLE
Decentralize Scheduler Run-Queues and Locking

### DIFF
--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -434,9 +434,12 @@ static void UpdatePriorityBoostScalable(CoreEntry* core, CPUEntry* cpu,
 								 now);
 
 	// Check CPU RunQueue
+	// Note: We only scan the local CPU's run-queue to maintain decentralization.
+	// Cross-CPU scanning is handled by work-stealing and load balancing.
 	if (cpu->ThreadCount() > 0) {
 		CPURunQueueLocker cpuLocker(cpu);
-		scanRunQueue(cpu->RunQueue());
+		if (cpu->ThreadCount() > 0)
+			scanRunQueue(cpu->RunQueue());
 	}
 }
 

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -67,8 +67,6 @@ bool gHasStandardCores = false;
 int32 gTotalRunnableThreads = 0;
 uint64 gIdleMask __attribute__((aligned(8))) = 0;
 
-spinlock gSchedulerLock = B_SPINLOCK_INITIALIZER;
-
 int64 gRCUGeneration __attribute__((aligned(8))) = 1;
 spinlock gSchedulerUpdateLock = B_SPINLOCK_INITIALIZER;
 
@@ -134,12 +132,16 @@ static const int kLoadBalanceThreshold = 2;
 static const bigtime_t kRescheduleCooldown = 500;
 
 extern "C" void AcquireSchedulerSpinlock() {
-	acquire_spinlock(&gSchedulerLock);
+	Thread* thread = get_cpu_struct()->running_thread;
+	if (thread != NULL)
+		acquire_spinlock(&thread->scheduler_lock);
 }
 
 
 extern "C" void ReleaseSchedulerSpinlock() {
-	release_spinlock(&gSchedulerLock);
+	Thread* thread = get_cpu_struct()->running_thread;
+	if (thread != NULL)
+		release_spinlock(&thread->scheduler_lock);
 }
 
 
@@ -422,95 +424,14 @@ static void UpdatePriorityBoostScalable(CoreEntry* core, CPUEntry* cpu,
 	if (now == 0)
 		now = system_time();
 
-	// Note: Mask computation optimization. This mask is recomputed from a
-	// compile-time constant on every reschedule.  Hoist it to a static const so
-	// the compiler evaluates it once at startup.
 	// Throttle: only run the boost scan every 10 context switches to reduce
 	// overhead.
 	if (cpu->fRescheduleCount++ % 10 != 0)
 		return;
 
-	// Scalable Priority Boosting:
-	// Instead of scanning all threads (O(N)), we scan only the heads of
-	// priority queues (O(1) relative to thread count).
-	// We verify if the longest-waiting thread in each queue is starving.
-	// This maintains O(1) complexity regardless of the number of threads.
-
-	// Budget is the number of priority buckets examined per run queue,
-	// not the number of threads.
 	const int kMaxPrioritiesToCheckPerQueue = 5;
-
 	RunQueueScanner scanRunQueue(0, kMaxPrioritiesToCheckPerQueue,
 								 now);
-
-	// Check Core RunQueue first to maintain Core -> CPU lock ordering
-	// On an N-way SMT core, all N CPUs previously scanned the shared
-	// core run queue every 10 reschedules, contending on CoreRunQueueLocker N×
-	// more often than necessary.  Gate the scan with round-robin ownership:
-	// only the CPU whose (boost_epoch % cpuCount) matches its modular index
-	// within the core performs the scan.
-	int32 coreCPUCount = max_c(1, core->CPUCount());
-
-	// Note: Counter wrap-around safety. when fRescheduleCount wraps UINT32_MAX
-	// → 0, the post-increment is 0, so (0 % 10 == 0) fires and preCount
-	// becomes UINT32_MAX, making boostEpoch ≈ 429M.  This causes all CPUs to
-	// satisfy the modular ownership check simultaneously, producing a
-	// correlated scan burst. Treat the wrap as a normal epoch boundary by
-	// clamping preCount.
-	uint32 preCount = cpu->fRescheduleCount - 1;
-	// Note: Use a non-zero epoch at wrap boundary to avoid bias.
-	if (cpu->fRescheduleCount == 0) {
-		preCount =
-			THREAD_MAX_SET_PRIORITY;  // Arbitrary but stable non-zero value
-	}
-
-	uint32 boostEpoch = preCount / 10;
-
-	// Calculate a dense local index using the fLocalIndices bitmask.
-	// This ensures fair round-robin ownership even if there are holes
-	// in the assigned local indices.
-	native_cpu_mask_t localMask = cpu_mask_get_atomic(&core->fLocalIndices);
-	const int32 maskBitCount = (int32)(sizeof(native_cpu_mask_t) * 8);
-	// 32/64-bit safety: shifting by the type width is undefined behavior.
-	// Clamp the shift domain so this remains valid on both 32-bit and 64-bit.
-	int32 localIndex = cpu->fCoreLocalIndex;
-	if (localIndex < 0)
-		localIndex = 0;
-	if (localIndex > maskBitCount)
-		localIndex = maskBitCount;
-
-	native_cpu_mask_t lowerMask = 0;
-	if (localIndex == maskBitCount)
-		lowerMask = localMask;
-	else if (localIndex > 0)
-		lowerMask = localMask & (((native_cpu_mask_t)1 << localIndex) - 1);
-
-	int32 denseLocalIndex = scheduler_popcount(lowerMask);
-
-	bool ownsCoreQueueScan = ((int32)(boostEpoch % (uint32)coreCPUCount) ==
-							  (int32)(denseLocalIndex % (uint32)coreCPUCount));
-
-	// Note: CoreRunQueueLocker(core, false) constructs with
-	// alreadyLocked=false and lockIfNotLocked defaulting to false, meaning
-	// the locker starts in an unlocked state. If Lock() is subsequently
-	// called and succeeds, the destructor correctly unlocks. However if
-	// the AutoLocker internal fLocked tracking ever diverges from the
-	// actual spinlock state (e.g. partial construction failure), the
-	// destructor may double-unlock or fail to unlock.
-	// Use explicit Lock()/Unlock() calls instead of the two-argument
-	// constructor to make the locking intent unambiguous.
-
-	// Note: The thread-count check was done without the lock; a thread
-	// could be removed between the check and lock acquisition, making the
-	// locked scan a wasted spinlock round-trip.  Re-check inside the lock.
-	if (ownsCoreQueueScan) {
-		// Scoped locker: ensure Core and CPU run-queue locks are NEVER
-		// held simultaneously in this function to eliminate lock inversion.
-		CoreRunQueueLocker coreLocker(core, false, false);
-		coreLocker.Lock();
-		if (core->CoreRunQueueThreadCount() > 0)
-			scanRunQueue(core->RunQueue());
-	}
 
 	// Check CPU RunQueue
 	if (cpu->ThreadCount() > 0) {
@@ -585,7 +506,7 @@ static bool enqueue(Thread* thread, bool newOne, Thread* waker, bigtime_t now) {
 		}
 
 		if (targetCPU == NULL || targetCore == NULL ||
-			!threadData->Enqueue(wasRunQueueEmpty, requestPreemption,
+			!threadData->Enqueue(targetCPU, wasRunQueueEmpty, requestPreemption,
 								 updateInteraction, now)) {
 			targetCore = NULL;
 			targetCPU = NULL;
@@ -1269,9 +1190,6 @@ void scheduler_set_cpu_enabled(int32 cpuID, bool enabled) {
 
 			// flush CPU run queue
 			while (true) {
-				// The flush loop holds CPURunQueueLocker per-iteration but not
-				// CoreRunQueueLocker. Global serialization comes from
-				// InterruptsBigSchedulerLocker held for this disable scope.
 				ThreadData* threadData;
 				{
 					CPURunQueueLocker locker(cpu);
@@ -1287,15 +1205,7 @@ void scheduler_set_cpu_enabled(int32 cpuID, bool enabled) {
 			{
 				CoreCPUHeapLocker heapLocker(core);
 				cpu->UpdatePriority(B_IDLE_PRIORITY);
-				// Note: document lock ordering.
-				// CoreCPUHeapLocker acquires fCPULock. RemoveCPU internally
-				// calls fPackage->RemoveIdleCore() which acquires fCoreLock
-				// (write). Lock ordering: fCPULock → fCoreLock. Verify no other
-				// path acquires these in reverse order. AddIdleCore() acquires
-				// fCoreLock then is called from AddCPU under fCPULock - same
-				// ordering, safe. CoreGoesIdle calls PackageEntry::CoreGoesIdle
-				// (no fCoreLock) - no ordering conflict.
-				core->RemoveCPU(cpu, enqueuer);
+				core->RemoveCPU(cpu);
 			}
 
 			cpu->Stop();

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -58,46 +58,56 @@ struct LocalNodeStealAction {
 
 		int32 coreIndex =
 			(int32)get_random_index(cpu->GetRandom(), victimCoreCount);
-		CoreEntry* victim = entry->GetCore(coreIndex);
+		CoreEntry* victimCore = entry->GetCore(coreIndex);
 
-		if (victim == NULL)
+		if (victimCore == NULL)
 			return false;
 
-		if ((entry->IdleCoreMask() &
-			 ((native_cpu_mask_t)1 << victim->PackageIndex())) != 0)
-			return false;
+		const CPUSet& victimMask = victimCore->CPUMask();
+		for (int32 word = 0; word < (SMP_MAX_CPUS + 31) / 32; word++) {
+			uint32 bits = victimMask.Bits(word);
+			while (bits != 0) {
+				int32 j = word * 32 + scheduler_ctz((native_cpu_mask_t)bits);
+				bits &= ~(1U << (j % 32));
 
-		// Lock-Free Bit-Stealing Phase 1: Atomic Remote Scanning
-		if (victim->RunQueue()->GetRealTimeBitmap() == 0 &&
-			victim->RunQueue()->GetFirstLevelBitmap() == 0)
-			return false;
+				CPUEntry* victim = CPUEntry::GetCPU(j);
+				if (victim == cpu || gCPU[j].disabled)
+					continue;
 
-		int32 stolenPriority = -1;
-		// Lock-Free Bit-Stealing Phase 2: Atomic Steal Attempt
-		*stolen = victim->StealThreadLockless(stolenPriority, cpu->ID());
+				// Lock-Free Bit-Stealing Phase 1: Atomic Remote Scanning
+				if (victim->RunQueue()->GetRealTimeBitmap() == 0 &&
+					victim->RunQueue()->GetFirstLevelBitmap() == 0)
+					continue;
 
-		if (*stolen != NULL) {
-			// We have the victim's run-queue lock.
-			bool success = false;
-			if ((*stolen)->GetLag() >= kNUMANodeLagThreshold) {
-				// Re-verify affinity under the lock (mostly redundant but safe).
-				const CPUSet& threadMask = (*stolen)->GetThread()->cpumask;
-				if (threadMask.IsEmpty() || threadMask.GetBit(cpu->ID())) {
-					(*stolen)->MigrateTo(cpu->Core(), now);
-					(*stolen)->fStolen = true;
-					cpu->Core()->IncrementTotalThreadCount();
-					success = true;
+				int32 stolenPriority = -1;
+				// Lock-Free Bit-Stealing Phase 2: Atomic Steal Attempt
+				*stolen = victim->StealThreadLockless(stolenPriority, cpu->ID());
+
+				if (*stolen != NULL) {
+					// We have the victim's run-queue lock.
+					bool success = false;
+					if ((*stolen)->GetLag() >= kNUMANodeLagThreshold) {
+						// Re-verify affinity under the lock (mostly redundant but safe).
+						const CPUSet& threadMask = (*stolen)->GetThread()->cpumask;
+						if (threadMask.IsEmpty() || threadMask.GetBit(cpu->ID())) {
+							(*stolen)->MigrateTo(cpu->Core(), now);
+							(*stolen)->fStolen = true;
+							cpu->Core()->IncrementTotalThreadCount();
+							success = true;
+						}
+					}
+
+					if (!success) {
+						// Thread not under-served enough or affinity changed; restore it.
+						victim->PushBack(*stolen, stolenPriority);
+						*stolen = NULL;
+					}
+
+					victim->UnlockRunQueue();
+					if (success)
+						return true;
 				}
 			}
-
-			if (!success) {
-				// Thread not under-served enough or affinity changed; restore it.
-				victim->PushBack(*stolen, stolenPriority);
-				*stolen = NULL;
-			}
-
-			victim->UnlockRunQueue();
-			return success;
 		}
 
 		return false;
@@ -131,46 +141,56 @@ struct GlobalRandomStealAction {
 
 		int32 coreIndex =
 			(int32)get_random_index(cpu->GetRandom(), victimCoreCount);
-		CoreEntry* victim = entry->GetCore(coreIndex);
+		CoreEntry* victimCore = entry->GetCore(coreIndex);
 
-		if (victim == NULL)
+		if (victimCore == NULL)
 			return false;
 
-		if ((entry->IdleCoreMask() &
-			 ((native_cpu_mask_t)1 << victim->PackageIndex())) != 0)
-			return false;
+		const CPUSet& victimMask = victimCore->CPUMask();
+		for (int32 word = 0; word < (SMP_MAX_CPUS + 31) / 32; word++) {
+			uint32 bits = victimMask.Bits(word);
+			while (bits != 0) {
+				int32 j = word * 32 + scheduler_ctz((native_cpu_mask_t)bits);
+				bits &= ~(1U << (j % 32));
 
-		// Lock-Free Bit-Stealing Phase 1: Atomic Remote Scanning
-		if (victim->RunQueue()->GetRealTimeBitmap() == 0 &&
-			victim->RunQueue()->GetFirstLevelBitmap() == 0)
-			return false;
+				CPUEntry* victim = CPUEntry::GetCPU(j);
+				if (victim == cpu || gCPU[j].disabled)
+					continue;
 
-		int32 stolenPriority = -1;
-		// Lock-Free Bit-Stealing Phase 2: Atomic Steal Attempt
-		*stolen = victim->StealThreadLockless(stolenPriority, cpu->ID());
+				// Lock-Free Bit-Stealing Phase 1: Atomic Remote Scanning
+				if (victim->RunQueue()->GetRealTimeBitmap() == 0 &&
+					victim->RunQueue()->GetFirstLevelBitmap() == 0)
+					continue;
 
-		if (*stolen != NULL) {
-			// We have the victim's run-queue lock.
-			bool success = false;
-			if ((*stolen)->GetLag() >= kGlobalLagThreshold) {
-				// Re-verify affinity under the lock.
-				const CPUSet& threadMask = (*stolen)->GetThread()->cpumask;
-				if (threadMask.IsEmpty() || threadMask.GetBit(cpu->ID())) {
-					(*stolen)->MigrateTo(cpu->Core(), now);
-					(*stolen)->fStolen = true;
-					cpu->Core()->IncrementTotalThreadCount();
-					success = true;
+				int32 stolenPriority = -1;
+				// Lock-Free Bit-Stealing Phase 2: Atomic Steal Attempt
+				*stolen = victim->StealThreadLockless(stolenPriority, cpu->ID());
+
+				if (*stolen != NULL) {
+					// We have the victim's run-queue lock.
+					bool success = false;
+					if ((*stolen)->GetLag() >= kGlobalLagThreshold) {
+						// Re-verify affinity under the lock.
+						const CPUSet& threadMask = (*stolen)->GetThread()->cpumask;
+						if (threadMask.IsEmpty() || threadMask.GetBit(cpu->ID())) {
+							(*stolen)->MigrateTo(cpu->Core(), now);
+							(*stolen)->fStolen = true;
+							cpu->Core()->IncrementTotalThreadCount();
+							success = true;
+						}
+					}
+
+					if (!success) {
+						// Thread not under-served enough or affinity changed; restore it.
+						victim->PushBack(*stolen, stolenPriority);
+						*stolen = NULL;
+					}
+
+					victim->UnlockRunQueue();
+					if (success)
+						return true;
 				}
 			}
-
-			if (!success) {
-				// Thread not under-served enough or affinity changed; restore it.
-				victim->PushBack(*stolen, stolenPriority);
-				*stolen = NULL;
-			}
-
-			victim->UnlockRunQueue();
-			return success;
 		}
 
 		return false;
@@ -398,9 +418,6 @@ void CPUEntry::Remove(ThreadData* thread) {
 	// (defensive): capture the priority the thread was enqueued with to
 	// ensure symmetric counter updates.
 	int32 priority = thread->fEnqueuedPriority;
-	// Use GetEffectivePriority() for fDisplayThreadCount symmetry
-	// with PushFront/PushBack.
-	int32 priority = thread->GetEffectivePriority();
 
 	thread->SetDequeued();
 	fRunQueue.Remove(thread);
@@ -513,41 +530,33 @@ ThreadData* CPUEntry::ChooseNextThread(ThreadData* oldThread, bool putAtBack,
 	if (oldThread != NULL)
 		oldPriority = oldThread->GetEffectivePriority();
 
-	CoreEntry* core = atomic_pointer_get<CoreEntry>(&fCore);
-	CoreRunQueueLocker coreLocker(core);
 	CPURunQueueLocker cpuLocker(this);
 
-	ThreadData* pinnedThread = PeekThread();
-	int32 pinnedPriority = -1;
-	if (pinnedThread != NULL)
-		pinnedPriority = pinnedThread->GetEffectivePriority();
-
-	ThreadData* sharedThread = core->PeekThread();
-	if (sharedThread == NULL && pinnedThread == NULL) {
+	ThreadData* nextThread = PeekThread();
+	if (nextThread == NULL) {
 		// try to steal work from other cores in the same package
-		sharedThread = _TryStealWork(now);
+		nextThread = _TryStealWork(now);
 	}
 
-	bool sharedThreadIsFloating =
-		sharedThread != NULL && !sharedThread->IsEnqueued();
+	bool nextThreadIsFloating =
+		nextThread != NULL && !nextThread->IsEnqueued();
 
-	if (sharedThread == NULL && pinnedThread == NULL && oldThread == NULL)
+	if (nextThread == NULL && oldThread == NULL)
 		return NULL;
 
-	int32 sharedPriority = -1;
-	if (sharedThread != NULL)
-		sharedPriority = sharedThread->GetEffectivePriority();
+	int32 nextPriority = -1;
+	if (nextThread != NULL)
+		nextPriority = nextThread->GetEffectivePriority();
 
 	// BMQ EEVDF selection logic: Real-Time threads (priority >= 100) always win.
 	if (oldPriority >= 100) {
-		if (oldPriority > pinnedPriority && oldPriority > sharedPriority) {
+		if (oldPriority >= nextPriority) {
 			// case A: oldThread is best.
-			if (sharedThreadIsFloating) {
+			if (nextThreadIsFloating) {
 				// Re-enqueue stolen thread
 				cpuLocker.Unlock();
-				coreLocker.Unlock();
 				bool dummy1, dummy2, updateInteraction;
-				sharedThread->Enqueue(dummy1, dummy2, updateInteraction, now);
+				nextThread->Enqueue(this, dummy1, dummy2, updateInteraction, now);
 				if (updateInteraction)
 					scheduler_update_interaction_state(now);
 			}
@@ -555,32 +564,25 @@ ThreadData* CPUEntry::ChooseNextThread(ThreadData* oldThread, bool putAtBack,
 		}
 	}
 
-	int32 rest = max_c(pinnedPriority, sharedPriority);
-	if (oldPriority > rest || (!putAtBack && oldPriority == rest)) {
+	if (oldPriority > nextPriority || (!putAtBack && oldPriority == nextPriority)) {
 		// Case A: oldThread is best.
-		if (sharedThreadIsFloating) {
+		if (nextThreadIsFloating) {
 			cpuLocker.Unlock();
-			coreLocker.Unlock();
 
 			bool wasRunQueueEmpty;
 			bool requestPreemption;
 			bool updateInteraction;
-			if (!sharedThread->Enqueue(wasRunQueueEmpty, requestPreemption,
+			if (!nextThread->Enqueue(this, wasRunQueueEmpty, requestPreemption,
 									   updateInteraction, now)) {
-				// Note: cache the Thread* once; sharedThread->GetThread()
-				// is called multiple times below and the pointer must be
-				// consistent.
-				Thread* const stolenThread = sharedThread->GetThread();
+				Thread* const stolenThread = nextThread->GetThread();
 				if (!enqueue_safe(stolenThread, now)) {
 					dprintf(
 						"scheduler: WARNING: stolen thread %" B_PRId32
 						" lost during hot-unplug -- forcing to current CPU\n",
 						stolenThread->id);
-					sharedThread->MigrateTo(fCore, now);
+					nextThread->MigrateTo(fCore, now);
 					bool dummy1, dummy2;
-					// Note: check return value; log if the last-resort also
-					// fails.
-					if (!sharedThread->Enqueue(dummy1, dummy2,
+					if (!nextThread->Enqueue(this, dummy1, dummy2,
 											   updateInteraction, now)) {
 						dprintf(
 							"scheduler: CRITICAL: thread %" B_PRId32
@@ -591,68 +593,23 @@ ThreadData* CPUEntry::ChooseNextThread(ThreadData* oldThread, bool putAtBack,
 				}
 			}
 
-			// Note: call while NOT holding run-queue locks.
 			if (updateInteraction)
 				scheduler_update_interaction_state(now);
 		}
 		return oldThread;
 	}
 
-	if (sharedPriority > pinnedPriority) {
-		// Case B: sharedThread is best.
-		if (sharedThread->fStolen) {
-			core->DecrementTotalThreadCount();
-			sharedThread->fStolen = false;
+	// Case B: nextThread is best.
+	if (nextThreadIsFloating) {
+		if (nextThread->fStolen) {
+			nextThread->fStolen = false;
 		}
-		if (sharedThread->Core() == core && !sharedThreadIsFloating)
-			core->Remove(sharedThread);
-
-		return sharedThread;
+		return nextThread;
 	}
 
-	// Case C: pinnedThread is best (or fallback).
-	// We MUST remove the thread while holding the locks to avoid a race
-	// condition.
-	ThreadData* nextThread = NULL;
-	if (pinnedThread != NULL && pinnedThread->IsEnqueued()) {
-		Remove(pinnedThread);
-		nextThread = pinnedThread;
-	} else {
-		// pinnedThread was stolen while we were stealing/peeking; fallback.
-		nextThread = PeekThread();
-		if (nextThread != NULL)
-			Remove(nextThread);
-	}
-
-	if (sharedThreadIsFloating) {
-		// We decided to run a pinned thread; put back the stolen shared thread.
-		cpuLocker.Unlock();
-		coreLocker.Unlock();
-
-		bool wasRunQueueEmpty;
-		bool requestPreemption;
-		bool updateInteraction;
-		if (!sharedThread->Enqueue(wasRunQueueEmpty, requestPreemption,
-								   updateInteraction, now)) {
-			Thread* const thread = sharedThread->GetThread();
-			if (!enqueue_safe(thread, now)) {
-				dprintf("scheduler: WARNING: shared thread %" B_PRId32
-						" lost during hot-unplug -- forcing to current CPU\n",
-						thread->id);
-				sharedThread->MigrateTo(fCore, now);
-				bool dummy1, dummy2;
-				if (!sharedThread->Enqueue(dummy1, dummy2, updateInteraction,
-										   now)) {
-					dprintf("scheduler: CRITICAL: thread %" B_PRId32
-							" could not be re-enqueued after forced migration;"
-							" scheduler state is inconsistent\n",
-							thread->id);
-				}
-			}
-		}
-
-		if (updateInteraction)
-			scheduler_update_interaction_state(now);
+	// Remove from local queue
+	if (nextThread != NULL && nextThread->IsEnqueued()) {
+		Remove(nextThread);
 	}
 
 	return nextThread;
@@ -801,68 +758,52 @@ ThreadData* CPUEntry::_TryStealWork(bigtime_t now) {
 		if (index >= registeredCores)
 			index -= registeredCores;
 
-		CoreEntry* victim = package->GetCore(index);
-
-		if (victim == NULL || victim == fCore || victim->CPUCount() == 0)
+		CoreEntry* victimCore = package->GetCore(index);
+		if (victimCore == NULL || victimCore == fCore || victimCore->CPUCount() == 0)
 			continue;
 
-		// Note: IdleCoreMask() is read atomically but without holding
-		// a lock. Between this read and TryLockRunQueue(), the victim core may
-		// have transitioned from idle to active. The skip is a best-effort
-		// optimization, not a guarantee. The comment "guaranteed empty" was
-		// incorrect - replace with accurate description.
-		// The TryLockRunQueue() + PeekOption() predicate below is the actual
-		// correctness barrier; this skip only avoids a redundant lock attempt.
-		if ((package->IdleCoreMask() &
-			 ((native_cpu_mask_t)1 << victim->PackageIndex())) != 0) {
-			continue;
-		}
+		// decentralized per-CPU run-queues. Target each logical CPU.
+		const CPUSet& victimMask = victimCore->CPUMask();
+		for (int32 word = 0; word < (SMP_MAX_CPUS + 31) / 32; word++) {
+			uint32 bits = victimMask.Bits(word);
+			while (bits != 0) {
+				int32 j = word * 32 + scheduler_ctz((native_cpu_mask_t)bits);
+				bits &= ~(1U << (j % 32));
 
-		// Lock-Free Bit-Stealing Phase 1: Atomic Remote Scanning
-		if (victim->RunQueue()->GetRealTimeBitmap() == 0 &&
-			victim->RunQueue()->GetFirstLevelBitmap() == 0)
-			continue;
+				CPUEntry* victim = CPUEntry::GetCPU(j);
+				if (victim == this || gCPU[j].disabled)
+					continue;
 
-		int32 stolenPriority = -1;
-		// Lock-Free Bit-Stealing Phase 2: Atomic Steal Attempt
-		ThreadData* stolen = victim->StealThreadLockless(stolenPriority, fCPUNumber);
+				// Lock-Free Bit-Stealing Phase 1: Atomic Remote Scanning
+				if (victim->RunQueue()->GetRealTimeBitmap() == 0 &&
+					victim->RunQueue()->GetFirstLevelBitmap() == 0)
+					continue;
 
-		if (stolen != NULL) {
-			// We have the victim's run-queue lock.
-			const CPUSet& threadMask = stolen->GetThread()->cpumask;
-			if (threadMask.IsEmpty() || threadMask.GetBit(fCPUNumber)) {
-				CoreEntry* core = atomic_pointer_get<CoreEntry>(&fCore);
-				stolen->MigrateTo(core, now);
-				stolen->fStolen = true;
-				core->IncrementTotalThreadCount();
+				int32 stolenPriority = -1;
+				// Lock-Free Bit-Stealing Phase 2: Atomic Steal Attempt
+				ThreadData* stolen = victim->StealThreadLockless(stolenPriority, fCPUNumber);
 
-				victim->UnlockRunQueue();
-				return stolen;
-			} else {
-				// Victim no longer matches thief after lock acquisition.
-				// Push it back and abort this victim.
-				victim->PushBack(stolen, stolen->GetThread()->priority);
-				stolen = NULL;
+				if (stolen != NULL) {
+					// We have the victim's run-queue lock.
+					const CPUSet& threadMask = stolen->GetThread()->cpumask;
+					if (threadMask.IsEmpty() || threadMask.GetBit(fCPUNumber)) {
+						CoreEntry* core = atomic_pointer_get<CoreEntry>(&fCore);
+						stolen->MigrateTo(core, now);
+						stolen->fStolen = true;
+						core->IncrementTotalThreadCount();
+
+						victim->UnlockRunQueue();
+						return stolen;
+					} else {
+						// Victim no longer matches thief after lock acquisition.
+						// Push it back and abort this victim.
+						victim->PushBack(stolen, stolen->GetThread()->priority);
+						stolen = NULL;
+					}
+
+					victim->UnlockRunQueue();
+				}
 			}
-
-			victim->UnlockRunQueue();
-		} else {
-			// Note: if StealThreadLockless returns NULL, it either failed
-			// its atomic bit-claim OR it acquired the lock but found no
-			// suitable thread. In both cases, we must ensure the lock is
-			// released if it was acquired.
-			//
-			// StealThreadLockless follows the pattern:
-			//   if (TestAndClearAtomic) {
-			//       LockRunQueue();
-			//       ... find thread ...
-			//       if (found) return thread; // LOCK HELD
-			//       UnlockRunQueue();
-			//   }
-			//   return NULL; // LOCK NOT HELD
-			//
-			// Thus if stolen == NULL, the lock is already released or was
-			// never held. No additional UnlockRunQueue() is needed here.
 		}
 	}
 
@@ -1009,7 +950,6 @@ CoreEntry::CoreEntry()
 	  fCPUCount(0),
 	  fCapacity(kDefaultCapacity),
 	  fIdleCPUCount(0),
-	  fThreadCount(0),
 	  fTotalThreadCount(0),
 	  fDisplayThreadCount(0),
 	  fActiveTime(0),
@@ -1019,7 +959,6 @@ CoreEntry::CoreEntry()
 	  fScoreFactor(1 << 16),
 	  fLocalIndices(0) {
 	B_INITIALIZE_SPINLOCK(&fCPULock);
-	B_INITIALIZE_SPINLOCK(&fQueueLock);
 }
 
 
@@ -1039,60 +978,8 @@ void CoreEntry::Init(int32 id, PackageEntry* package) {
 }
 
 
-void CoreEntry::PushFront(ThreadData* thread, int32 priority) {
-	SCHEDULER_ENTER_FUNCTION();
 
-	// Note: Formal EEVDF Eligibility.
-	// Threads only enter the active heap when mathematically eligible.
-	// In a shared core queue, we use a global approximation or the waker's CPU SVT.
-
-	thread->fEnqueuedPriority = priority;
-
-	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
-	fRunQueue.PushFront(thread, priority, cpu->SystemVirtualTime());
-	IncrementThreadCount();
-	IncrementTotalThreadCount();
-	if (priority >= B_DISPLAY_PRIORITY)
-		IncrementDisplayThreadCount();
-}
-
-
-void CoreEntry::PushBack(ThreadData* thread, int32 priority) {
-	SCHEDULER_ENTER_FUNCTION();
-
-	thread->fEnqueuedPriority = priority;
-
-	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
-	fRunQueue.PushBack(thread, priority, cpu->SystemVirtualTime());
-	IncrementThreadCount();
-	IncrementTotalThreadCount();
-	if (priority >= B_DISPLAY_PRIORITY)
-		IncrementDisplayThreadCount();
-}
-
-
-void CoreEntry::Remove(ThreadData* thread) {
-	SCHEDULER_ENTER_FUNCTION();
-
-	ASSERT(!thread->IsIdle());
-	ASSERT(thread->IsEnqueued());
-
-	// (defensive): capture the enqueued priority to ensure consistent
-	// fDisplayThreadCount accounting.
-	int32 priority = thread->fEnqueuedPriority;
-	// Use GetEffectivePriority() for fDisplayThreadCount symmetry.
-	int32 priority = thread->GetEffectivePriority();
-
-	thread->SetDequeued();
-
-	DecrementThreadCount();
-	DecrementTotalThreadCount();
-	if (priority >= B_DISPLAY_PRIORITY)
-		DecrementDisplayThreadCount();
-	fRunQueue.Remove(thread);
-}
-
-ThreadData* CoreEntry::StealThread(int32& stolenPriority, int32 thiefCPU) {
+ThreadData* CPUEntry::StealThread(int32& stolenPriority, int32 thiefCPU) {
 	SCHEDULER_ENTER_FUNCTION();
 
 	// Note: Formal EEVDF Steal Criteria: "The Laggiest Wins".
@@ -1119,7 +1006,7 @@ ThreadData* CoreEntry::StealThread(int32& stolenPriority, int32 thiefCPU) {
 	return thread;
 }
 
-ThreadData* CoreEntry::StealThreadLockless(int32& stolenPriority, int32 thiefCPU) {
+ThreadData* CPUEntry::StealThreadLockless(int32& stolenPriority, int32 thiefCPU) {
 	SCHEDULER_ENTER_FUNCTION();
 
 	bigtime_t svt = SystemVirtualTime();
@@ -1281,8 +1168,7 @@ void CoreEntry::AddCPU(CPUEntry* cpu) {
 }
 
 
-void CoreEntry::RemoveCPU(CPUEntry* cpu,
-						  ThreadProcessing& threadPostProcessing) {
+void CoreEntry::RemoveCPU(CPUEntry* cpu) {
 	ASSERT(LoadAcquire(fCPUCount) > 0);
 	ASSERT(LoadAcquire(fIdleCPUCount) >= 1);
 
@@ -1297,68 +1183,14 @@ void CoreEntry::RemoveCPU(CPUEntry* cpu,
 		// core has been disabled
 		cpu_mask_and_atomic(&fPackage->fEnabledCoreMask, ~((native_cpu_mask_t)1 << fPackageIndex));
 
-		// Note: only call RemoveIdleCore if the core was actually idle
-		// (all its CPUs were idle). Calling unconditionally when a non-idle
-		// core is removed decrements fIdleCoreCount below its true value,
-		// corrupting idle core accounting for the entire package.
 		if (oldIdleCount == 1)
 			fPackage->RemoveIdleCore(this);
-
-		// Note: use CoreRunQueueLocker per-iteration to prevent
-		// a concurrent work-stealer (which uses TryLockRunQueue) from
-		// stealing a thread between PeekMaximum and Remove, leaving
-		// fThreadCount positive with an empty queue.
-		// The steal path checks CPUCount()==0 before adding stolen threads,
-		// so once we set oldCPUCount==1 no new threads can arrive.
-		while (true) {
-			ThreadData* threadData;
-			{
-				CoreRunQueueLocker locker(this);
-				threadData = fRunQueue.PeekMaximum();
-				if (threadData == NULL)
-					break;
-
-				Remove(threadData);
-			}
-
-			ASSERT(threadData->Core() == NULL);
-			// Note: threadPostProcessing calls enqueue() which calls
-			// Enqueue() which increments gTotalRunnableThreads for non-idle
-			// threads. If enqueue() subsequently fails (all cores disabled),
-			// it returns false without a matching decrement. Detect this case
-			// and decrement manually to avoid a permanent counter leak.
-			threadPostProcessing(threadData);
-		}
-
-		// Note: after drain, explicitly verify fThreadCount is zero.
-		// If a concurrent steal occurred in the narrow window, fThreadCount
-		// may be positive. Force it to zero since CPUCount==0 prevents
-		// further enqueues, making any residual count a permanent leak.
-		int32 residual = LoadAcquire(fThreadCount);
-		if (residual != 0) {
-			dprintf("CoreEntry::RemoveCPU: fThreadCount=%" B_PRId32
-					" after drain (expected 0) - resetting\n",
-					residual);
-			StoreRelease(fThreadCount, 0);
-		}
 	}
 
-	// Use B_INT32_MIN instead of the implicit magic -1.  B_INT32_MIN is
-	// less than every valid scheduler priority (minimum B_IDLE_PRIORITY == 0),
-	// so the CPU is guaranteed to bubble to the heap root.  The explicit
-	// constant makes the intent clear and prevents silent misbehavior if the
-	// priority range ever grows to include negative values.
 	fCPUHeap.ModifyKey(cpu, B_INT32_MIN);
-	// Note: fCPUHeap is accessed exclusively under fCPULock, which the
-	// caller holds via CoreCPUHeapLocker for the duration of RemoveCPU.  No
-	// other CPU can concurrently modify the heap, so the root is guaranteed to
-	// be 'cpu' immediately after ModifyKey(cpu, B_INT32_MIN).  The previous
-	// spin loop was dead code and its 1000-iteration cap masked any real
-	// invariant violations by silently proceeding with a wrong root.
 	ASSERT(fCPUHeap.PeekRoot() == cpu);
 	fCPUHeap.RemoveRoot();
 
-	// Atomically clear the bit in fLocalIndices.
 	cpu_mask_and_atomic(&fLocalIndices, ~((native_cpu_mask_t)1 << cpu->fCoreLocalIndex));
 
 	ASSERT(cpu->GetLoad() >= 0 && cpu->GetLoad() <= kMaxLoad);
@@ -1379,12 +1211,22 @@ bigtime_t CPUEntry::GetMinVirtualRuntime() const {
 bigtime_t CoreEntry::GetMinVirtualRuntime() const {
 	SCHEDULER_ENTER_FUNCTION();
 
-	CoreRunQueueLocker locker(const_cast<CoreEntry*>(this));
-	ThreadData* thread =
-		fRunQueue.PeekBest(ThreadDataVRuntimeCompare(), ThreadDataOptimal());
-	if (thread == NULL)
-		return 0;
-	return thread->GetVirtualRuntime();
+	// Approximation: return minimum vruntime of all logical CPUs.
+	bigtime_t minRuntime = B_INT64_MAX;
+	bool found = false;
+
+	for (int32 i = 0; i < smp_get_num_cpus(); i++) {
+		CPUEntry* cpu = CPUEntry::GetCPU(i);
+		if (cpu->Core() == this && !gCPU[i].disabled) {
+			bigtime_t vrt = cpu->GetMinVirtualRuntime();
+			if (vrt > 0 && vrt < minRuntime) {
+				minRuntime = vrt;
+				found = true;
+			}
+		}
+	}
+
+	return found ? minRuntime : 0;
 }
 
 CPUEntry* CoreEntry::PeekMinimumLoadCPU() {
@@ -2044,9 +1886,6 @@ CoreEntry* PackageEntry::PeekMaximumLoadCore(CPUEntry* cpu, const CPUSet* mask,
 	}
 }
 
-/* static */ void DebugDumper::DumpCoreRunQueue(CoreEntry* core) {
-	core->fRunQueue.Dump();
-}
 
 /* static */ void DebugDumper::DumpCoreEntryLoad(CoreEntry* entry) {
 	CoreThreadsData threadsData;
@@ -2099,12 +1938,6 @@ CoreEntry* PackageEntry::PeekMaximumLoadCore(CPUEntry* cpu, const CPUSet* mask,
 
 static int dump_run_queue(int /* argc */, char** /* argv */) {
 	int32 cpuCount = smp_get_num_cpus();
-	int32 coreCount = gCoreCount;
-
-	for (int32 i = 0; i < coreCount; i++) {
-		kprintf("%sCore %" B_PRId32 " run queue:\n", i > 0 ? "\n" : "", i);
-		DebugDumper::DumpCoreRunQueue(&gCoreEntries[i]);
-	}
 
 	for (int32 i = 0; i < cpuCount; i++)
 		DebugDumper::DumpCPURunQueue(&gCPUEntries[i]);

--- a/src/system/kernel/scheduler/scheduler_cpu.cpp
+++ b/src/system/kernel/scheduler/scheduler_cpu.cpp
@@ -1211,17 +1211,25 @@ bigtime_t CPUEntry::GetMinVirtualRuntime() const {
 bigtime_t CoreEntry::GetMinVirtualRuntime() const {
 	SCHEDULER_ENTER_FUNCTION();
 
-	// Approximation: return minimum vruntime of all logical CPUs.
+	// Approximation: return minimum vruntime of all logical CPUs in this core.
 	bigtime_t minRuntime = B_INT64_MAX;
 	bool found = false;
 
-	for (int32 i = 0; i < smp_get_num_cpus(); i++) {
-		CPUEntry* cpu = CPUEntry::GetCPU(i);
-		if (cpu->Core() == this && !gCPU[i].disabled) {
-			bigtime_t vrt = cpu->GetMinVirtualRuntime();
-			if (vrt > 0 && vrt < minRuntime) {
-				minRuntime = vrt;
-				found = true;
+	const CPUSet& cpuMask = CPUMask();
+	for (int32 word = 0; word < (SMP_MAX_CPUS + 31) / 32; word++) {
+		uint32 bits = cpuMask.Bits(word);
+		while (bits != 0) {
+			int bit = scheduler_ctz((native_cpu_mask_t)bits);
+			bits &= ~(1U << (bit % 32));
+			int32 i = word * 32 + bit;
+
+			CPUEntry* cpu = CPUEntry::GetCPU(i);
+			if (!gCPU[i].disabled) {
+				bigtime_t vrt = cpu->GetMinVirtualRuntime();
+				if (vrt > 0 && vrt < minRuntime) {
+					minRuntime = vrt;
+					found = true;
+				}
 			}
 		}
 	}

--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -100,6 +100,9 @@ public:
 	inline void IncrementThreadCount() { AddRelease(fThreadCount, 1); }
 	inline void DecrementThreadCount() { AddRelease(fThreadCount, -1); }
 
+	ThreadData* StealThread(int32& stolenPriority, int32 thiefCPU);
+	ThreadData* StealThreadLockless(int32& stolenPriority, int32 thiefCPU);
+
 	// Index of this CPU within its core, assigned sequentially in AddCPU.
 	// Used by UpdatePriorityBoostScalable for round-robin epoch ownership.
 	// Public because UpdatePriorityBoostScalable is a file-scope function.
@@ -251,38 +254,6 @@ public:
 	inline void DecrementDisplayThreadCount() {
 		AddRelease(fDisplayThreadCount, -1);
 	}
-	inline int32 CoreRunQueueThreadCount() const {
-		return LoadAcquire(fThreadCount);
-	}
-
-	inline void LockRunQueue();
-	inline bool TryLockRunQueue();
-	inline void UnlockRunQueue();
-
-	inline void IncrementThreadCount() { AddRelease(fThreadCount, 1); }
-	inline void DecrementThreadCount() { AddRelease(fThreadCount, -1); }
-	// Note: lockless check for display-priority threads in the
-	// run queue.  Used by ComputeQuantum to avoid TryLockRunQueue on the
-	// scheduling hot path.
-	inline bool HasHighPriorityThread() const;
-
-	ThreadData* StealThread(int32& stolenPriority, int32 thiefCPU);
-	ThreadData* StealThreadLockless(int32& stolenPriority, int32 thiefCPU);
-
-	void PushFront(ThreadData* thread, int32 priority);
-	void PushBack(ThreadData* thread, int32 priority);
-	void Remove(ThreadData* thread);
-	ThreadData* PeekThread() const;
-	inline ThreadData* PeekHead() const { return fRunQueue.PeekMaximum(); }
-	inline const ThreadRunQueue* RunQueue() const { return &fRunQueue; }
-
-	inline ThreadRunQueue::ConstIterator GetConstIterator() const {
-		return fRunQueue.GetConstIterator();
-	}
-
-	inline void CheckEligibility(bigtime_t svt) {
-		fRunQueue.CheckEligibility(svt);
-	}
 
 	inline bigtime_t SystemVirtualTime() const {
 		return (bigtime_t)LoadAcquire64(fSystemVirtualTime);
@@ -327,7 +298,7 @@ public:
 	CPUEntry* PeekMinimumLoadCPU();
 
 	void AddCPU(CPUEntry* cpu);
-	void RemoveCPU(CPUEntry* cpu, ThreadProcessing& threadPostProcessing);
+	void RemoveCPU(CPUEntry* cpu);
 
 private:
 	void _UpdateLoad(bool forceUpdate = false, bigtime_t now = 0);
@@ -356,11 +327,8 @@ private:
 	CPUPriorityHeap fCPUHeap;
 	spinlock fCPULock;
 
-	spinlock fQueueLock;
-	int32 fThreadCount __attribute__((aligned(8)));
 	int32 fTotalThreadCount __attribute__((aligned(8)));
 	int32 fDisplayThreadCount __attribute__((aligned(8)));
-	ThreadRunQueue fRunQueue;
 
 	int32 fLoad;
 
@@ -569,20 +537,6 @@ inline CPUPriorityHeap* CoreEntry::CPUHeap() {
 	return &fCPUHeap;
 }
 
-inline void CoreEntry::LockRunQueue() {
-	SCHEDULER_ENTER_FUNCTION();
-	acquire_spinlock(&fQueueLock);
-}
-
-inline bool CoreEntry::TryLockRunQueue() {
-	SCHEDULER_ENTER_FUNCTION();
-	return try_acquire_spinlock(&fQueueLock);
-}
-
-inline void CoreEntry::UnlockRunQueue() {
-	SCHEDULER_ENTER_FUNCTION();
-	release_spinlock(&fQueueLock);
-}
 
 inline void CoreEntry::IncreaseActiveTime(bigtime_t activeTime) {
 	SCHEDULER_ENTER_FUNCTION();
@@ -911,12 +865,7 @@ inline CoreEntry* PackageEntry::GetCore(int32 index) const {
 inline void PackageEntry::ReadLockCore() { acquire_read_spinlock(&fCoreLock); }
 
 inline bool CoreEntry::HasHighPriorityThread() const {
-	// Note: lockless check for high-priority threads at the heap root.
-	ThreadData* root = fRunQueue.PeekRoot();
-	if (root == NULL)
-		return false;
-
-	return root->GetEffectivePriority() >= B_DISPLAY_PRIORITY;
+	return DisplayThreadCount() > 0;
 }
 
 inline void PackageEntry::ReadUnlockCore() {

--- a/src/system/kernel/scheduler/scheduler_locking.h
+++ b/src/system/kernel/scheduler/scheduler_locking.h
@@ -31,22 +31,25 @@ private:
 	void Acquire() {
 		fStatus = disable_interrupts();
 
-#ifdef DEBUG_SCHEDULER
-		// Use get_cpu_struct()->running_thread for safer access during
-		// context switches and early boot.
+		// Decentralized protection: acquire the current thread's scheduler_lock.
+		// This provides execution-state protection for code that previously
+		// relied on the global gSchedulerLock.
 		Thread* thread = get_cpu_struct()->running_thread;
+		if (thread != NULL)
+			acquire_spinlock(&thread->scheduler_lock);
+
+#ifdef DEBUG_SCHEDULER
 		if (thread != NULL)
 			thread->scheduler_lock_depth++;
 #endif
-
-		AcquireSchedulerSpinlock();
 	}
 
 	void Release() {
-		ReleaseSchedulerSpinlock();
+		Thread* thread = get_cpu_struct()->running_thread;
+		if (thread != NULL)
+			release_spinlock(&thread->scheduler_lock);
 
 #ifdef DEBUG_SCHEDULER
-		Thread* thread = get_cpu_struct()->running_thread;
 		if (thread != NULL) {
 			thread->scheduler_lock_depth--;
 			ASSERT(thread->scheduler_lock_depth >= 0);
@@ -126,26 +129,6 @@ public:
 
 typedef AutoLocker<CPUEntry, CPURunQueueLocking> CPURunQueueLocker;
 
-class CoreRunQueueLocking {
-public:
-	inline bool Lock(CoreEntry* core) {
-		core->LockRunQueue();
-		return true;
-	}
-
-	inline void Unlock(CoreEntry* core) { core->UnlockRunQueue(); }
-};
-
-class CoreRunQueueTryLocking {
-public:
-	inline bool Lock(CoreEntry* core) { return core->TryLockRunQueue(); }
-
-	inline void Unlock(CoreEntry* core) { core->UnlockRunQueue(); }
-};
-
-typedef AutoLocker<CoreEntry, CoreRunQueueTryLocking> CoreRunQueueTryLocker;
-
-typedef AutoLocker<CoreEntry, CoreRunQueueLocking> CoreRunQueueLocker;
 
 class CoreCPUHeapLocking {
 public:

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -133,6 +133,11 @@ public:
 								  bool& updateInteraction, bigtime_t now = 0);
 	SCHEDULER_INLINE bool Dequeue();
 
+	inline CPUEntry* EnqueuedCPU() const {
+		return atomic_pointer_get<CPUEntry>(
+			const_cast<CPUEntry* volatile*>(&fEnqueuedCPU));
+	}
+
 	SCHEDULER_INLINE void UpdateVirtualRuntime(bigtime_t delta,
 											   bigtime_t svt,
 											   bigtime_t maxLatency = 0);
@@ -177,6 +182,7 @@ public:
 	SCHEDULER_INLINE void SetDequeued() {
 		fEnqueued = false;
 		fEnqueuedInCPURunQueue = false;
+		atomic_pointer_set<CPUEntry>(&fEnqueuedCPU, (CPUEntry*)NULL);
 	}
 
 	SCHEDULER_INLINE int32 GetLoad() const { return fNeededLoad; }
@@ -250,6 +256,7 @@ private:
 
 	DoublyLinkedListLink<ThreadData> fRunQueueLink;
 
+	CPUEntry* fEnqueuedCPU __attribute__((aligned(8)));
 	CoreEntry* fCore __attribute__((aligned(8)));
 };
 
@@ -608,6 +615,7 @@ inline void ThreadData::PutBack(bigtime_t now) {
 
 	CPURunQueueLocker _(cpu);
 	ASSERT(!fEnqueued);
+	atomic_pointer_set<CPUEntry>(&fEnqueuedCPU, cpu);
 	fEnqueued = true;
 	fEnqueuedInCPURunQueue = true;
 
@@ -690,6 +698,7 @@ inline bool ThreadData::Enqueue(CPUEntry* cpu, bool& wasRunQueueEmpty, bool& req
 	fThread->state = B_THREAD_READY;
 
 	ASSERT(!fEnqueued);
+	atomic_pointer_set<CPUEntry>(&fEnqueuedCPU, cpu);
 	fEnqueued = true;
 	fEnqueuedInCPURunQueue = true;
 
@@ -721,15 +730,25 @@ inline bool ThreadData::Enqueue(CPUEntry* cpu, bool& wasRunQueueEmpty, bool& req
 inline bool ThreadData::Dequeue() {
 	SCHEDULER_ENTER_FUNCTION();
 
-	ASSERT(fEnqueuedInCPURunQueue);
-	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
-
-	CPURunQueueLocker _(cpu);
 	if (!fEnqueued)
 		return false;
-	cpu->Remove(this);
-	ASSERT(!fEnqueued);
-	return true;
+
+	while (true) {
+		CPUEntry* cpu = EnqueuedCPU();
+		if (cpu == NULL)
+			return false;
+
+		CPURunQueueLocker locker(cpu);
+		if (EnqueuedCPU() != cpu)
+			continue;
+
+		if (!fEnqueued)
+			return false;
+
+		cpu->Remove(this);
+		ASSERT(!fEnqueued);
+		return true;
+	}
 }
 
 inline void RunQueueTraits<ThreadData>::SetInRunQueue(ThreadData* element,

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -128,7 +128,7 @@ public:
 	// timestamp propagation.
 	SCHEDULER_INLINE void PutBack(bigtime_t now = 0);
 	SCHEDULER_INLINE status_t CheckCapacity();
-	SCHEDULER_INLINE bool Enqueue(bool& wasRunQueueEmpty,
+	SCHEDULER_INLINE bool Enqueue(CPUEntry* targetCPU, bool& wasRunQueueEmpty,
 								  bool& requestPreemption,
 								  bool& updateInteraction, bigtime_t now = 0);
 	SCHEDULER_INLINE bool Dequeue();
@@ -603,46 +603,23 @@ inline void ThreadData::PutBack(bigtime_t now) {
 			fThread->id);
 	}
 
-	if (fThread->pinned_to_cpu > 0) {
-		ASSERT(fThread->cpu != NULL);
-		CPUEntry* cpu = CPUEntry::GetCPU(fThread->cpu->cpu_num);
+	ASSERT(fThread->cpu != NULL);
+	CPUEntry* cpu = CPUEntry::GetCPU(fThread->cpu->cpu_num);
 
-		// If the thread is pinned but we are running on a different CPU, it
-		// means the pinned CPU was disabled. We should float until it comes
-		// back.
-		if (fThread->cpu->cpu_num != fThread->pinned_to_cpu - 1)
-			goto enqueue_core;
+	CPURunQueueLocker _(cpu);
+	ASSERT(!fEnqueued);
+	fEnqueued = true;
+	fEnqueuedInCPURunQueue = true;
 
-		CPURunQueueLocker _(cpu);
-		ASSERT(!fEnqueued);
-		fEnqueued = true;
-		fEnqueuedInCPURunQueue = true;
-
-		cpu->PushFront(this, priority);
-	} else {
-	enqueue_core:
-		CoreEntry* core = Core();
-		CoreRunQueueLocker _(core);
-		ASSERT(!fEnqueued);
-		fEnqueued = true;
-		fEnqueuedInCPURunQueue = false;
-
-		core->PushFront(this, priority);
-	}
+	cpu->PushFront(this, priority);
 }
 
 inline status_t ThreadData::CheckCapacity() {
-	if (fThread->pinned_to_cpu > 0) {
-		CPUEntry* cpu = CPUEntry::GetCPU(fThread->previous_cpu->cpu_num);
-		return const_cast<ThreadRunQueue*>(cpu->RunQueue())->CheckCapacity(cpu->ThreadCount() + 1);
-	} else {
-		CoreEntry* core = Core();
-		if (core == NULL) return B_OK;
-		return const_cast<ThreadRunQueue*>(core->RunQueue())->CheckCapacity(core->CoreRunQueueThreadCount() + 1);
-	}
+	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
+	return const_cast<ThreadRunQueue*>(cpu->RunQueue())->CheckCapacity(cpu->ThreadCount() + 1);
 }
 
-inline bool ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption,
+inline bool ThreadData::Enqueue(CPUEntry* cpu, bool& wasRunQueueEmpty, bool& requestPreemption,
 								bool& updateInteraction, bigtime_t now) {
 	SCHEDULER_ENTER_FUNCTION();
 
@@ -653,173 +630,82 @@ inline bool ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption,
 
 	bool wasReady = fReady;
 
-	if (CheckCapacity() != B_OK)
+	if (cpu == NULL)
 		return false;
 
 	const int32 priority = GetEffectivePriority();
-	bool pinned = fThread->pinned_to_cpu > 0;
-	if (pinned) {
-		ASSERT(fThread->previous_cpu != NULL);
-		CPUEntry* cpu = CPUEntry::GetCPU(fThread->previous_cpu->cpu_num);
 
-		CPURunQueueLocker locker(cpu);
+	// decentralized per-CPU run-queues.
+	CoreEntry* core = cpu->Core();
 
-		// Check if the pinned CPU is disabled under the lock
-		if (gCPU[cpu->ID()].disabled) {
-			locker.Unlock();
-			pinned = false;	 // float
-		} else {
-			if (!wasReady && !IsRealTime()) {
-				bigtime_t svt = cpu->SystemVirtualTime();
-				bigtime_t vrt = GetVirtualRuntime();
+	if (core == NULL)
+		return false;
 
-				// Scale the lag floor to virtual time based on thread weight.
-				// vLagFloor = (kMaxLagFloor * 1000000) / weight
-				int64 weight = GetWeight();
-				if (weight <= 0)
-					weight = 1;
-				bigtime_t vLagFloor = (kMaxLagFloor * 1000000LL) / weight;
+	CPURunQueueLocker locker(cpu);
 
-				if (vrt < svt - vLagFloor)
-					StoreRelease64(fThread->virtual_runtime, (int64)(svt - vLagFloor));
+	if (gCPU[cpu->ID()].disabled)
+		return false;
 
-				_UpdateDeadline(now);
-			}
-
-			// defer the gTotalRunnableThreads increment until after the
-			// CPUCount guard in the non-pinned path (see below).  For the
-			// pinned path the CPU liveness check happens under
-			// CPURunQueueLocker.
-			if (!wasReady && !IsIdle())
-				AddRelease(gTotalRunnableThreads, 1);
-
-			fReady = true;
-			fThread->state = B_THREAD_READY;
-
-			ASSERT(!fEnqueued);
-			fEnqueued = true;
-			fEnqueuedInCPURunQueue = true;
-
-			ThreadData* top = cpu->PeekThread();
-			wasRunQueueEmpty = (top == NULL || top->IsIdle());
-
-			bool isForeground = fIsForeground;
-
-			if (fQuickStartCredit || isForeground) {
-				cpu->PushFront(this, priority);
-				requestPreemption = true;
-				if (isForeground)
-					updateInteraction = true;
-			} else
-				cpu->PushBack(this, priority);
-		}
-	}
-
-	if (!pinned) {
-		// guard fCore NULL before constructing the RAII lockers.
-		// MigrateTo(NULL) can set fCore=NULL when all masked CPUs are disabled.
-		// Both CoreCPULocker and CoreRunQueueLocker dereference their argument
-		// in the constructor; a NULL fCore here causes a null-dereference panic
-		// before we even reach the existing null check below.
-		CoreEntry* coreSnapshot = atomic_pointer_get<CoreEntry>(&fCore);
-		if (coreSnapshot == NULL)
-			return false;
-
-		CoreCPULocker cpuLocker(coreSnapshot);
-		CoreRunQueueLocker locker(coreSnapshot);
-
-		// Note: re-check under the lock - fCore may have been set to
-		// NULL between the guard above and lock acquisition.  The explicit
-		// Unlock() calls were redundant: AutoLocker's destructor checks
-		// fLocked and will not double-unlock.  RAII handles cleanup correctly.
-		if (atomic_pointer_get<CoreEntry>(&fCore) != coreSnapshot)
-			return false;
-
-		CoreEntry* core = coreSnapshot;
-
-		// move the fStolen decrement AFTER the CPUCount guard so
-		// that a return-false path never leaves TotalThreadCount decremented
-		// without a corresponding enqueue to balance it.
-		// Note: AddLoad was previously called unconditionally before
-		// the CPUCount guard, leaving load permanently inflated when
-		// CPUCount==0 caused return false. Move AddLoad AFTER all guards.
-		if (fStolen) {
-			if (core->CPUCount() == 0) {
-				core->DecrementTotalThreadCount();
-				fStolen = false;
-				return false;
-			}
-			// Note: AddLoad happens here, after all early-return guards.
-			if (gTrackCoreLoad && !wasReady) {
-				bigtime_t timeSlept =
-					now - (bigtime_t)LoadAcquire64(fWentSleep);
-				bool updateLoad = timeSlept > 0;
-				core->AddLoad(fNeededLoad, fLoadMeasurementEpoch, !updateLoad,
-							  now);
-				if (updateLoad) {
-					AddRelease64(fMeasureAvailableTime, (int64)timeSlept);
-					_ComputeNeededLoad(now);
-				}
-			}
-			core->DecrementTotalThreadCount();
-			fStolen = false;
-		} else if (core->CPUCount() == 0) {
-			return false;
-		} else if (!wasReady && gTrackCoreLoad) {
-			// Note: for non-stolen threads, AddLoad after CPUCount guard.
-			// Note: ensure AddLoad captures the full sleep time when a thread
-			// is woken up.
-			bigtime_t timeSlept =
-				now - (bigtime_t)LoadAcquire64(fWentSleep);
+	if (fStolen) {
+		if (gTrackCoreLoad && !wasReady) {
+			bigtime_t timeSlept = now - (bigtime_t)LoadAcquire64(fWentSleep);
 			bool updateLoad = timeSlept > 0;
-			core->AddLoad(fNeededLoad, fLoadMeasurementEpoch, !updateLoad, now);
+			core->AddLoad(fNeededLoad, fLoadMeasurementEpoch, !updateLoad,
+						  now);
 			if (updateLoad) {
 				AddRelease64(fMeasureAvailableTime, (int64)timeSlept);
 				_ComputeNeededLoad(now);
 			}
 		}
-
-		if (!wasReady && !IsRealTime()) {
-			bigtime_t svt = core->SystemVirtualTime();
-			bigtime_t vrt = GetVirtualRuntime();
-
-			// Scale the lag floor to virtual time based on thread weight.
-			int64 weight = GetWeight();
-			if (weight <= 0)
-				weight = 1;
-			bigtime_t vLagFloor = (kMaxLagFloor * 1000000LL) / weight;
-
-			if (vrt < svt - vLagFloor)
-				StoreRelease64(fThread->virtual_runtime, (int64)(svt - vLagFloor));
-
-			_UpdateDeadline(now);
+		fStolen = false;
+	} else if (!wasReady && gTrackCoreLoad) {
+		bigtime_t timeSlept = now - (bigtime_t)LoadAcquire64(fWentSleep);
+		bool updateLoad = timeSlept > 0;
+		core->AddLoad(fNeededLoad, fLoadMeasurementEpoch, !updateLoad, now);
+		if (updateLoad) {
+			AddRelease64(fMeasureAvailableTime, (int64)timeSlept);
+			_ComputeNeededLoad(now);
 		}
-
-		// defer the gTotalRunnableThreads increment until after the
-		// CPUCount guard in the non-pinned path.
-		if (!wasReady && !IsIdle())
-			AddRelease(gTotalRunnableThreads, 1);
-
-		fReady = true;
-		fThread->state = B_THREAD_READY;
-
-		ASSERT(!fEnqueued);
-		fEnqueued = true;
-		fEnqueuedInCPURunQueue = false;
-
-		ThreadData* top = core->PeekThread();
-		wasRunQueueEmpty = (top == NULL || top->IsIdle());
-
-		bool isForeground = fIsForeground;
-
-		if (fQuickStartCredit || isForeground) {
-			core->PushFront(this, priority);
-			requestPreemption = true;
-			if (isForeground)
-				updateInteraction = true;
-		} else
-			core->PushBack(this, priority);
 	}
+
+	if (!wasReady && !IsRealTime()) {
+		bigtime_t svt = cpu->SystemVirtualTime();
+		bigtime_t vrt = GetVirtualRuntime();
+
+		int64 weight = GetWeight();
+		if (weight <= 0)
+			weight = 1;
+		bigtime_t vLagFloor = (kMaxLagFloor * 1000000LL) / weight;
+
+		if (vrt < svt - vLagFloor)
+			StoreRelease64(fThread->virtual_runtime, (int64)(svt - vLagFloor));
+
+		_UpdateDeadline(now);
+	}
+
+	if (!wasReady && !IsIdle())
+		AddRelease(gTotalRunnableThreads, 1);
+
+	fReady = true;
+	fThread->state = B_THREAD_READY;
+
+	ASSERT(!fEnqueued);
+	fEnqueued = true;
+	fEnqueuedInCPURunQueue = true;
+
+	ThreadData* top = cpu->PeekThread();
+	wasRunQueueEmpty = (top == NULL || top->IsIdle());
+
+	bool isForeground = fIsForeground;
+
+	if (fQuickStartCredit || isForeground) {
+		cpu->PushFront(this, priority);
+		requestPreemption = true;
+		if (isForeground)
+			updateInteraction = true;
+	} else
+		cpu->PushBack(this, priority);
+
 	// Note: Global run-queue counter update. gTotalRunnableThreads is
 	// incremented AFTER the CPUCount == 0 guards in both the pinned and
 	// non-pinned paths.  There is no return-false path after the increment;
@@ -835,24 +721,13 @@ inline bool ThreadData::Enqueue(bool& wasRunQueueEmpty, bool& requestPreemption,
 inline bool ThreadData::Dequeue() {
 	SCHEDULER_ENTER_FUNCTION();
 
-	if (fEnqueuedInCPURunQueue) {
-		ASSERT(fThread->previous_cpu != NULL);
-		CPUEntry* cpu = CPUEntry::GetCPU(fThread->previous_cpu->cpu_num);
+	ASSERT(fEnqueuedInCPURunQueue);
+	CPUEntry* cpu = CPUEntry::GetCPU(smp_get_current_cpu());
 
-		CPURunQueueLocker _(cpu);
-		if (!fEnqueued)
-			return false;
-		cpu->Remove(this);
-		ASSERT(!fEnqueued);
-		return true;
-	}
-
-	CoreEntry* core = Core();
-	CoreRunQueueLocker _(core);
+	CPURunQueueLocker _(cpu);
 	if (!fEnqueued)
 		return false;
-
-	core->Remove(this);
+	cpu->Remove(this);
 	ASSERT(!fEnqueued);
 	return true;
 }


### PR DESCRIPTION
This change completes the architectural shift of the Haiku scheduler from a global/core-shared run-queue model to a strictly decentralized per-logical-CPU model. Every logical processor now manages its own run-queue and isolated spinlock. The global gSchedulerLock has been removed, with its role for thread-state protection being replaced by the individual thread->scheduler_lock. Work-stealing and load-balancing algorithms have been updated to efficiently navigate this new topology using bitmask-based scans.

---
*PR created automatically by Jules for task [10269371309193042031](https://jules.google.com/task/10269371309193042031) started by @tonestone57*