### PR TITLE
Add missing fCapacity member and verify ScoreFactor logic

### DIFF
--- a/src/system/kernel/scheduler/scheduler_cpu.h
+++ b/src/system/kernel/scheduler/scheduler_cpu.h
@@ -347,6 +347,7 @@ private:
 
 	int32 fLoad;
 
+	int32 fCapacity;
 	uint32 fScoreFactor;
 
 	native_cpu_mask_t fLocalIndices __attribute__((aligned(8)));


### PR DESCRIPTION
The CoreEntry class was missing the `fCapacity` data member, although it had a `Capacity()` accessor and was used in `ScoreFactor` calculations. I added `int32 fCapacity;` to `CoreEntry` in `scheduler_cpu.h`. I also verified that `fScoreFactor` and the `ScoreFactor()` method are present and correctly initialized in `scheduler_cpu.cpp` and `scheduler.cpp` during CPU topology discovery and capacity updates. This ensures that the performance-scaling logic has the necessary data to function correctly.

---
*PR created automatically by Jules for task [6519900418505562014](https://jules.google.com/task/6519900418505562014) started by @tonestone57*