### PR TITLE
Implement Refined Preemption Hysteresis

### DIFF
--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -666,7 +666,7 @@ static bool enqueue(Thread* thread, bool newOne, Thread* waker, bigtime_t now) {
 		// Strengthen the architectural boundary on preemption to guard against
 		// "quantum shredding" and unnecessary context switches.
 		bool suppressPreemption = false;
-		if (!isRT && !wasRunQueueEmpty) {
+		if (!isRT) {
 			Thread* running = gCPU[targetCPU->ID()].running_thread;
 			ThreadData* runningData = (running != NULL) ? running->scheduler_data : NULL;
 
@@ -685,8 +685,8 @@ static bool enqueue(Thread* thread, bool newOne, Thread* waker, bigtime_t now) {
 						weight = 1;
 
 					// EEVDF Preemption: scale real-time epsilon to virtual time.
-					// Consistent with _ComputeEffectivePriority, we use a reference
-					// scale of 1000 for virtual conversion.
+					// We use a scale of 1000 for consistency with existing
+					// nanosecond-based lag math and _ComputeEffectivePriority.
 					bigtime_t vEpsilon = (epsilon * 1000) / weight;
 
 					if (runningData->GetVirtualDeadline() - threadData->GetVirtualDeadline() < vEpsilon) {

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -665,56 +665,62 @@ static bool enqueue(Thread* thread, bool newOne, Thread* waker, bigtime_t now) {
 		// Refined Preemption Hysteresis:
 		// Strengthen the architectural boundary on preemption to guard against
 		// "quantum shredding" and unnecessary context switches.
-		if (!isRT) {
+		bool suppressPreemption = false;
+		if (!isRT && !wasRunQueueEmpty) {
 			Thread* running = gCPU[targetCPU->ID()].running_thread;
 			ThreadData* runningData = (running != NULL) ? running->scheduler_data : NULL;
 
 			if (runningData != NULL && !runningData->IsIdle() && !runningData->IsRealTime()) {
 				// 1. Execution Floor Check: ensure the running thread has executed
-				// for at least MinimalQuantum() before allowing immediate preemption.
+				// for at least MinimalQuantum() before allowing preemption.
 				bigtime_t runtime = now - runningData->QuantumStart();
 				if (runtime < Scheduler::MinimalQuantum()) {
-					gCPU[targetCPU->ID()].invoke_scheduler = true;
-					return true;
-				}
+					suppressPreemption = true;
+				} else {
+					// 2. Preemption Threshold Delta Check:
+					// A waking thread only preempts if VD_waking < VD_running - delta.
+					bigtime_t epsilon = targetCPU->PreemptionThreshold();
+					int64 weight = runningData->GetWeight();
+					if (weight <= 0)
+						weight = 1;
 
-				// 2. Preemption Threshold Delta Check:
-				// A waking thread only preempts if VD_waking < VD_running - delta.
-				bigtime_t epsilon = targetCPU->PreemptionThreshold();
-				int64 weight = runningData->GetWeight();
-				if (weight <= 0)
-					weight = 1;
+					// EEVDF Preemption: scale real-time epsilon to virtual time.
+					// Consistent with _ComputeEffectivePriority, we use a reference
+					// scale of 1000 for virtual conversion.
+					bigtime_t vEpsilon = (epsilon * 1000) / weight;
 
-				// EEVDF Preemption: scale real-time epsilon to virtual time.
-				// Consistent with _ComputeEffectivePriority, we use a reference
-				// scale of 1000 for virtual conversion.
-				bigtime_t vEpsilon = (epsilon * 1000) / weight;
-
-				if (runningData->GetVirtualDeadline() - threadData->GetVirtualDeadline() < vEpsilon) {
-					// Not urgent enough to justify immediate preemption;
-					// use lazy flagging instead.
-					gCPU[targetCPU->ID()].invoke_scheduler = true;
-					return true;
+					if (runningData->GetVirtualDeadline() - threadData->GetVirtualDeadline() < vEpsilon) {
+						suppressPreemption = true;
+					}
 				}
 			}
 		}
 
-		if (targetCPU->ID() == smp_get_current_cpu()) {
-			gCPU[targetCPU->ID()].invoke_scheduler = true;
-		} else {
-			// Note: this IPI dispatch was unreachable before; now
-			// correctly wakes the target CPU when a thread is enqueued.
-			if (ShouldReschedule(now,
-								 (bigtime_t)LoadAcquire64(targetCPU->fLastReschedule),
-								 kRescheduleCooldown)) {
-				if (targetCPU->SetReschedulePending()) {
-					StoreRelease64(targetCPU->fLastReschedule, (int64)now);
-					smp_send_ici(targetCPU->ID(), SMP_MSG_RESCHEDULE, 0, 0, 0,
-								 NULL, SMP_MSG_FLAG_ASYNC);
-				}
+		if (!suppressPreemption) {
+			if (targetCPU->ID() == smp_get_current_cpu()) {
+				gCPU[targetCPU->ID()].invoke_scheduler = true;
 			} else {
-				// Coalesced preemption: if we are within the cooldown period
-				// for IPIs, use lazy flagging.
+				// Note: correctly wakes the target CPU when a thread is enqueued.
+				if (ShouldReschedule(now,
+									 (bigtime_t)LoadAcquire64(targetCPU->fLastReschedule),
+									 kRescheduleCooldown)) {
+					if (targetCPU->SetReschedulePending()) {
+						StoreRelease64(targetCPU->fLastReschedule, (int64)now);
+						smp_send_ici(targetCPU->ID(), SMP_MSG_RESCHEDULE, 0, 0, 0,
+									 NULL, SMP_MSG_FLAG_ASYNC);
+					}
+				} else {
+					// Coalesced preemption: if we are within the cooldown period
+					// for IPIs, use lazy flagging.
+					gCPU[targetCPU->ID()].invoke_scheduler = true;
+				}
+			}
+		} else {
+			// Hysteresis suppressed immediate preemption.
+			// Use "lazy flagging" for remote CPUs: flag the CPU so it
+			// reschedules at its next natural kernel boundary, but don't
+			// send a disruptive IPI.
+			if (targetCPU->ID() != smp_get_current_cpu()) {
 				gCPU[targetCPU->ID()].invoke_scheduler = true;
 			}
 		}

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -684,10 +684,11 @@ static bool enqueue(Thread* thread, bool newOne, Thread* waker, bigtime_t now) {
 					if (weight <= 0)
 						weight = 1;
 
-					// EEVDF Preemption: scale real-time epsilon to virtual time.
-					// We use a scale of 1000 for consistency with existing
-					// nanosecond-based lag math and _ComputeEffectivePriority.
-					bigtime_t vEpsilon = (epsilon * 1000) / weight;
+					// EEVDF Preemption: scale real-time epsilon (nanoseconds) to
+					// virtual time. Virtual time units in this scheduler are
+					// (microseconds * kReferenceWeight) / weight.
+					// vEpsilon = ( (epsilon_ns / 1000) * kReferenceWeight ) / weight
+					bigtime_t vEpsilon = (epsilon * (kReferenceWeight / 1000)) / weight;
 
 					if (runningData->GetVirtualDeadline() - threadData->GetVirtualDeadline() < vEpsilon) {
 						suppressPreemption = true;
@@ -720,6 +721,9 @@ static bool enqueue(Thread* thread, bool newOne, Thread* waker, bigtime_t now) {
 			// Use "lazy flagging" for remote CPUs: flag the CPU so it
 			// reschedules at its next natural kernel boundary, but don't
 			// send a disruptive IPI.
+			// For the local CPU, we skip setting invoke_scheduler entirely
+			// to avoid immediate reschedule from wakers using
+			// scheduler_reschedule_if_necessary().
 			if (targetCPU->ID() != smp_get_current_cpu()) {
 				gCPU[targetCPU->ID()].invoke_scheduler = true;
 			}

--- a/src/system/kernel/scheduler/scheduler.cpp
+++ b/src/system/kernel/scheduler/scheduler.cpp
@@ -662,27 +662,37 @@ static bool enqueue(Thread* thread, bool newOne, Thread* waker, bigtime_t now) {
 		(threadPriority == heapPriority && rescheduleNeeded) ||
 		wasRunQueueEmpty || requestPreemption || isRT) {
 
-		// Note: Dynamic Preemption Granularity.
-		// Only trigger IPI if Delta(deadline) > epsilon.
-		// A more urgent thread (earlier deadline) only preempts if it is
-		// significantly more urgent (Delta > epsilon).
-		if (!isRT && targetCPU->ID() != smp_get_current_cpu()) {
-			bigtime_t epsilon = targetCPU->PreemptionThreshold();
+		// Refined Preemption Hysteresis:
+		// Strengthen the architectural boundary on preemption to guard against
+		// "quantum shredding" and unnecessary context switches.
+		if (!isRT) {
 			Thread* running = gCPU[targetCPU->ID()].running_thread;
 			ThreadData* runningData = (running != NULL) ? running->scheduler_data : NULL;
+
 			if (runningData != NULL && !runningData->IsIdle() && !runningData->IsRealTime()) {
-				// EEVDF Preemption: scale real-time epsilon to virtual time.
-				// vEpsilon = (epsilon * kFairShareReferenceWeight) / weight
+				// 1. Execution Floor Check: ensure the running thread has executed
+				// for at least MinimalQuantum() before allowing immediate preemption.
+				bigtime_t runtime = now - runningData->QuantumStart();
+				if (runtime < Scheduler::MinimalQuantum()) {
+					gCPU[targetCPU->ID()].invoke_scheduler = true;
+					return true;
+				}
+
+				// 2. Preemption Threshold Delta Check:
+				// A waking thread only preempts if VD_waking < VD_running - delta.
+				bigtime_t epsilon = targetCPU->PreemptionThreshold();
 				int64 weight = runningData->GetWeight();
 				if (weight <= 0)
 					weight = 1;
+
+				// EEVDF Preemption: scale real-time epsilon to virtual time.
+				// Consistent with _ComputeEffectivePriority, we use a reference
+				// scale of 1000 for virtual conversion.
 				bigtime_t vEpsilon = (epsilon * 1000) / weight;
 
-				// Preempt only if runningData->Deadline - threadData->Deadline > vEpsilon
 				if (runningData->GetVirtualDeadline() - threadData->GetVirtualDeadline() < vEpsilon) {
-					// Not urgent enough to justify immediate preemption via IPI;
-					// use lazy flagging instead. The remote CPU will pick this
-					// up on its next kernel exit.
+					// Not urgent enough to justify immediate preemption;
+					// use lazy flagging instead.
 					gCPU[targetCPU->ID()].invoke_scheduler = true;
 					return true;
 				}

--- a/src/system/kernel/scheduler/scheduler_thread.h
+++ b/src/system/kernel/scheduler/scheduler_thread.h
@@ -113,6 +113,10 @@ public:
 		return (bigtime_t)LoadAcquire64(fWentSleepActive);
 	}
 
+	SCHEDULER_INLINE bigtime_t QuantumStart() const {
+		return (bigtime_t)LoadAcquire64(fQuantumStart);
+	}
+
 	SCHEDULER_INLINE void PutBack(bigtime_t now = 0);
 	SCHEDULER_INLINE status_t CheckCapacity(CPUEntry* targetCPU);
 	SCHEDULER_INLINE bool Enqueue(CPUEntry* targetCPU, bool& wasRunQueueEmpty,


### PR DESCRIPTION
This change implements Refined Preemption Hysteresis in the Haiku scheduler to guard against "quantum shredding" and reduce high-frequency context switching.

Key features:
1. **Execution Floor**: Enforces a minimum execution granularity (typically 1.2ms) before a non-real-time thread can be preempted by another non-real-time thread.
2. **Preemption Threshold Delta**: Requires a waking thread to have a significantly more urgent virtual deadline (defined by the CPU's PreemptionThreshold scaled to virtual time) before triggering an immediate reschedule or IPI.
3. **Lazy Preemption**: For remote CPUs, if the preemption is suppressed by hysteresis, the system now uses lazy flagging (setting `invoke_scheduler = true` without an immediate IPI) instead of either doing nothing or sending a disruptive interrupt.
4. **Safety and Responsiveness**: Real-time threads and wakeups on idle CPUs are exempted from these hysteresis checks to ensure that latency-critical tasks and system idle recovery remain fast.

The implementation includes a new `QuantumStart()` accessor in `ThreadData` and logic refinements in the `enqueue()` function in `scheduler.cpp`.

---
*PR created automatically by Jules for task [5268104614530352059](https://jules.google.com/task/5268104614530352059) started by @tonestone57*